### PR TITLE
docs: add DocC documentation catalogs and swift-docc-plugin

### DIFF
--- a/GrowWisePackage/Package.resolved
+++ b/GrowWisePackage/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "fe2058021877317dc0eb2a90f72cf1f109191d19c941bd34f79fc766b4cd9308",
+  "originHash" : "766210c522dd1e225bda379ce3f6345485c83afe95bcbe288e7df453b3734fcc",
   "pins" : [
     {
       "identity" : "amplitude-swift",
@@ -35,6 +35,24 @@
       "state" : {
         "revision" : "990135f0881e56ac6b39404de0f5b0cd0dcf2131",
         "version" : "9.6.0"
+      }
+    },
+    {
+      "identity" : "swift-docc-plugin",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-docc-plugin",
+      "state" : {
+        "revision" : "e977f65879f82b375a044c8837597f690c067da6",
+        "version" : "1.4.6"
+      }
+    },
+    {
+      "identity" : "swift-docc-symbolkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-docc-symbolkit",
+      "state" : {
+        "revision" : "b45d1f2ed151d057b54504d653e0da5552844e34",
+        "version" : "1.0.0"
       }
     }
   ],

--- a/GrowWisePackage/Package.swift
+++ b/GrowWisePackage/Package.swift
@@ -32,6 +32,10 @@ let package = Package(
             url: "https://github.com/amplitude/Amplitude-Swift",
             from: "1.10.0"
         ),
+        .package(
+            url: "https://github.com/apple/swift-docc-plugin",
+            from: "1.4.3"
+        ),
     ],
     targets: [
         // Core feature module - main app views and navigation

--- a/GrowWisePackage/Sources/GrowWiseModels/GrowWiseModels.docc/GrowWiseModels.md
+++ b/GrowWisePackage/Sources/GrowWiseModels/GrowWiseModels.docc/GrowWiseModels.md
@@ -1,0 +1,72 @@
+# ``GrowWiseModels``
+
+SwiftData model layer for the GrowWise gardening app.
+
+## Overview
+
+GrowWiseModels defines all persistent data types used by the GrowWise (Cultivation) iOS app. Every model class uses SwiftData's `@Model` macro and is designed for CloudKit compatibility — all properties are optional or have defaults.
+
+The module has no external dependencies, making it safe to import from any target.
+
+## Topics
+
+### Plants
+
+- ``Plant``
+- ``PlantType``
+- ``DifficultyLevel``
+- ``SunlightLevel``
+- ``WateringFrequency``
+- ``GrowthStage``
+- ``HealthStatus``
+- ``SpaceRequirement``
+- ``ContainerType``
+
+### Gardens
+
+- ``Garden``
+- ``GardenType``
+- ``SunExposure``
+- ``SoilType``
+- ``DrainageLevel``
+- ``SpaceSize``
+- ``GardenBed``
+- ``BedType``
+
+### Journal
+
+- ``JournalEntry``
+- ``JournalEntryType``
+- ``SoilMoisture``
+- ``WeatherCondition``
+- ``PlantMood``
+
+### Reminders
+
+- ``PlantReminder``
+- ``ReminderType``
+- ``ReminderFrequency``
+- ``SnoozeDuration``
+- ``ReminderPriority``
+
+### Soil Tracking
+
+- ``SoilLog``
+- ``FertilizerType``
+- ``SoilRecommendation``
+- ``SoilNutrientStatus``
+- ``SoilTestRanges``
+
+### User Profile
+
+- ``User``
+- ``ReminderSettings``
+- ``GardeningSkillLevel``
+- ``GardeningGoal``
+- ``TimeCommitment``
+- ``MeasurementSystem``
+- ``SubscriptionTier``
+
+### Statistics
+
+- ``GardeningStats``

--- a/GrowWisePackage/Sources/GrowWiseServices/GrowWiseServices.docc/GrowWiseServices.md
+++ b/GrowWisePackage/Sources/GrowWiseServices/GrowWiseServices.docc/GrowWiseServices.md
@@ -1,0 +1,76 @@
+# ``GrowWiseServices``
+
+Business logic and service layer for the GrowWise gardening app.
+
+## Overview
+
+GrowWiseServices contains all non-UI logic for the GrowWise (Cultivation) iOS app. Services follow the `@Observable` pattern and are injected into SwiftUI views via `@Environment`. The module integrates with CloudKit for sync, Sentry for error tracking, and Amplitude for analytics.
+
+All services are `@MainActor`-isolated for UI-bound work, with dedicated actors for concurrent operations.
+
+## Topics
+
+### Data Persistence
+
+- ``DataService``
+- ``DataServiceError``
+- ``ModelContainerFactory``
+- ``DataTransformationService``
+- ``SwiftDataCache``
+
+### Cloud & Sync
+
+- ``CloudSyncService``
+- ``CloudKitError``
+- ``CloudSyncStatus``
+
+### Plant Intelligence
+
+- ``CompanionPlantingService``
+- ``CompanionPlantingInfo``
+- ``PlantCompatibilityProfile``
+- ``GardenCompatibilityAnalysis``
+- ``PlantCompatibility``
+- ``PlantDatabaseService``
+- ``PlantDiagnosticService``
+
+### Location & Weather
+
+- ``LocationService``
+- ``LocationError``
+- ``PlantingWindow``
+- ``WeatherAlertType``
+- ``AlertSeverity``
+
+### Notifications
+
+- ``NotificationService``
+- ``ReminderService``
+
+### Subscriptions & Features
+
+- ``SubscriptionService``
+- ``FeatureFlagService``
+- ``FeatureFlag``
+
+### Security
+
+- ``KeychainService``
+- ``BiometricService``
+
+### Observability
+
+- ``ObservabilityService``
+- ``AnalyticsService``
+- ``AnalyticsEvent``
+
+### Tutorials
+
+- ``TutorialService``
+- ``TutorialContent``
+- ``TutorialTopic``
+- ``TutorialStep``
+
+### Validation
+
+- ``ValidationService``


### PR DESCRIPTION
## Automated Documentation Generation Signal Fix

The project already had a `docc.yml` CI workflow for building and publishing DocC documentation, but it was missing two critical pieces: the swift-docc-plugin dependency and DocC catalog bundles for organized documentation.

### Changes

- **`GrowWiseModels.docc/GrowWiseModels.md`** — Landing page organizing all SwiftData models by domain: Plants, Gardens, Journal, Reminders, Soil Tracking, User Profile, Statistics
- **`GrowWiseServices.docc/GrowWiseServices.md`** — Landing page organizing all services by responsibility: Data Persistence, Cloud & Sync, Plant Intelligence, Location & Weather, Notifications, Security, Observability, Tutorials
- **`Package.swift`** — Added `swift-docc-plugin` (1.4.3+) dependency to enable `swift package generate-documentation`

### Why This Matters

Without DocC catalogs, the existing CI workflow generated a flat alphabetical list of symbols. With these catalogs, the documentation is structured into logical topic groups that match the app's architecture, making it navigable and useful.

### Verification

DocC builds successfully for GrowWiseModels locally:
```
Generated documentation archive at:
  .build/plugins/Swift-DocC/outputs/GrowWiseModels.doccarchive
```