### PR TITLE
chore: add Claude skills standard directory for agent readiness

### DIFF
--- a/.claude/skills/beads-issue-workflow/SKILL.md
+++ b/.claude/skills/beads-issue-workflow/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: beads-issue-workflow
+description: Use when creating, updating, tracking, or closing beads (bd) issues in GrowWise. Ensures consistent issue management, proper labeling, and session handoff hygiene.
+---
+
+# Beads Issue Workflow Skill
+
+GrowWise uses **beads** (`bd`) as its primary issue tracker — local-first, git-native, no browser required.
+
+## Core Commands
+
+```bash
+# View current issues
+bd show                          # All open issues
+bd show --status in_progress     # In-progress only
+bd show --filter "label:bug"     # Filtered by label
+
+# Create issues
+bd add "Fix crash in DataService when model is nil"
+bd add "Refactor KeyRotationManager" --label chore
+bd add "P0 security issue in token validation" --label "P0: Critical,security"
+
+# Update issues
+bd start GW-42          # Mark in_progress
+bd close GW-42          # Mark closed
+bd block GW-42          # Mark blocked
+bd edit GW-42           # Open in editor
+
+# Session workflow
+bd ready                # Show what's ready to work on
+bd sync                 # Push beads state to git remote
+```
+
+## Issue Lifecycle
+
+```
+open → in_progress → closed
+         ↓
+       blocked → in_progress
+```
+
+Always move an issue to `in_progress` before starting work:
+```bash
+bd start GW-XXX
+```
+
+## Filing Issues for Unfinished Work
+
+At the end of every session, file issues for anything not completed:
+
+```bash
+# Quick issue filing
+bd add "Implement plant deletion confirmation dialog" --label enhancement
+bd add "Add unit tests for CompanionPlantingService" --label "area: services"
+bd add "SwiftLint violations in DataService.swift" --label chore
+```
+
+## Linking Issues in Code
+
+Always reference beads issues in code comments:
+```swift
+// TODO(GW-123): Extract this into a separate service after refactoring
+// FIXME(GW-456): Memory leak in this subscription chain
+```
+
+## Session Handoff Checklist
+
+Before ending any session:
+
+```bash
+# 1. File remaining issues
+bd add "description of unfinished work"
+
+# 2. Close completed issues
+bd close GW-XXX
+
+# 3. Sync beads state
+bd sync
+
+# 4. Push to remote
+git push
+```
+
+Verify sync:
+```bash
+git status   # Must show "up to date with origin"
+```
+
+## Label Conventions
+
+| Label | Use For |
+|-------|---------|
+| `P0: Critical` | Production-breaking or security issue |
+| `P1: High` | Significant user impact |
+| `P2: Medium` | Notable issue, backlog priority |
+| `P3: Low` | Nice-to-have |
+| `bug` | Something broken |
+| `enhancement` | New feature or improvement |
+| `chore` | Maintenance, refactoring |
+| `security` | Security-sensitive change |
+| `area: models` | SwiftData model changes |
+| `area: services` | Service layer changes |
+| `area: ui` | SwiftUI view changes |
+| `area: sync` | CloudKit sync issues |

--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: code-review
+description: Run the GrowWise code-reviewer droid on staged/uncommitted changes or a specific branch. Use before merging any feature branch. Also useful ad-hoc anytime Blake or an agent wants a quick review pass.
+---
+
+# Code Review — GrowWise
+
+Invokes the `code-reviewer` droid with context about what changed.
+
+## Pre-merge review (staged + uncommitted changes)
+
+```bash
+cd ~/Projects/GrowWise
+droid "Use the code-reviewer droid. Review all staged and uncommitted changes against main. Focus on: MV architecture compliance, Swift 6 concurrency, SwiftData/CloudKit safety, force unwraps, and print statements. Produce a structured report with PASS/WARN/FAIL per category."
+```
+
+## Review specific branch vs main
+
+```bash
+cd ~/Projects/GrowWise
+droid "Use the code-reviewer droid. Review the diff between HEAD and main (git diff main...HEAD). Same checklist — MV pattern, Swift 6, SwiftData, security. List any blocking issues."
+```
+
+## Ad-hoc quick review (last commit)
+
+```bash
+cd ~/Projects/GrowWise
+droid "Use the code-reviewer droid on the last commit (git show HEAD). Flag any issues."
+```
+
+## When to run
+- ✅ Before merging any feature branch
+- ✅ After a large refactor or AI-generated code change
+- ✅ Before releasing
+- ✅ Anytime Blake asks for a review pass
+
+## CI integration
+The `agent-code-review.yml` workflow runs an automated version on every PR.
+The droid review above is for deeper, interactive pre-merge checks.

--- a/.claude/skills/ios-swift-development/SKILL.md
+++ b/.claude/skills/ios-swift-development/SKILL.md
@@ -1,0 +1,195 @@
+---
+name: ios-swift-development
+description: Use when implementing features, fixing bugs, or refactoring in the GrowWise iOS codebase. Enforces Swift 6 concurrency, MV architecture, SwiftData/CloudKit conventions, and security requirements.
+---
+
+# GrowWise iOS Development Skill
+
+## Prerequisites
+
+Before writing any code, verify the current state:
+
+```bash
+# Check which branch you're on
+git rev-parse --abbrev-ref HEAD
+
+# See current beads issues
+bd show
+
+# Run existing tests to ensure a clean baseline
+cd GrowWisePackage && swift test
+```
+
+## Architecture Rules (Non-Negotiable)
+
+**MV Pattern only — NO ViewModels:**
+- Views get data via `@Environment(Service.self)` injected from the app root
+- Local ephemeral state uses `@State` in the view itself
+- Never create `class MyViewModel: ObservableObject`
+- Never use `@StateObject` or `@ObservedObject`
+
+**Concurrency:**
+- UI-bound services must be `@MainActor`
+- Background operations use Swift `Actor` or `async/await`
+- Never use `DispatchQueue` or completion handlers
+- Structured concurrency only — no `Task.detached` without justification
+
+**SwiftData:**
+- All `@Model` properties must be `Optional` or have defaults (CloudKit requirement)
+- Never use `ModelConfiguration(isStoredInMemoryOnly: true)` in production
+- Migrations must be additive — never delete properties from models
+
+## Code Quality Requirements
+
+**Never acceptable:**
+```swift
+// WRONG — force unwrap
+let name = plant.name!
+
+// WRONG — force cast
+let service = object as! DataService
+
+// WRONG — silencing errors in views
+try? service.save()
+
+// WRONG — no issue reference
+// TODO: fix this later
+```
+
+**Always required:**
+```swift
+// CORRECT — safe unwrap
+guard let name = plant.name else { return }
+
+// CORRECT — typed error handling
+do {
+    try service.save()
+} catch {
+    // handle with fallback or surface to user
+}
+
+// CORRECT — linked tech debt
+// TODO(GW-123): refactor this after migration completes
+```
+
+**Accessibility (mandatory):**
+```swift
+Button("Add Plant") { ... }
+    .accessibilityIdentifier("addPlantButton")
+    .accessibilityLabel("Add a new plant")
+```
+
+**Logging (never use print):**
+```swift
+import OSLog
+private let logger = Logger(subsystem: "com.growwise", category: "DataService")
+logger.info("Plant saved: \(plant.id, privacy: .public)")
+// For sensitive data, always use .private or omit
+logger.debug("Key rotation: \(keyID, privacy: .private)")
+```
+
+## Security Rules
+
+For any change touching `GrowWiseServices/Keychain*`, `Encryption*`, `SecureEnclave*`, `KeyRotation*`, `Token*`, or `JWT*`:
+
+1. Never log key material, tokens, or user secrets — even at debug level
+2. Never store sensitive data in `UserDefaults` — use `KeychainStorageService`
+3. Always use the `AuditLogger` for security-relevant events
+4. Follow the multi-level fallback pattern from `DataService`
+
+## Testing
+
+```bash
+# All tests
+cd GrowWisePackage && swift test
+
+# Specific module
+swift test --filter GrowWiseServicesTests
+swift test --filter GrowWiseModelsTests
+swift test --filter GrowWiseFeatureTests
+```
+
+Tests use Swift Testing framework (`@Test`, `#expect`, `#require`). Never use `XCTAssert*` in new tests.
+
+## Build Verification
+
+```bash
+xcodebuild \
+  -workspace GrowWise.xcworkspace \
+  -scheme GrowWise \
+  -sdk iphonesimulator \
+  -destination 'platform=iOS Simulator,name=iPhone 16' \
+  build \
+  CODE_SIGNING_ALLOWED=NO
+```
+
+## Quality Gates Before Commit
+
+```bash
+# Lint check
+swiftlint lint --strict --config .swiftlint.yml
+
+# Format check
+swiftformat --lint --config .swiftformat GrowWisePackage/Sources GrowWise
+
+# Tests
+cd GrowWisePackage && swift test
+```
+
+## Completing Work
+
+1. File any follow-up issues: `bd add "description"`
+2. Mark resolved issues: `bd close GW-XXX`
+3. Sync beads state: `bd sync`
+4. Push: `git push`
+
+---
+
+## ⚠️ Test Quality Standards — Mock Trap Prevention
+
+> **Critical:** These rules apply to ALL test writing, including when using Droid/Factory agents.
+
+### The Mock Trap (learn from NM2's 349-test incident)
+Mock-only tests prove plumbing works. They do NOT prove real services produce output.
+Before writing any test, ask: *"If I deleted the mock and used the real service, would this test still pass?"*
+If no → mock-only gap. You need an integration or contract test too.
+
+### Required test types by service kind
+| Service Type | Required |
+|-------------|---------|
+| Pure logic (calculators, parsers) | Unit tests with known inputs |
+| `@Observable` services | Mock-based unit tests (plumbing only) |
+| Network/CloudKit API services | **Contract test** — real parser + fixture JSON |
+| Services that produce user-visible output | **Integration test** — real service + verify non-empty output |
+| Any service with `catch {}` or `try?` | **P0 bug first** — fix error surfacing before writing tests |
+
+### Silent failure audit (run before writing ANY tests)
+Scan the real service implementation for:
+- `catch { }` or `catch { _ = error }` — error swallowed, user sees blank screen
+- `try?` without logging — failure invisible
+- `guard else { return }` — silent no-op
+
+These are P0 bugs. Fix them first. Then write tests.
+
+### ❌ Reject (shallow)
+```swift
+XCTAssertTrue(app.buttons["Save"].exists)           // existence only
+#expect(vm.items.count == 2)  // with mock service  // mock-only
+```
+
+### ✅ Require (functional)
+```swift
+// Outcome validation
+app.buttons["Save"].tap()
+XCTAssertTrue(app.staticTexts["Saved"].waitForExistence(timeout: 2))
+
+// Contract test — real parser + fixture
+let fixture = Data("""{"status":"ok","count":3}""".utf8)
+let result = try JSONDecoder().decode(MyResponse.self, from: fixture)
+#expect(result.count == 3)
+
+// Integration test — real service
+let svc = PlantService()  // REAL, not mock
+let plants = try await svc.fetchPlants(query: "tomato")
+#expect(!plants.isEmpty, "Real service must return results")
+```

--- a/.claude/skills/run-tests/SKILL.md
+++ b/.claude/skills/run-tests/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: run-tests
+description: Run GrowWise tests. Always use swift test on the GrowWisePackage — never xcodebuild test without -skip-testing:GrowWiseUITests (causes 10+ crash dialogs every 20 seconds).
+---
+
+# Run Tests — GrowWise
+
+## Standard test run (safe on any machine)
+
+```bash
+cd ~/Projects/GrowWise
+swift test --package-path GrowWisePackage
+```
+
+Baseline: **663 tests, 0 failures** (as of 2026-02-28)
+
+## Filter by target
+
+```bash
+swift test --package-path GrowWisePackage --filter GrowWiseServicesTests
+swift test --package-path GrowWisePackage --filter GrowWiseModelsTests
+swift test --package-path GrowWisePackage --filter GrowWiseFeatureTests
+```
+
+## Coverage report (use llvm-cov — NOT grep on raw output)
+
+```bash
+cd ~/Projects/GrowWise
+swift test --package-path GrowWisePackage --enable-code-coverage
+xcrun llvm-cov report \
+  $(find GrowWisePackage/.build/debug -name '*PackageTests' -type f 2>/dev/null | head -1) \
+  -instr-profile $(find GrowWisePackage/.build/debug -name 'default.profdata' 2>/dev/null | head -1) \
+  --ignore-filename-regex='.build|Tests' \
+  --summary-only
+```
+
+Target: **80% on GrowWisePackage** (enforced in CI once infra branch merges).
+
+## ⚠️ NEVER do this
+
+```bash
+# DANGEROUS — causes 10+ crash dialogs every 20 seconds
+xcodebuild test -scheme GrowWise -destination '...'
+
+# SAFE if you must use xcodebuild
+xcodebuild test -scheme GrowWise -destination '...' -skip-testing:GrowWiseUITests
+```
+
+## Framework
+Swift Testing (`@Test`, `#expect`, `#require`). Never use `XCTAssert*` in new tests.


### PR DESCRIPTION
## Summary

Adds `.claude/skills/` directory following the [Claude skills open standard](https://code.claude.com/docs/en/skills) to fix the **Skills Configuration [0/1]** agent readiness signal.

## What changed

Mirrored the existing `.factory/skills/` content into `.claude/skills/` — the standard location that readiness evaluators check. Four substantive skills are included:

| Skill | Purpose |
|-------|---------|
| `ios-swift-development` | Enforces Swift 6 concurrency, MV architecture, SwiftData/CloudKit conventions, and security requirements |
| `beads-issue-workflow` | Issue lifecycle management with `bd` — creation, labeling, session handoff |
| `run-tests` | Safe test execution (swift test only, never raw xcodebuild test) |
| `code-review` | Invokes the code-reviewer droid for pre-merge reviews |

Each skill has YAML frontmatter with `name` and `description`, plus detailed prompt content with code examples and guardrails.

## Why

The agent readiness evaluator reported "No skills configured" despite `.factory/skills/` existing. Adding `.claude/skills/` ensures the standard location is covered.