### PR TITLE
feat(garden): redesign gardens page as garden-centric dashboard

### DIFF
--- a/GrowWisePackage/Sources/GrowWiseFeature/Design/GardenComponents.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Design/GardenComponents.swift
@@ -1,6 +1,23 @@
 import GrowWiseModels
 import SwiftUI
 
+// MARK: - GardenType Icon Extension
+
+extension GardenType {
+    var iconName: String {
+        switch self {
+        case .outdoor: "sun.max.fill"
+        case .indoor: "house.fill"
+        case .container: "rectangle.3.offgrid.fill"
+        case .raised: "rectangle.stack.fill"
+        case .hydroponic: "drop.circle.fill"
+        case .greenhouse: "leaf.fill"
+        case .balcony: "building.2.fill"
+        case .windowsill: "window.horizontal"
+        }
+    }
+}
+
 // MARK: - Plant Model Extensions
 
 extension HealthStatus {

--- a/GrowWisePackage/Sources/GrowWiseFeature/OnboardingFlow/Views/GardenSetupView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/OnboardingFlow/Views/GardenSetupView.swift
@@ -186,22 +186,7 @@ private struct SpaceSizeRow: View {
     }
 }
 
-// MARK: - GardenType icon extension
-
-extension GardenType {
-    var iconName: String {
-        switch self {
-        case .outdoor: "sun.max.fill"
-        case .indoor: "house.fill"
-        case .container: "rectangle.3.offgrid.fill"
-        case .raised: "rectangle.stack.fill"
-        case .hydroponic: "drop.circle.fill"
-        case .greenhouse: "leaf.fill"
-        case .balcony: "building.2.fill"
-        case .windowsill: "window.horizontal"
-        }
-    }
-}
+// GardenType icon extension moved to GardenComponents.swift
 
 #Preview {
     ZStack {

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/Garden/CreateGardenSheet.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/Garden/CreateGardenSheet.swift
@@ -1,0 +1,320 @@
+import GrowWiseModels
+import GrowWiseServices
+import SwiftUI
+
+// MARK: - CreateGardenSheet
+
+/// Sheet for creating a new garden with name, type, and environment settings.
+struct CreateGardenSheet: View {
+    @Environment(DataService.self) private var dataService
+    @Environment(\.dismiss) private var dismiss
+
+    let onCreated: (Garden) -> Void
+
+    @State private var gardenName: String = ""
+    @State private var selectedType: GardenType = .outdoor
+    @State private var selectedSun: SunExposure = .fullSun
+    @State private var selectedSize: SpaceSize = .medium
+    @State private var isSaving = false
+
+    private var isValid: Bool {
+        !gardenName.trimmingCharacters(in: .whitespaces).isEmpty
+    }
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                CultivationTheme.Colors.backgroundSecondary.ignoresSafeArea()
+
+                ScrollView {
+                    VStack(spacing: CultivationTheme.Spacing.sectionGap) {
+                        // Drag handle
+                        Capsule()
+                            .fill(CultivationTheme.Colors.cardBorder)
+                            .frame(width: 36, height: 4)
+                            .padding(.top, 8)
+
+                        // Name field
+                        VStack(alignment: .leading, spacing: 8) {
+                            Text("Garden Name")
+                                .sectionLabelStyle()
+                                .padding(.horizontal, CultivationTheme.Spacing.screenPadding)
+
+                            HStack(spacing: 10) {
+                                Image(systemName: selectedType.iconName)
+                                    .font(.system(size: 18, weight: .medium))
+                                    .foregroundStyle(CultivationTheme.Colors.brandLeaf)
+                                    .frame(width: 28)
+
+                                TextField("e.g. Backyard, Herb Window, Patio", text: $gardenName)
+                                    .font(.system(.body, design: .rounded))
+                                    .foregroundStyle(CultivationTheme.Colors.textPrimary)
+                                    .accessibilityIdentifier("creategarden_textfield_name")
+                            }
+                            .padding(CultivationTheme.Spacing.cardPadding)
+                            .glassCard()
+                            .padding(.horizontal, CultivationTheme.Spacing.screenPadding)
+                        }
+
+                        // Garden type picker
+                        VStack(alignment: .leading, spacing: 8) {
+                            Text("Garden Type")
+                                .sectionLabelStyle()
+                                .padding(.horizontal, CultivationTheme.Spacing.screenPadding)
+
+                            ScrollView(.horizontal, showsIndicators: false) {
+                                HStack(spacing: 10) {
+                                    ForEach(GardenType.allCases, id: \.self) { type in
+                                        GardenTypeChip(
+                                            gardenType: type,
+                                            isSelected: selectedType == type
+                                        ) {
+                                            withAnimation(CultivationTheme.Animation.selection) {
+                                                selectedType = type
+                                            }
+                                        }
+                                    }
+                                }
+                                .padding(.horizontal, CultivationTheme.Spacing.screenPadding)
+                            }
+                        }
+
+                        // Sun exposure
+                        VStack(alignment: .leading, spacing: 8) {
+                            Text("Sun Exposure")
+                                .sectionLabelStyle()
+                                .padding(.horizontal, CultivationTheme.Spacing.screenPadding)
+
+                            VStack(spacing: 6) {
+                                ForEach(SunExposure.allCases, id: \.self) { sun in
+                                    SunExposureRow(
+                                        exposure: sun,
+                                        isSelected: selectedSun == sun
+                                    ) {
+                                        withAnimation(CultivationTheme.Animation.selection) {
+                                            selectedSun = sun
+                                        }
+                                    }
+                                }
+                            }
+                            .padding(.horizontal, CultivationTheme.Spacing.screenPadding)
+                        }
+
+                        // Space size
+                        VStack(alignment: .leading, spacing: 8) {
+                            Text("Space Available")
+                                .sectionLabelStyle()
+                                .padding(.horizontal, CultivationTheme.Spacing.screenPadding)
+
+                            ScrollView(.horizontal, showsIndicators: false) {
+                                HStack(spacing: 8) {
+                                    ForEach(SpaceSize.allCases, id: \.self) { size in
+                                        GlassPill(
+                                            label: size.displayName,
+                                            isSelected: selectedSize == size,
+                                            accessibilityID: "creategarden_pill_\(size.rawValue)"
+                                        ) {
+                                            withAnimation(CultivationTheme.Animation.selection) {
+                                                selectedSize = size
+                                            }
+                                        }
+                                    }
+                                }
+                                .padding(.horizontal, CultivationTheme.Spacing.screenPadding)
+                            }
+                        }
+
+                        Spacer(minLength: 20)
+                    }
+                }
+
+                // Save button pinned to bottom
+                VStack {
+                    Spacer()
+
+                    Button {
+                        saveGarden()
+                    } label: {
+                        if isSaving {
+                            ProgressView()
+                                .tint(.white)
+                        } else {
+                            Text("Create Garden")
+                        }
+                    }
+                    .buttonStyle(GradientButtonStyle(isDisabled: !isValid))
+                    .disabled(!isValid || isSaving)
+                    .padding(.horizontal, CultivationTheme.Spacing.screenPadding)
+                    .padding(.bottom, 24)
+                    .background {
+                        LinearGradient(
+                            colors: [
+                                CultivationTheme.Colors.backgroundSecondary.opacity(0),
+                                CultivationTheme.Colors.backgroundSecondary,
+                            ],
+                            startPoint: .top,
+                            endPoint: .bottom
+                        )
+                        .frame(height: 100)
+                        .allowsHitTesting(false)
+                    }
+                    .accessibilityIdentifier("creategarden_button_save")
+                }
+            }
+            .navigationTitle("New Garden")
+            .gwNavigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                        .accessibilityIdentifier("creategarden_button_cancel")
+                }
+            }
+        }
+    }
+
+    private func saveGarden() {
+        let trimmed = gardenName.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else { return }
+        isSaving = true
+
+        let isIndoor = selectedType == .indoor || selectedType == .windowsill
+        do {
+            let garden = try dataService.gardens.create(
+                name: trimmed,
+                type: selectedType,
+                isIndoor: isIndoor,
+                user: nil
+            )
+            garden.sunExposure = selectedSun
+            garden.spaceAvailable = selectedSize
+            try dataService.mainContext.save()
+            onCreated(garden)
+            dismiss()
+        } catch {
+            isSaving = false
+        }
+    }
+}
+
+// MARK: - GardenTypeChip
+
+private struct GardenTypeChip: View {
+    let gardenType: GardenType
+    let isSelected: Bool
+    let onTap: () -> Void
+
+    var body: some View {
+        Button(action: onTap) {
+            VStack(spacing: 6) {
+                Image(systemName: gardenType.iconName)
+                    .font(.system(size: 20, weight: .medium))
+                Text(gardenType.displayName)
+                    .font(.system(.caption2, design: .rounded, weight: .medium))
+                    .multilineTextAlignment(.center)
+                    .lineLimit(2)
+                    .frame(width: 76)
+            }
+            .padding(.vertical, 12)
+            .padding(.horizontal, 8)
+            .background {
+                RoundedRectangle(cornerRadius: CultivationTheme.Radius.card)
+                    .fill(
+                        isSelected
+                            ? CultivationTheme.Colors.brandLeaf.opacity(0.15)
+                            : CultivationTheme.Colors.cardSurface
+                    )
+                    .overlay {
+                        RoundedRectangle(cornerRadius: CultivationTheme.Radius.card)
+                            .stroke(
+                                isSelected
+                                    ? CultivationTheme.Colors.brandLeaf
+                                    : CultivationTheme.Colors.cardBorder,
+                                lineWidth: isSelected ? 1.5 : 1
+                            )
+                    }
+            }
+            .foregroundStyle(
+                isSelected
+                    ? CultivationTheme.Colors.brandLeaf
+                    : CultivationTheme.Colors.textSecondary
+            )
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier("creategarden_chip_\(gardenType.rawValue)")
+    }
+}
+
+// MARK: - SunExposureRow
+
+private struct SunExposureRow: View {
+    let exposure: SunExposure
+    let isSelected: Bool
+    let onTap: () -> Void
+
+    private var iconName: String {
+        switch exposure {
+        case .fullSun: "sun.max.fill"
+        case .partialSun: "sun.haze.fill"
+        case .partialShade: "cloud.sun.fill"
+        case .fullShade: "cloud.fill"
+        case .artificial: "lightbulb.fill"
+        }
+    }
+
+    private var iconColor: Color {
+        switch exposure {
+        case .fullSun: Color(hex: "F59E0B")
+        case .partialSun: Color(hex: "F59E0B").opacity(0.8)
+        case .partialShade: Color(hex: "6B7280")
+        case .fullShade: Color(hex: "6B7280")
+        case .artificial: Color(hex: "A855F7")
+        }
+    }
+
+    var body: some View {
+        Button(action: onTap) {
+            HStack(spacing: 12) {
+                Image(systemName: iconName)
+                    .font(.system(size: 16, weight: .medium))
+                    .foregroundStyle(isSelected ? iconColor : CultivationTheme.Colors.textTertiary)
+                    .frame(width: 24)
+
+                Text(exposure.displayName)
+                    .font(.system(.subheadline, design: .rounded))
+                    .foregroundStyle(
+                        isSelected
+                            ? CultivationTheme.Colors.textPrimary
+                            : CultivationTheme.Colors.textSecondary
+                    )
+
+                Spacer()
+
+                if isSelected {
+                    Image(systemName: "checkmark.circle.fill")
+                        .font(.system(size: 18))
+                        .foregroundStyle(CultivationTheme.Colors.brandLeaf)
+                }
+            }
+            .padding(12)
+            .background {
+                RoundedRectangle(cornerRadius: CultivationTheme.Radius.card)
+                    .fill(
+                        isSelected
+                            ? CultivationTheme.Colors.brandLeaf.opacity(0.08)
+                            : CultivationTheme.Colors.cardSurface
+                    )
+            }
+            .overlay {
+                RoundedRectangle(cornerRadius: CultivationTheme.Radius.card)
+                    .stroke(
+                        isSelected
+                            ? CultivationTheme.Colors.brandLeaf.opacity(0.3)
+                            : CultivationTheme.Colors.cardBorder,
+                        lineWidth: 1
+                    )
+            }
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier("creategarden_sun_\(exposure.rawValue)")
+    }
+}

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/Garden/GardenCardView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/Garden/GardenCardView.swift
@@ -1,0 +1,397 @@
+import GrowWiseModels
+import SwiftUI
+
+// MARK: - GardenCardView
+
+/// Visual card representing a single garden in the dashboard grid.
+/// Shows garden type icon, name, a mini visual layout of beds, and stats.
+struct GardenCardView: View {
+    let garden: Garden
+    let plantCount: Int
+    let bedCount: Int
+    let alertCount: Int
+    let onTap: () -> Void
+
+    private var gardenType: GardenType {
+        garden.gardenType ?? .outdoor
+    }
+
+    private var healthSummary: GardenHealthSummary {
+        let plants = garden.plants ?? []
+        let healthy = plants.filter { ($0.healthStatus ?? .healthy) == .healthy }.count
+        let warning = plants.filter {
+            let s = $0.healthStatus ?? .healthy
+            return s == .needsAttention || s == .sick
+        }.count
+        let critical = plants.filter {
+            let s = $0.healthStatus ?? .healthy
+            return s == .dying || s == .dead
+        }.count
+        return GardenHealthSummary(healthy: healthy, warning: warning, critical: critical)
+    }
+
+    var body: some View {
+        Button(action: onTap) {
+            VStack(alignment: .leading, spacing: 12) {
+                // Top: icon + name + type badge
+                HStack(spacing: 10) {
+                    Image(systemName: gardenType.iconName)
+                        .font(.system(size: 22, weight: .medium))
+                        .foregroundStyle(CultivationTheme.Colors.brandLeaf)
+                        .frame(width: 40, height: 40)
+                        .background(
+                            RoundedRectangle(cornerRadius: CultivationTheme.Radius.icon)
+                                .fill(CultivationTheme.Colors.brandLeaf.opacity(0.12))
+                        )
+
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(garden.name ?? "Garden")
+                            .font(.system(.headline, design: .rounded, weight: .semibold))
+                            .foregroundStyle(CultivationTheme.Colors.textPrimary)
+                            .lineLimit(1)
+
+                        Text(gardenType.displayName)
+                            .font(.system(.caption, design: .rounded))
+                            .foregroundStyle(CultivationTheme.Colors.textSecondary)
+                    }
+
+                    Spacer()
+
+                    if alertCount > 0 {
+                        Text("\(alertCount)")
+                            .font(.system(size: 11, weight: .bold, design: .rounded))
+                            .foregroundStyle(.white)
+                            .frame(width: 22, height: 22)
+                            .background(Circle().fill(CultivationTheme.Colors.statusAlert))
+                    }
+                }
+
+                // Mini garden layout visualization
+                GardenMiniLayout(garden: garden)
+                    .frame(height: 72)
+
+                // Stats row
+                HStack(spacing: 0) {
+                    GardenMiniStat(
+                        icon: "leaf.fill",
+                        value: "\(plantCount)",
+                        label: plantCount == 1 ? "Plant" : "Plants",
+                        color: CultivationTheme.Colors.statusHealthy
+                    )
+
+                    Spacer()
+
+                    GardenMiniStat(
+                        icon: "square.grid.2x2.fill",
+                        value: "\(bedCount)",
+                        label: bedCount == 1 ? "Bed" : "Beds",
+                        color: CultivationTheme.Colors.brandLeaf
+                    )
+
+                    Spacer()
+
+                    healthIndicator
+                }
+            }
+            .padding(CultivationTheme.Spacing.cardPadding)
+            .glassCard()
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier("garden_card_\(garden.id?.uuidString ?? "unknown")")
+    }
+
+    @ViewBuilder
+    private var healthIndicator: some View {
+        let summary = healthSummary
+        if plantCount == 0 {
+            GardenMiniStat(
+                icon: "sparkles",
+                value: "--",
+                label: "Health",
+                color: CultivationTheme.Colors.textTertiary
+            )
+        } else if summary.critical > 0 {
+            GardenMiniStat(
+                icon: "exclamationmark.triangle.fill",
+                value: "\(summary.critical)",
+                label: "Critical",
+                color: CultivationTheme.Colors.statusAlert
+            )
+        } else if summary.warning > 0 {
+            GardenMiniStat(
+                icon: "exclamationmark.circle.fill",
+                value: "\(summary.warning)",
+                label: "Attention",
+                color: CultivationTheme.Colors.statusWarning
+            )
+        } else {
+            GardenMiniStat(
+                icon: "checkmark.circle.fill",
+                value: "All",
+                label: "Healthy",
+                color: CultivationTheme.Colors.statusHealthy
+            )
+        }
+    }
+}
+
+// MARK: - GardenHealthSummary
+
+private struct GardenHealthSummary {
+    let healthy: Int
+    let warning: Int
+    let critical: Int
+}
+
+// MARK: - GardenMiniStat
+
+private struct GardenMiniStat: View {
+    let icon: String
+    let value: String
+    let label: String
+    let color: Color
+
+    var body: some View {
+        HStack(spacing: 4) {
+            Image(systemName: icon)
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundStyle(color)
+
+            VStack(alignment: .leading, spacing: 0) {
+                Text(value)
+                    .font(.system(size: 13, weight: .bold, design: .rounded))
+                    .foregroundStyle(CultivationTheme.Colors.textPrimary)
+                Text(label)
+                    .font(.system(size: 9, design: .rounded))
+                    .foregroundStyle(CultivationTheme.Colors.textTertiary)
+            }
+        }
+    }
+}
+
+// MARK: - GardenMiniLayout
+
+/// A visual mini-map of the garden's beds rendered as colored tiles.
+/// Creates a spatial feel for how the garden is organized.
+struct GardenMiniLayout: View {
+    let garden: Garden
+
+    private var beds: [GardenBed] {
+        (garden.beds ?? []).sorted { ($0.name ?? "") < ($1.name ?? "") }
+    }
+
+    private static let bedColors: [Color] = [
+        Color(hex: "52B788"), // leaf green
+        Color(hex: "7A9D68"), // sage
+        Color(hex: "E9C46A"), // gold
+        Color(hex: "9DC5BB"), // teal
+        Color(hex: "B7E4C7"), // mint
+        Color(hex: "D4A373"), // terracotta
+        Color(hex: "A8DADC"), // sky blue
+        Color(hex: "CDB4DB"), // lavender
+    ]
+
+    var body: some View {
+        if beds.isEmpty {
+            emptyLayout
+        } else {
+            filledLayout
+        }
+    }
+
+    private var emptyLayout: some View {
+        RoundedRectangle(cornerRadius: 8)
+            .fill(CultivationTheme.Colors.brandLeaf.opacity(0.05))
+            .overlay {
+                VStack(spacing: 4) {
+                    Image(systemName: "plus.viewfinder")
+                        .font(.system(size: 16, weight: .light))
+                        .foregroundStyle(CultivationTheme.Colors.textTertiary)
+                    Text("No beds yet")
+                        .font(.system(size: 10, design: .rounded))
+                        .foregroundStyle(CultivationTheme.Colors.textTertiary)
+                }
+            }
+            .overlay {
+                RoundedRectangle(cornerRadius: 8)
+                    .stroke(
+                        CultivationTheme.Colors.brandLeaf.opacity(0.15),
+                        style: StrokeStyle(lineWidth: 1, dash: [4])
+                    )
+            }
+    }
+
+    private var filledLayout: some View {
+        let layout = computeLayout()
+        return GeometryReader { geo in
+            let spacing: CGFloat = 3
+            let totalWidth = geo.size.width
+            let totalHeight = geo.size.height
+
+            ZStack(alignment: .topLeading) {
+                // Background soil/grass texture hint
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(CultivationTheme.Colors.brandLeaf.opacity(0.04))
+
+                ForEach(Array(layout.enumerated()), id: \.offset) { index, rect in
+                    let color = Self.bedColors[index % Self.bedColors.count]
+                    let bed = beds[index]
+                    let plantCount = (bed.plants ?? []).count
+
+                    BedTile(
+                        name: bed.name ?? "Bed",
+                        plantCount: plantCount,
+                        color: color
+                    )
+                    .frame(
+                        width: rect.width * totalWidth - spacing,
+                        height: rect.height * totalHeight - spacing
+                    )
+                    .offset(
+                        x: rect.minX * totalWidth + spacing / 2,
+                        y: rect.minY * totalHeight + spacing / 2
+                    )
+                }
+            }
+            .clipShape(RoundedRectangle(cornerRadius: 8))
+        }
+    }
+
+    /// Compute a proportional layout for beds.
+    /// Uses a simple row-packing algorithm to create a visually interesting grid.
+    private func computeLayout() -> [CGRect] {
+        let count = beds.count
+        guard count > 0 else { return [] }
+
+        switch count {
+        case 1:
+            return [CGRect(x: 0, y: 0, width: 1.0, height: 1.0)]
+        case 2:
+            return [
+                CGRect(x: 0, y: 0, width: 0.55, height: 1.0),
+                CGRect(x: 0.55, y: 0, width: 0.45, height: 1.0),
+            ]
+        case 3:
+            return [
+                CGRect(x: 0, y: 0, width: 0.5, height: 1.0),
+                CGRect(x: 0.5, y: 0, width: 0.5, height: 0.5),
+                CGRect(x: 0.5, y: 0.5, width: 0.5, height: 0.5),
+            ]
+        case 4:
+            return [
+                CGRect(x: 0, y: 0, width: 0.5, height: 0.5),
+                CGRect(x: 0.5, y: 0, width: 0.5, height: 0.5),
+                CGRect(x: 0, y: 0.5, width: 0.5, height: 0.5),
+                CGRect(x: 0.5, y: 0.5, width: 0.5, height: 0.5),
+            ]
+        case 5:
+            return [
+                CGRect(x: 0, y: 0, width: 0.6, height: 0.55),
+                CGRect(x: 0.6, y: 0, width: 0.4, height: 0.55),
+                CGRect(x: 0, y: 0.55, width: 0.33, height: 0.45),
+                CGRect(x: 0.33, y: 0.55, width: 0.33, height: 0.45),
+                CGRect(x: 0.66, y: 0.55, width: 0.34, height: 0.45),
+            ]
+        default:
+            // For 6+ beds, pack into a 3-column grid with varying heights
+            let cols = 3
+            let rows = (count + cols - 1) / cols
+            let rowHeight = 1.0 / Double(rows)
+            return (0..<count).map { i in
+                let row = i / cols
+                let col = i % cols
+                let colWidth = 1.0 / Double(min(cols, count - row * cols))
+                return CGRect(
+                    x: Double(col) * colWidth,
+                    y: Double(row) * rowHeight,
+                    width: colWidth,
+                    height: rowHeight
+                )
+            }
+        }
+    }
+}
+
+// MARK: - BedTile
+
+/// A small colored tile representing a bed in the mini layout.
+private struct BedTile: View {
+    let name: String
+    let plantCount: Int
+    let color: Color
+
+    var body: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 5)
+                .fill(color.opacity(0.2))
+            RoundedRectangle(cornerRadius: 5)
+                .stroke(color.opacity(0.4), lineWidth: 1)
+
+            VStack(spacing: 1) {
+                Text(name)
+                    .font(.system(size: 8, weight: .semibold, design: .rounded))
+                    .foregroundStyle(color)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.7)
+
+                if plantCount > 0 {
+                    HStack(spacing: 2) {
+                        ForEach(0..<min(plantCount, 5), id: \.self) { _ in
+                            Circle()
+                                .fill(color.opacity(0.6))
+                                .frame(width: 4, height: 4)
+                        }
+                        if plantCount > 5 {
+                            Text("+\(plantCount - 5)")
+                                .font(.system(size: 6, weight: .medium, design: .rounded))
+                                .foregroundStyle(color.opacity(0.6))
+                        }
+                    }
+                }
+            }
+            .padding(3)
+        }
+    }
+}
+
+// MARK: - AddGardenCard
+
+/// A dashed-border card prompting the user to add a new garden.
+struct AddGardenCard: View {
+    let onTap: () -> Void
+
+    var body: some View {
+        Button(action: onTap) {
+            VStack(spacing: 12) {
+                Image(systemName: "plus.circle.fill")
+                    .font(.system(size: 32, weight: .light))
+                    .foregroundStyle(CultivationTheme.Colors.brandLeaf.opacity(0.6))
+
+                VStack(spacing: 2) {
+                    Text("New Garden")
+                        .font(.system(.subheadline, design: .rounded, weight: .semibold))
+                        .foregroundStyle(CultivationTheme.Colors.textPrimary)
+
+                    Text("Backyard, balcony, indoor...")
+                        .font(.system(.caption2, design: .rounded))
+                        .foregroundStyle(CultivationTheme.Colors.textTertiary)
+                }
+            }
+            .frame(maxWidth: .infinity)
+            .frame(minHeight: 160)
+            .background {
+                RoundedRectangle(cornerRadius: CultivationTheme.Radius.card)
+                    .fill(CultivationTheme.Colors.brandLeaf.opacity(0.03))
+            }
+            .overlay {
+                RoundedRectangle(cornerRadius: CultivationTheme.Radius.card)
+                    .stroke(
+                        CultivationTheme.Colors.brandLeaf.opacity(0.3),
+                        style: StrokeStyle(lineWidth: 1.5, dash: [8, 6])
+                    )
+            }
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier("garden_button_newgarden")
+    }
+}

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/Garden/GardenCardView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/Garden/GardenCardView.swift
@@ -18,15 +18,15 @@ struct GardenCardView: View {
 
     private var healthSummary: GardenHealthSummary {
         let plants = garden.plants ?? []
-        let healthy = plants.filter { ($0.healthStatus ?? .healthy) == .healthy }.count
-        let warning = plants.filter {
+        let healthy = plants.count(where: { ($0.healthStatus ?? .healthy) == .healthy })
+        let warning = plants.count(where: {
             let s = $0.healthStatus ?? .healthy
             return s == .needsAttention || s == .sick
-        }.count
-        let critical = plants.filter {
+        })
+        let critical = plants.count(where: {
             let s = $0.healthStatus ?? .healthy
             return s == .dying || s == .dead
-        }.count
+        })
         return GardenHealthSummary(healthy: healthy, warning: warning, critical: critical)
     }
 
@@ -297,7 +297,7 @@ struct GardenMiniLayout: View {
             let cols = 3
             let rows = (count + cols - 1) / cols
             let rowHeight = 1.0 / Double(rows)
-            return (0..<count).map { i in
+            return (0 ..< count).map { i in
                 let row = i / cols
                 let col = i % cols
                 let colWidth = 1.0 / Double(min(cols, count - row * cols))
@@ -336,7 +336,7 @@ private struct BedTile: View {
 
                 if plantCount > 0 {
                     HStack(spacing: 2) {
-                        ForEach(0..<min(plantCount, 5), id: \.self) { _ in
+                        ForEach(0 ..< min(plantCount, 5), id: \.self) { _ in
                             Circle()
                                 .fill(color.opacity(0.6))
                                 .frame(width: 4, height: 4)

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/Garden/GardenDetailView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/Garden/GardenDetailView.swift
@@ -60,7 +60,7 @@ struct GardenDetailView: View {
 
                 if isLoading {
                     loadingState
-                } else if filteredGroups.isEmpty && searchText.isEmpty {
+                } else if filteredGroups.isEmpty, searchText.isEmpty {
                     emptyState
                 } else if filteredGroups.isEmpty {
                     noResultsState

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/Garden/GardenDetailView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/Garden/GardenDetailView.swift
@@ -1,0 +1,391 @@
+import GrowWiseModels
+import GrowWiseServices
+import SwiftUI
+
+// MARK: - GardenDetailView
+
+/// Drill-down view for a single garden showing its beds, plants, and stats.
+/// Reached by tapping a garden card on the main Gardens dashboard.
+struct GardenDetailView: View {
+    @Environment(DataService.self) private var dataService
+    @Environment(\.modelContext) private var modelContext
+
+    let garden: Garden
+
+    @State private var groupedPlants: [PlantGroup] = []
+    @State private var searchText: String = ""
+    @State private var selectedPlant: Plant?
+    @State private var showAddPlant = false
+    @State private var showCreateBed = false
+    @State private var plantToNavigate: Plant?
+    @State private var isLoading = true
+
+    private var filteredGroups: [PlantGroup] {
+        guard !searchText.isEmpty else { return groupedPlants }
+        let query = searchText.lowercased()
+        return groupedPlants.compactMap { group in
+            let matching = group.plants.filter { plant in
+                (plant.name ?? "").lowercased().contains(query) ||
+                    (plant.scientificName ?? "").lowercased().contains(query) ||
+                    (plant.notes ?? "").lowercased().contains(query)
+            }
+            guard !matching.isEmpty else { return nil }
+            return PlantGroup(id: group.id, bed: group.bed, plants: matching)
+        }
+    }
+
+    private var plantCount: Int {
+        groupedPlants.reduce(0) { $0 + $1.plants.count }
+    }
+
+    private var bedCount: Int {
+        (garden.beds ?? []).count
+    }
+
+    private var alertCount: Int {
+        let now = Date()
+        return groupedPlants.flatMap(\.plants).count { plant in
+            (plant.reminders ?? []).contains { $0.isEnabled && $0.nextDueDate < now }
+        }
+    }
+
+    var body: some View {
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: CultivationTheme.Spacing.sectionGap) {
+                // Garden info header
+                gardenHeader
+
+                // Search bar
+                searchBar
+
+                if isLoading {
+                    loadingState
+                } else if filteredGroups.isEmpty && searchText.isEmpty {
+                    emptyState
+                } else if filteredGroups.isEmpty {
+                    noResultsState
+                } else {
+                    ForEach(filteredGroups) { group in
+                        GardenBedSection(
+                            group: group,
+                            onPlantTap: { plant in selectedPlant = plant },
+                            onQuickAction: { _ in },
+                            onDelete: { plant in
+                                modelContext.delete(plant)
+                                Task { await rebuildGroups() }
+                            }
+                        )
+                    }
+
+                    addBedButton
+                }
+            }
+            .padding(.horizontal, CultivationTheme.Spacing.screenPadding)
+            .padding(.bottom, 32)
+        }
+        .background(CultivationTheme.Colors.background.ignoresSafeArea())
+        .navigationTitle(garden.name ?? "Garden")
+        .gwNavigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Button {
+                    showAddPlant = true
+                } label: {
+                    Image(systemName: "plus")
+                        .font(.system(size: 15, weight: .semibold))
+                        .foregroundStyle(.white)
+                        .frame(width: 30, height: 30)
+                        .background(CultivationTheme.Gradients.ctaVertical)
+                        .clipShape(Circle())
+                }
+                .accessibilityIdentifier("gardendetail_button_add")
+            }
+        }
+        .task { await rebuildGroups() }
+        .refreshable { await rebuildGroups() }
+        .navigationDestination(item: $plantToNavigate) { plant in
+            PlantDetailView(plant: plant)
+        }
+        .sheet(isPresented: $showAddPlant, onDismiss: {
+            Task { await rebuildGroups() }
+        }) {
+            AddPlantSheet()
+        }
+        .sheet(item: $selectedPlant) { plant in
+            PlantQuickCard(
+                plant: plant,
+                onWater: { selectedPlant = nil },
+                onPrune: { selectedPlant = nil },
+                onLog: { selectedPlant = nil },
+                onViewDetails: {
+                    let captured = plant
+                    selectedPlant = nil
+                    Task { @MainActor in
+                        try? await Task.sleep(for: .milliseconds(350))
+                        plantToNavigate = captured
+                    }
+                }
+            )
+            .presentationDetents([.medium, .large])
+            .presentationDragIndicator(.hidden)
+        }
+        .sheet(isPresented: $showCreateBed, onDismiss: {
+            Task { await rebuildGroups() }
+        }) {
+            CreateBedSheet(garden: garden) { _ in
+                Task { await rebuildGroups() }
+            }
+            .presentationDetents([.medium])
+            .presentationDragIndicator(.hidden)
+        }
+    }
+
+    // MARK: - Sub-views
+
+    private var gardenHeader: some View {
+        VStack(spacing: 12) {
+            // Stats strip
+            HStack(spacing: 10) {
+                QuickStatCard(
+                    value: plantCount,
+                    label: "Plants",
+                    color: CultivationTheme.Colors.statusHealthy
+                )
+                QuickStatCard(
+                    value: bedCount,
+                    label: "Beds",
+                    color: CultivationTheme.Colors.brandLeaf
+                )
+                QuickStatCard(
+                    value: alertCount,
+                    label: "Alerts",
+                    color: alertCount > 0
+                        ? CultivationTheme.Colors.statusAlert
+                        : CultivationTheme.Colors.textTertiary
+                )
+            }
+
+            // Garden info chips
+            HStack(spacing: 8) {
+                if let gardenType = garden.gardenType {
+                    InfoChip(icon: gardenType.iconName, text: gardenType.displayName)
+                }
+                if let sun = garden.sunExposure {
+                    InfoChip(icon: "sun.max.fill", text: sun.displayName)
+                }
+            }
+        }
+        .padding(.top, 8)
+    }
+
+    private var searchBar: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "magnifyingglass")
+                .font(.system(size: 14, weight: .medium))
+                .foregroundStyle(CultivationTheme.Colors.textTertiary)
+
+            TextField("Search plants\u{2026}", text: $searchText)
+                .font(.system(.subheadline, design: .rounded))
+                .accessibilityIdentifier("gardendetail_search_field")
+
+            if !searchText.isEmpty {
+                Button {
+                    searchText = ""
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundStyle(CultivationTheme.Colors.textSecondary)
+                }
+            }
+        }
+        .padding(10)
+        .glassCard()
+    }
+
+    private var loadingState: some View {
+        VStack(spacing: 16) {
+            ProgressView()
+                .tint(CultivationTheme.Colors.brandLeaf)
+            Text("Loading plants\u{2026}")
+                .font(.system(.subheadline, design: .rounded))
+                .foregroundStyle(CultivationTheme.Colors.textSecondary)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.top, 40)
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 16) {
+            IconBubble(
+                systemName: "leaf",
+                color: CultivationTheme.Colors.brandLeaf,
+                size: 64,
+                iconSize: 28
+            )
+            Text("No plants yet")
+                .font(.system(.headline, design: .rounded))
+                .foregroundStyle(CultivationTheme.Colors.textPrimary)
+            Text("Start by adding beds and plants to this garden")
+                .font(.system(.subheadline))
+                .foregroundStyle(CultivationTheme.Colors.textSecondary)
+                .multilineTextAlignment(.center)
+
+            HStack(spacing: 12) {
+                Button("Add Bed") { showCreateBed = true }
+                    .buttonStyle(OutlineButtonStyle())
+                    .accessibilityIdentifier("gardendetail_button_addbed_empty")
+
+                Button("Add Plant") { showAddPlant = true }
+                    .buttonStyle(GradientButtonStyle())
+                    .accessibilityIdentifier("gardendetail_button_addplant_empty")
+            }
+            .padding(.horizontal, 20)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.top, 40)
+    }
+
+    private var noResultsState: some View {
+        VStack(spacing: 8) {
+            Text("No results")
+                .font(.system(.headline, design: .rounded))
+                .foregroundStyle(CultivationTheme.Colors.textPrimary)
+            Text("Try a different search term")
+                .font(.system(.subheadline))
+                .foregroundStyle(CultivationTheme.Colors.textSecondary)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.top, 40)
+    }
+
+    private var addBedButton: some View {
+        Button {
+            showCreateBed = true
+        } label: {
+            HStack {
+                Image(systemName: "plus.circle")
+                Text("Add Bed or Area")
+            }
+            .font(.system(.subheadline, design: .rounded, weight: .medium))
+            .foregroundStyle(CultivationTheme.Colors.brandLeaf)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 14)
+            .background {
+                RoundedRectangle(cornerRadius: CultivationTheme.Radius.card)
+                    .stroke(
+                        CultivationTheme.Colors.brandLeaf.opacity(0.3),
+                        style: StrokeStyle(lineWidth: 1, dash: [6])
+                    )
+            }
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier("gardendetail_button_addbed")
+    }
+
+    // MARK: - Data
+
+    private func rebuildGroups() async {
+        let allPlants: [Plant]
+        do {
+            allPlants = try dataService.plants.fetchAll()
+        } catch {
+            allPlants = []
+        }
+
+        let gardenPlants = allPlants.filter { $0.garden?.id == garden.id }
+
+        var bedMap: [String: (GardenBed, [Plant])] = [:]
+        var unassigned: [Plant] = []
+
+        for plant in gardenPlants {
+            if let bed = plant.bed, let bedID = bed.id?.uuidString {
+                if bedMap[bedID] == nil {
+                    bedMap[bedID] = (bed, [])
+                }
+                bedMap[bedID]?.1.append(plant)
+            } else {
+                unassigned.append(plant)
+            }
+        }
+
+        var groups: [PlantGroup] = bedMap.values
+            .sorted { ($0.0.name ?? "") < ($1.0.name ?? "") }
+            .map { bed, bedPlants in
+                PlantGroup(
+                    id: bed.id?.uuidString ?? UUID().uuidString,
+                    bed: bed,
+                    plants: bedPlants.sorted { ($0.name ?? "") < ($1.name ?? "") }
+                )
+            }
+
+        if !unassigned.isEmpty {
+            groups.append(PlantGroup(
+                id: "__unassigned__",
+                bed: nil,
+                plants: unassigned.sorted { ($0.name ?? "") < ($1.name ?? "") }
+            ))
+        }
+
+        // Also add empty beds (beds with no plants) so they appear in the layout
+        let bedsWithPlants = Set(bedMap.keys)
+        for bed in garden.beds ?? [] {
+            if let bedID = bed.id?.uuidString, !bedsWithPlants.contains(bedID) {
+                groups.insert(
+                    PlantGroup(id: bedID, bed: bed, plants: []),
+                    at: max(0, groups.count - (unassigned.isEmpty ? 0 : 1))
+                )
+            }
+        }
+
+        groupedPlants = groups
+        isLoading = false
+    }
+}
+
+// MARK: - InfoChip
+
+private struct InfoChip: View {
+    let icon: String
+    let text: String
+
+    var body: some View {
+        HStack(spacing: 4) {
+            Image(systemName: icon)
+                .font(.system(size: 10, weight: .medium))
+            Text(text)
+                .font(.system(.caption2, design: .rounded, weight: .medium))
+                .lineLimit(1)
+        }
+        .foregroundStyle(CultivationTheme.Colors.textSecondary)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 5)
+        .background {
+            Capsule()
+                .fill(CultivationTheme.Colors.cardSurface)
+        }
+        .overlay {
+            Capsule()
+                .stroke(CultivationTheme.Colors.cardBorder, lineWidth: 1)
+        }
+    }
+}
+
+// MARK: - OutlineButtonStyle
+
+struct OutlineButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .font(.system(.headline, design: .rounded, weight: .semibold))
+            .foregroundStyle(CultivationTheme.Colors.brandLeaf)
+            .frame(maxWidth: .infinity, minHeight: 50)
+            .background {
+                RoundedRectangle(cornerRadius: CultivationTheme.Radius.button)
+                    .fill(CultivationTheme.Colors.brandLeaf.opacity(0.08))
+            }
+            .overlay {
+                RoundedRectangle(cornerRadius: CultivationTheme.Radius.button)
+                    .stroke(CultivationTheme.Colors.brandLeaf.opacity(0.35), lineWidth: 1)
+            }
+            .scaleEffect(configuration.isPressed ? 0.97 : 1.0)
+            .animation(CultivationTheme.Animation.card, value: configuration.isPressed)
+    }
+}

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/Garden/GardenViewModel.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/Garden/GardenViewModel.swift
@@ -25,16 +25,25 @@ public struct PlantGroup: Identifiable {
     }
 }
 
+// MARK: - GardenSummary
+
+/// Lightweight summary for each garden shown on the dashboard cards.
+public struct GardenSummary: Identifiable {
+    public let id: UUID
+    public let garden: Garden
+    public let plantCount: Int
+    public let bedCount: Int
+    public let alertCount: Int
+}
+
 // MARK: - GardenViewModel
 
-/// Data layer for the Garden tab grouped plant list (Task 6 hero screen).
+/// Data layer for the Garden tab dashboard.
 ///
 /// Responsibilities:
-/// - Load all gardens via DataService
-/// - Default-select the first garden
-/// - Group the selected garden's plants by GardenBed
-/// - Expose search-filtered groups for the list view
-/// - Surface aggregate counts for the hero header (total plants, alert count)
+/// - Load all gardens and compute per-garden summaries
+/// - Support creating and deleting gardens
+/// - Surface aggregate stats for the dashboard header
 @MainActor
 @Observable
 public final class GardenViewModel {
@@ -57,6 +66,9 @@ public final class GardenViewModel {
 
     /// Non-nil when a load error occurs.
     public var error: Error?
+
+    /// Per-garden summaries for dashboard cards.
+    public var gardenSummaries: [GardenSummary] = []
 
     // MARK: - Computed Properties
 
@@ -93,13 +105,23 @@ public final class GardenViewModel {
             })
     }
 
+    /// Total plants across all gardens.
+    public var totalPlantsAllGardens: Int {
+        gardenSummaries.reduce(0) { $0 + $1.plantCount }
+    }
+
+    /// Total alerts across all gardens.
+    public var totalAlertsAllGardens: Int {
+        gardenSummaries.reduce(0) { $0 + $1.alertCount }
+    }
+
     // MARK: - Private State
 
     private var allPlants: [Plant] = []
 
     // MARK: - Public API
 
-    /// Initial load: fetch all gardens and plants, then group.
+    /// Initial load: fetch all gardens and plants, then build summaries.
     public func load(dataService: DataService) async {
         isLoading = true
         error = nil
@@ -124,6 +146,7 @@ public final class GardenViewModel {
         }
 
         rebuildGroups()
+        rebuildSummaries()
         isLoading = false
     }
 
@@ -137,6 +160,23 @@ public final class GardenViewModel {
             self.error = error
         }
         rebuildGroups()
+    }
+
+    /// Delete a garden and reload data.
+    public func deleteGarden(_ garden: Garden, dataService: DataService) async {
+        do {
+            try dataService.gardens.delete(garden)
+        } catch {
+            self.error = error
+            return
+        }
+
+        // If we deleted the selected garden, clear selection
+        if selectedGarden?.id == garden.id {
+            selectedGarden = nil
+        }
+
+        await load(dataService: dataService)
     }
 
     // MARK: - Private Helpers
@@ -184,5 +224,23 @@ public final class GardenViewModel {
         }
 
         groupedPlants = groups
+    }
+
+    /// Build per-garden summaries for dashboard cards.
+    private func rebuildSummaries() {
+        let now = Date()
+        gardenSummaries = gardens.map { garden in
+            let gardenPlants = allPlants.filter { $0.garden?.id == garden.id }
+            let alerts = gardenPlants.count { plant in
+                (plant.reminders ?? []).contains { $0.isEnabled && $0.nextDueDate < now }
+            }
+            return GardenSummary(
+                id: garden.id ?? UUID(),
+                garden: garden,
+                plantCount: gardenPlants.count,
+                bedCount: (garden.beds ?? []).count,
+                alertCount: alerts
+            )
+        }
     }
 }

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/GardenView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/GardenView.swift
@@ -4,143 +4,187 @@ import SwiftUI
 
 // MARK: - GardenView
 
-/// Garden tab — hero screen with grouped plant list by bed/location.
-/// Full redesign implementation (Task 6).
+/// Garden tab — dashboard showing all gardens as visual cards.
+/// Tap a garden card to drill into its plant list.
+/// Prominent "New Garden" card for easy garden creation.
 public struct GardenView: View {
     @Environment(DataService.self) private var dataService
     @Environment(\.modelContext) private var modelContext
 
     @State private var viewModel = GardenViewModel()
-    @State private var selectedPlant: Plant?
-    @State private var showAddPlant = false
-    @State private var showCreateBed = false
-    @State private var showSearch = false
-    @State private var plantToNavigate: Plant?
+    @State private var showCreateGarden = false
+    @State private var gardenToNavigate: Garden?
+    @State private var gardenToDelete: Garden?
+    @State private var showDeleteConfirmation = false
 
     public init() {}
 
     public var body: some View {
         NavigationStack {
             ScrollView {
-                LazyVStack(alignment: .leading, spacing: CultivationTheme.Spacing.sectionGap) {
+                VStack(alignment: .leading, spacing: 0) {
+                    // Dashboard header
+                    dashboardHeader
+                        .padding(.bottom, CultivationTheme.Spacing.sectionGap)
+
                     if viewModel.isLoading {
                         loadingState
-                    } else if viewModel.filteredGroups.isEmpty {
+                    } else if viewModel.gardens.isEmpty {
                         emptyState
                     } else {
-                        ForEach(viewModel.filteredGroups) { group in
-                            GardenBedSection(
-                                group: group,
-                                onPlantTap: { plant in selectedPlant = plant },
-                                onQuickAction: { _ in
-                                    // Phase 6: mark care complete
-                                },
-                                onDelete: { plant in
-                                    modelContext.delete(plant)
-                                    Task { await viewModel.load(dataService: dataService) }
-                                }
-                            )
-                        }
-
-                        addBedButton
+                        // Garden cards grid
+                        gardenGrid
                     }
                 }
                 .padding(.horizontal, CultivationTheme.Spacing.screenPadding)
                 .padding(.bottom, 32)
             }
             .background(CultivationTheme.Colors.background.ignoresSafeArea())
-            .safeAreaInset(edge: .top) {
-                VStack(spacing: 0) {
-                    GardenHeroHeader(
-                        gardens: viewModel.gardens,
-                        selectedGarden: viewModel.selectedGarden,
-                        totalPlants: viewModel.totalPlantCount,
-                        alertCount: viewModel.alertCount,
-                        onSelectGarden: { garden in
-                            Task { await viewModel.selectGarden(garden, dataService: dataService) }
-                        },
-                        onAdd: { showAddPlant = true },
-                        onSearch: { withAnimation(.easeInOut(duration: 0.2)) { showSearch.toggle() } }
-                    )
-                    if showSearch {
-                        HStack(spacing: 10) {
-                            Image(systemName: "magnifyingglass")
-                                .font(.system(size: 15, weight: .medium))
-                                .foregroundStyle(CultivationTheme.Colors.textSecondary)
-                            TextField("Search plants\u{2026}", text: $viewModel.searchText)
-                                .font(.system(.body, design: .rounded))
-                                .accessibilityIdentifier("garden_search_field")
-                            if !viewModel.searchText.isEmpty {
-                                Button {
-                                    viewModel.searchText = ""
-                                } label: {
-                                    Image(systemName: "xmark.circle.fill")
-                                        .foregroundStyle(CultivationTheme.Colors.textSecondary)
-                                }
-                                .accessibilityIdentifier("garden_button_clearsearch")
-                            }
-                        }
-                        .padding(.horizontal, CultivationTheme.Spacing.screenPadding)
-                        .padding(.vertical, 10)
-                        .background(CultivationTheme.Colors.background)
-                    }
-                }
-            }
-            .toolbarBackground(.hidden)
             .task {
                 await viewModel.load(dataService: dataService)
             }
             .refreshable {
                 await viewModel.load(dataService: dataService)
             }
-            .navigationDestination(item: $plantToNavigate) { plant in
-                PlantDetailView(plant: plant)
+            .navigationDestination(item: $gardenToNavigate) { garden in
+                GardenDetailView(garden: garden)
             }
-            .sheet(isPresented: $showAddPlant, onDismiss: {
+            .sheet(isPresented: $showCreateGarden, onDismiss: {
                 Task { await viewModel.load(dataService: dataService) }
             }) {
-                AddPlantSheet()
-            }
-            .sheet(item: $selectedPlant) { plant in
-                PlantQuickCard(
-                    plant: plant,
-                    onWater: {
-                        selectedPlant = nil
-                    },
-                    onPrune: { selectedPlant = nil },
-                    onLog: { selectedPlant = nil },
-                    onViewDetails: {
-                        let captured = plant
-                        selectedPlant = nil
-                        Task { @MainActor in
-                            try? await Task.sleep(for: .milliseconds(350))
-                            plantToNavigate = captured
-                        }
-                    }
-                )
-                .presentationDetents([.medium, .large])
+                CreateGardenSheet { _ in
+                    Task { await viewModel.load(dataService: dataService) }
+                }
+                .presentationDetents([.large])
                 .presentationDragIndicator(.hidden)
             }
-            .sheet(isPresented: $showCreateBed) {
-                if let garden = viewModel.selectedGarden {
-                    CreateBedSheet(garden: garden) { _ in
-                        Task { await viewModel.load(dataService: dataService) }
+            .alert("Delete Garden?", isPresented: $showDeleteConfirmation) {
+                Button("Cancel", role: .cancel) {
+                    gardenToDelete = nil
+                }
+                Button("Delete", role: .destructive) {
+                    if let garden = gardenToDelete {
+                        Task {
+                            await viewModel.deleteGarden(garden, dataService: dataService)
+                        }
+                        gardenToDelete = nil
                     }
-                    .presentationDetents([.medium])
-                    .presentationDragIndicator(.hidden)
+                }
+            } message: {
+                if let garden = gardenToDelete {
+                    let plantCount = (garden.plants ?? []).count
+                    Text("This will permanently delete \"\(garden.name ?? "this garden")\" and its \(plantCount) plant\(plantCount == 1 ? "" : "s").")
                 }
             }
         }
         .accessibilityIdentifier("screen_garden")
     }
 
-    // MARK: - Sub-views
+    // MARK: - Dashboard Header
+
+    private var dashboardHeader: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            // Title row
+            HStack(alignment: .top) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("MY GARDENS")
+                        .font(.system(size: 12, design: .rounded))
+                        .foregroundStyle(CultivationTheme.Colors.textSecondary)
+                        .tracking(0.5)
+                    Text("Gardens")
+                        .font(.system(.title, design: .rounded, weight: .bold))
+                        .foregroundStyle(CultivationTheme.Colors.textPrimary)
+                }
+
+                Spacer()
+
+                Button {
+                    showCreateGarden = true
+                } label: {
+                    Image(systemName: "plus")
+                        .font(.system(size: 17, weight: .semibold))
+                        .foregroundStyle(.white)
+                        .frame(width: 36, height: 36)
+                        .background(CultivationTheme.Gradients.ctaVertical)
+                        .clipShape(Circle())
+                }
+                .accessibilityIdentifier("garden_button_add")
+            }
+
+            // Global stats
+            if !viewModel.gardens.isEmpty {
+                HStack(spacing: 10) {
+                    QuickStatCard(
+                        value: viewModel.gardens.count,
+                        label: "Gardens",
+                        color: CultivationTheme.Colors.brandLeaf
+                    )
+                    QuickStatCard(
+                        value: viewModel.totalPlantsAllGardens,
+                        label: "Plants",
+                        color: CultivationTheme.Colors.statusHealthy
+                    )
+                    QuickStatCard(
+                        value: viewModel.totalAlertsAllGardens,
+                        label: "Alerts",
+                        color: viewModel.totalAlertsAllGardens > 0
+                            ? CultivationTheme.Colors.statusAlert
+                            : CultivationTheme.Colors.textTertiary
+                    )
+                }
+            }
+        }
+        .padding(.top, 16)
+    }
+
+    // MARK: - Garden Grid
+
+    private var gardenGrid: some View {
+        LazyVStack(spacing: 14) {
+            ForEach(viewModel.gardenSummaries) { summary in
+                GardenCardView(
+                    garden: summary.garden,
+                    plantCount: summary.plantCount,
+                    bedCount: summary.bedCount,
+                    alertCount: summary.alertCount,
+                    onTap: {
+                        gardenToNavigate = summary.garden
+                    }
+                )
+                .contextMenu {
+                    Button {
+                        gardenToNavigate = summary.garden
+                    } label: {
+                        Label("Open", systemImage: "arrow.right.circle")
+                    }
+
+                    Button(role: .destructive) {
+                        gardenToDelete = summary.garden
+                        showDeleteConfirmation = true
+                    } label: {
+                        Label("Delete Garden", systemImage: "trash")
+                    }
+                }
+                .transition(.asymmetric(
+                    insertion: .scale(scale: 0.95).combined(with: .opacity),
+                    removal: .opacity
+                ))
+            }
+
+            // Add garden card — always visible at the bottom
+            AddGardenCard {
+                showCreateGarden = true
+            }
+        }
+    }
+
+    // MARK: - States
 
     private var loadingState: some View {
         VStack(spacing: 16) {
             ProgressView()
                 .tint(CultivationTheme.Colors.brandLeaf)
-            Text("Loading garden…")
+            Text("Loading gardens\u{2026}")
                 .font(.system(.subheadline, design: .rounded))
                 .foregroundStyle(CultivationTheme.Colors.textSecondary)
         }
@@ -150,49 +194,87 @@ public struct GardenView: View {
     }
 
     private var emptyState: some View {
-        VStack(spacing: 16) {
-            IconBubble(
-                systemName: "leaf",
-                color: CultivationTheme.Colors.brandLeaf,
-                size: 64,
-                iconSize: 28
-            )
-            Text("No plants yet")
-                .font(.system(.headline, design: .rounded))
-                .foregroundStyle(CultivationTheme.Colors.textPrimary)
-            Text("Add your first plant to get started")
-                .font(.system(.subheadline))
-                .foregroundStyle(CultivationTheme.Colors.textSecondary)
-            Button("Add Plant") { showAddPlant = true }
-                .buttonStyle(GradientButtonStyle())
-                .padding(.horizontal, 40)
-                .accessibilityIdentifier("garden_button_addplant_empty")
+        VStack(spacing: 20) {
+            // Illustration
+            ZStack {
+                Circle()
+                    .fill(CultivationTheme.Colors.brandLeaf.opacity(0.08))
+                    .frame(width: 120, height: 120)
+
+                VStack(spacing: 4) {
+                    Image(systemName: "leaf.circle.fill")
+                        .font(.system(size: 44))
+                        .foregroundStyle(CultivationTheme.Colors.brandLeaf)
+                    Image(systemName: "plus.circle")
+                        .font(.system(size: 18))
+                        .foregroundStyle(CultivationTheme.Colors.brandLeaf.opacity(0.6))
+                        .offset(x: 20, y: -8)
+                }
+            }
+
+            VStack(spacing: 6) {
+                Text("Plant your first garden")
+                    .font(.system(.title3, design: .rounded, weight: .semibold))
+                    .foregroundStyle(CultivationTheme.Colors.textPrimary)
+
+                Text("Create a garden for your backyard, balcony,\nwindowsill, or anywhere you grow")
+                    .font(.system(.subheadline))
+                    .foregroundStyle(CultivationTheme.Colors.textSecondary)
+                    .multilineTextAlignment(.center)
+            }
+
+            Button("Create Your First Garden") {
+                showCreateGarden = true
+            }
+            .buttonStyle(GradientButtonStyle())
+            .padding(.horizontal, 24)
+            .accessibilityIdentifier("garden_button_create_first")
+
+            // Quick-start suggestions
+            VStack(alignment: .leading, spacing: 8) {
+                Text("POPULAR SETUPS")
+                    .sectionLabelStyle()
+
+                HStack(spacing: 10) {
+                    QuickStartChip(icon: "sun.max.fill", label: "Backyard") {
+                        showCreateGarden = true
+                    }
+                    QuickStartChip(icon: "building.2.fill", label: "Balcony") {
+                        showCreateGarden = true
+                    }
+                    QuickStartChip(icon: "house.fill", label: "Indoor") {
+                        showCreateGarden = true
+                    }
+                }
+            }
+            .padding(.top, 8)
         }
         .frame(maxWidth: .infinity)
-        .padding(.top, 60)
+        .padding(.top, 40)
     }
+}
 
-    private var addBedButton: some View {
-        Button {
-            showCreateBed = true
-        } label: {
-            HStack {
-                Image(systemName: "plus.circle")
-                Text("Add Bed or Area")
+// MARK: - QuickStartChip
+
+private struct QuickStartChip: View {
+    let icon: String
+    let label: String
+    let onTap: () -> Void
+
+    var body: some View {
+        Button(action: onTap) {
+            VStack(spacing: 6) {
+                Image(systemName: icon)
+                    .font(.system(size: 18, weight: .medium))
+                    .foregroundStyle(CultivationTheme.Colors.brandLeaf)
+                Text(label)
+                    .font(.system(.caption, design: .rounded, weight: .medium))
+                    .foregroundStyle(CultivationTheme.Colors.textSecondary)
             }
-            .font(.system(.subheadline, design: .rounded, weight: .medium))
-            .foregroundStyle(CultivationTheme.Colors.brandLeaf)
             .frame(maxWidth: .infinity)
             .padding(.vertical, 14)
-            .background {
-                RoundedRectangle(cornerRadius: CultivationTheme.Radius.card)
-                    .stroke(
-                        CultivationTheme.Colors.brandLeaf.opacity(0.3),
-                        style: StrokeStyle(lineWidth: 1, dash: [6])
-                    )
-            }
+            .glassCard()
         }
         .buttonStyle(.plain)
-        .accessibilityIdentifier("garden_button_addbed")
     }
 }


### PR DESCRIPTION
Replace the plant-list-first approach with a garden-centric dashboard
that makes it easy to see, manage, and create multiple gardens.

New components:
- GardenCardView: visual card for each garden with mini bed layout,
  plant/bed counts, health summary, and alert badges
- GardenMiniLayout: spatial visualization of garden beds as colored tiles
- AddGardenCard: prominent dashed-border card to create new gardens
- CreateGardenSheet: full garden creation flow with type, sun, and size
- GardenDetailView: drill-down view showing plants/beds for a single garden
- GardenSummary: lightweight per-garden stats model for dashboard cards

The main GardenView now shows:
- Dashboard header with global stats (gardens, plants, alerts)
- Scrollable list of garden cards with visual bed layouts
- Always-visible "New Garden" card at bottom
- Context menu on cards for quick delete
- Empty state with quick-start suggestions

GardenViewModel updated with garden summaries, delete support,
and aggregate stats across all gardens.

https://claude.ai/code/session_01EfwxefevUoebouYw5GQoTg