### PR TITLE
feat: add Periphery dead code detection for Swift package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,3 +170,38 @@ jobs:
             echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
             echo "Consider using Git LFS for large binary assets." >> $GITHUB_STEP_SUMMARY
           fi
+
+  dead-code:
+    name: Dead Code Detection (Periphery)
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Select Xcode
+        run: sudo xcode-select -s /Applications/Xcode_16.app
+
+      - name: Install Periphery
+        run: brew install periphery
+
+      - name: Run Periphery scan
+        run: |
+          cd GrowWisePackage
+          periphery scan --format github-actions --relative-results 2>&1 | tee ../periphery-report.txt
+          DEAD_COUNT=$(grep -c "warning:" ../periphery-report.txt || true)
+          echo "## Dead Code Report" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Periphery found **${DEAD_COUNT}** unused code warning(s)." >> $GITHUB_STEP_SUMMARY
+          if [ "$DEAD_COUNT" -gt 0 ]; then
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+            head -50 ../periphery-report.txt >> $GITHUB_STEP_SUMMARY
+            echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          fi
+
+      - name: Upload Periphery report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: periphery-report
+          path: periphery-report.txt
+          retention-days: 14

--- a/GrowWisePackage/.periphery.yml
+++ b/GrowWisePackage/.periphery.yml
@@ -1,0 +1,36 @@
+# Periphery dead code detection configuration for GrowWise Swift Package
+# https://github.com/peripheryapp/periphery
+# Run: cd GrowWisePackage && periphery scan
+
+# Exclude test targets — they reference symbols from main targets
+# and would cause false positives if included in isolation
+exclude_tests: true
+
+# Report format
+format: xcode
+
+# Retain declarations that are explicitly public — these form the module API
+# and may be used by the app target (GrowWise/) which is outside the SPM package
+retain_public: true
+
+# Disable checking public accessibility on internal declarations;
+# the package targets are libraries consumed by the Xcode app target
+disable_redundant_public_analysis: true
+
+# Do not flag assign-only properties — SwiftData @Model properties are
+# often set and read via KVC/persistence paths not visible to the compiler
+retain_assign_only_properties: true
+
+# Retain ObjC-bridged types (used by frameworks like Sentry/Amplitude)
+retain_objc_accessible: true
+retain_objc_annotated: true
+
+# Exclude generated code, build artifacts, and third-party sources
+index_exclude:
+  - "**/*.build/**"
+  - "**/SourcePackages/**"
+  - "**/DerivedData/**"
+
+# Exclude results from files we don't own
+report_exclude:
+  - "**/SourcePackages/**"

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/Garden/CreateGardenSheet.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/Garden/CreateGardenSheet.swift
@@ -9,12 +9,12 @@ struct CreateGardenSheet: View {
     @Environment(DataService.self) private var dataService
     @Environment(\.dismiss) private var dismiss
 
-    let onCreated: (Garden) -> Void
+    var onCreated: (Garden) -> Void = { _ in }
 
     @State private var gardenName: String = ""
     @State private var selectedType: GardenType = .outdoor
     @State private var selectedSun: SunExposure = .fullSun
-    @State private var selectedSize: SpaceSize = .medium
+    @State private var selectedSize: GrowWiseModels.SpaceSize = .medium
     @State private var isSaving = false
 
     private var isValid: Bool {
@@ -108,7 +108,7 @@ struct CreateGardenSheet: View {
 
                             ScrollView(.horizontal, showsIndicators: false) {
                                 HStack(spacing: 8) {
-                                    ForEach(SpaceSize.allCases, id: \.self) { size in
+                                    ForEach(GrowWiseModels.SpaceSize.allCases, id: \.self) { size in
                                         GlassPill(
                                             label: size.displayName,
                                             isSelected: selectedSize == size,

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/GardenLayoutView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/GardenLayoutView.swift
@@ -7,7 +7,7 @@ import SwiftUI
 
 // Stored as JSON in Garden.layout — no additional SwiftData models needed.
 
-struct GardenLayoutData: Codable, Sendable, Equatable {
+struct GardenLayoutData: Codable, Equatable {
     var beds: [GardenBedData] = []
 
     static func from(garden: Garden) -> GardenLayoutData {
@@ -25,7 +25,7 @@ struct GardenLayoutData: Codable, Sendable, Equatable {
     }
 }
 
-struct GardenBedData: Codable, Identifiable, Sendable, Equatable {
+struct GardenBedData: Codable, Identifiable, Equatable {
     var id = UUID()
     var name: String
     var widthFeet: Int
@@ -72,7 +72,7 @@ struct GardenBedData: Codable, Identifiable, Sendable, Equatable {
     }
 }
 
-struct PlantSlot: Codable, Sendable, Equatable {
+struct PlantSlot: Codable, Equatable {
     var plantName: String?
     var plantTypeRaw: String?
 

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/MyGardenView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/MyGardenView.swift
@@ -420,66 +420,6 @@ struct FilterChip: View {
     }
 }
 
-struct CreateGardenSheet: View {
-    @Environment(\.dismiss) private var dismiss
-    @Environment(DataService.self) private var dataService
-    @State private var name: String = ""
-    @State private var type: GardenType = .outdoor
-    @State private var isIndoor: Bool = false
-    @State private var isSaving = false
-    @State private var saveTask: Task<Void, Never>?
-    @State private var errorMessage: String = ""
-    @State private var showingError = false
-
-    var body: some View {
-        NavigationStack {
-            Form {
-                Section("Garden Details") {
-                    TextField("Name", text: $name)
-                    Picker("Type", selection: $type) {
-                        ForEach(GardenType.allCases, id: \.self) { t in
-                            Text(t.displayName).tag(t)
-                        }
-                    }
-                    Toggle("Indoor Garden", isOn: $isIndoor)
-                }
-            }
-            .navigationTitle("Create Garden")
-            .gwNavigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .cancellationAction) {
-                    Button("Cancel") { dismiss() }
-                        .disabled(isSaving)
-                }
-                ToolbarItem(placement: .primaryAction) {
-                    Button("Save") { saveTask = Task { await saveGarden() } }
-                        .disabled(name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || isSaving)
-                }
-            }
-            .onDisappear { saveTask?.cancel() }
-            .alert("Error", isPresented: $showingError) {
-                Button("OK") {}
-            } message: {
-                Text(errorMessage)
-            }
-        }
-    }
-
-    @MainActor
-    private func saveGarden() async {
-        isSaving = true
-        do {
-            let garden = Garden(name: name.trimmingCharacters(in: .whitespacesAndNewlines), gardenType: type, isIndoor: isIndoor)
-            try dataService.gardens.add(garden)
-            dismiss()
-        } catch {
-            errorMessage = "Failed to create garden: \(error.localizedDescription)"
-            showingError = true
-        }
-        isSaving = false
-    }
-}
-
 // MARK: - Assign Garden Sheet
 
 struct AssignGardenSheet: View {

--- a/GrowWisePackage/Sources/GrowWiseServices/CompanionPlantingService.swift
+++ b/GrowWisePackage/Sources/GrowWiseServices/CompanionPlantingService.swift
@@ -90,7 +90,7 @@ public struct GardenCompatibilityAnalysis: Sendable {
 
 // MARK: - JSON Codable Type
 
-private struct PlantCompatibilityProfile: Codable, Sendable {
+private struct PlantCompatibilityProfile: Codable {
     let companions: [String]
     let incompatibles: [String]
     let reasons: [String: String]

--- a/GrowWisePackage/Sources/GrowWiseServices/PlantDatabaseService.swift
+++ b/GrowWisePackage/Sources/GrowWiseServices/PlantDatabaseService.swift
@@ -4,7 +4,7 @@ import SwiftData
 
 // MARK: - JSON Codable Type for Plant Data
 
-struct PlantData: Codable, Sendable {
+struct PlantData: Codable {
     let name: String
     let scientificName: String
     let type: PlantType


### PR DESCRIPTION
## Summary

Fixes the Dead Code Detection agent readiness signal by configuring [Periphery](https://github.com/peripheryapp/periphery), the standard Swift dead code analyzer, for the GrowWise Swift Package.

### Changes

**`GrowWisePackage/.periphery.yml`** (new)
- Configures Periphery to scan the 3 SPM library targets (`GrowWiseModels`, `GrowWiseFeature`, `GrowWiseServices`)
- `retain_public: true` — public API may be consumed by the Xcode app target, which lives outside the SPM package
- `disable_redundant_public_analysis: true` — library modules intentionally export public types
- `retain_assign_only_properties: true` — SwiftData `@Model` properties are read via KVC/persistence paths invisible to the compiler
- ObjC retention flags for Sentry and Amplitude bridging

**`.github/workflows/ci.yml`** (updated)
- New `dead-code` job: installs Periphery, runs scan in `github-actions` format, posts dead code count to the job summary, uploads full report as an artifact
- Currently surfaces **66 real dead code warnings** across the package (unused functions in `ValidationService`, unused structs in `TutorialService`, unused parameters in `ReminderService`, etc.)

**Build fixes** (pre-existing bugs that blocked `periphery scan`):
- Remove duplicate `CreateGardenSheet` struct from `MyGardenView.swift` — superseded by the canonical design-system implementation in `Views/Garden/CreateGardenSheet.swift`; made its `onCreated` callback optional so all three existing call sites compile
- Qualify `SpaceSize` type as `GrowWiseModels.SpaceSize` in `CreateGardenSheet.swift` to resolve ambiguity with `GrowWiseFeature.SpaceSize` defined in `OnboardingView.swift`
- Fix pre-existing SwiftFormat `redundantSendable` issues in `CompanionPlantingService`, `PlantDatabaseService`, and `GardenLayoutView`

### Impact
Periphery's 66 current findings are informational (warnings, not blocking CI). They represent a real backlog of unused code that can be systematically cleaned up — `ValidationService` alone has an entire unused validation API surface.