### PR TITLE
Add plant disease knowledge base and CoreML model support (GH-102)

### DIFF
--- a/GrowWisePackage/Sources/GrowWiseServices/PlantDiagnosticService.swift
+++ b/GrowWisePackage/Sources/GrowWiseServices/PlantDiagnosticService.swift
@@ -1,5 +1,6 @@
 import CoreML
 import Foundation
+import GrowWiseModels
 import Observation
 import Vision
 
@@ -33,25 +34,29 @@ public struct PlantDiagnosis: Sendable, Equatable {
     public let severity: Severity
     public let recommendation: String
     public let alternatives: [PlantClassificationCandidate]
+    public let condition: PlantCondition?
 
     public init(
         primaryLabel: String,
         confidence: Float,
         severity: Severity,
         recommendation: String,
-        alternatives: [PlantClassificationCandidate]
+        alternatives: [PlantClassificationCandidate],
+        condition: PlantCondition? = nil
     ) {
         self.primaryLabel = primaryLabel
         self.confidence = confidence
         self.severity = severity
         self.recommendation = recommendation
         self.alternatives = alternatives
+        self.condition = condition
     }
 }
 
 public enum PlantDiagnosticError: Error, LocalizedError {
     case invalidImage
     case noClassification
+    case diagnosisLimitReached(remaining: Int, tier: SubscriptionTier)
 
     public var errorDescription: String? {
         switch self {
@@ -60,8 +65,17 @@ public enum PlantDiagnosticError: Error, LocalizedError {
 
         case .noClassification:
             "No diagnosis could be produced from the image."
+
+        case .diagnosisLimitReached(let remaining, let tier):
+            "You have reached your monthly diagnosis limit (\(tier.aiDiagnosesPerMonth) per month on the \(tier.displayName) plan). Upgrade for unlimited diagnoses. Remaining: \(remaining)."
         }
     }
+}
+
+// MARK: - Diagnosis Limit Constants
+
+private enum DiagnosisLimits {
+    static let freeTierMonthlyLimit = 3
 }
 
 @MainActor
@@ -71,7 +85,45 @@ public final class PlantDiagnosticService {
     public private(set) var lastDiagnosis: PlantDiagnosis?
     public private(set) var lastError: String?
 
+    /// Cached custom CoreML model, loaded once on first use.
+    private var customModel: VNCoreMLModel?
+    private var didAttemptModelLoad = false
+
     public init() {}
+
+    // MARK: - Subscription Tier Enforcement
+
+    /// Whether the given user can perform another diagnosis this month.
+    public func canDiagnose(user: User) -> Bool {
+        remainingDiagnoses(user: user) != 0
+    }
+
+    /// Number of diagnoses remaining this month. Returns -1 for unlimited (premium/pro).
+    public func remainingDiagnoses(user: User) -> Int {
+        let tier = user.subscriptionTier
+        let limit = tier.aiDiagnosesPerMonth
+        // Unlimited tiers
+        if limit < 0 { return -1 }
+
+        let used = diagnosesUsedThisMonth(user: user)
+        return max(limit - used, 0)
+    }
+
+    /// Diagnoses used in the current calendar month, accounting for monthly reset.
+    private func diagnosesUsedThisMonth(user: User) -> Int {
+        guard let lastReset = user.lastDiagnosisReset else {
+            // Never reset — all recorded uses are from the current period
+            return user.aiDiagnosesUsed
+        }
+        let calendar = Calendar.current
+        if calendar.isDate(lastReset, equalTo: Date(), toGranularity: .month) {
+            return user.aiDiagnosesUsed
+        }
+        // Different month — counter effectively resets to 0
+        return 0
+    }
+
+    // MARK: - Sample / Demo
 
     public func setSampleDiagnosis() {
         lastDiagnosis = summarize([
@@ -80,6 +132,49 @@ public final class PlantDiagnosticService {
         ])
     }
 
+    // MARK: - Diagnosis
+
+    /// Run a full diagnosis, enforcing the user's subscription limits.
+    /// Increments `user.aiDiagnosesUsed` and updates `user.lastDiagnosisReset` on success.
+    public func diagnose(image: PlatformImage, user: User) async {
+        isAnalyzing = true
+        lastError = nil
+        defer { isAnalyzing = false }
+
+        // Enforce tier limits
+        let remaining = remainingDiagnoses(user: user)
+        if remaining == 0 {
+            lastError = PlantDiagnosticError.diagnosisLimitReached(
+                remaining: 0, tier: user.subscriptionTier
+            ).localizedDescription
+            return
+        }
+
+        do {
+            let candidates = try await classify(image: image)
+            let diagnosis = summarize(candidates)
+            lastDiagnosis = diagnosis
+
+            // Track usage
+            let calendar = Calendar.current
+            if let lastReset = user.lastDiagnosisReset,
+               !calendar.isDate(lastReset, equalTo: Date(), toGranularity: .month)
+            {
+                // New month — reset counter
+                user.aiDiagnosesUsed = 1
+                user.lastDiagnosisReset = Date()
+            } else {
+                user.aiDiagnosesUsed += 1
+                if user.lastDiagnosisReset == nil {
+                    user.lastDiagnosisReset = Date()
+                }
+            }
+        } catch {
+            lastError = error.localizedDescription
+        }
+    }
+
+    /// Legacy diagnose without user — no tier enforcement.
     public func diagnose(image: PlatformImage) async {
         isAnalyzing = true
         lastError = nil
@@ -94,6 +189,8 @@ public final class PlantDiagnosticService {
         }
     }
 
+    // MARK: - Summarize
+
     public func summarize(_ candidates: [PlantClassificationCandidate]) -> PlantDiagnosis {
         guard let primary = candidates.first else {
             return PlantDiagnosis(
@@ -105,8 +202,14 @@ public final class PlantDiagnosticService {
             )
         }
 
+        // Look up knowledge base for detailed info
+        let knownCondition = PlantDiseaseKnowledge.condition(for: primary.label)
+
         let lowercased = primary.label.lowercased()
-        let severity: PlantDiagnosis.Severity = if lowercased.contains("healthy") {
+        let severity: PlantDiagnosis.Severity = if let knownCondition, primary.confidence >= 0.45 {
+            // Use the knowledge base severity when we have a confident match
+            knownCondition.severity
+        } else if lowercased.contains("healthy") {
             .healthy
         } else if primary.confidence >= 0.85 {
             .severe
@@ -118,21 +221,28 @@ public final class PlantDiagnosticService {
             .unknown
         }
 
-        let recommendation = switch severity {
-        case .healthy:
-            "No obvious disease detected. Continue normal care and weekly inspection."
+        let recommendation: String
+        if let knownCondition, primary.confidence >= 0.45 {
+            // Build a rich recommendation from the knowledge base
+            let treatmentSummary = knownCondition.treatments.prefix(2).joined(separator: " ")
+            recommendation = "\(knownCondition.commonName) detected. \(treatmentSummary)"
+        } else {
+            recommendation = switch severity {
+            case .healthy:
+                "No obvious disease detected. Continue normal care and weekly inspection."
 
-        case .mild:
-            "Possible early issue. Isolate affected leaves and monitor for 48 hours."
+            case .mild:
+                "Possible early issue. Isolate affected leaves and monitor for 48 hours."
 
-        case .moderate:
-            "Likely disease or stress. Remove affected tissue and apply targeted treatment."
+            case .moderate:
+                "Likely disease or stress. Remove affected tissue and apply targeted treatment."
 
-        case .severe:
-            "High-confidence issue. Quarantine plant, inspect nearby plants, and begin treatment now."
+            case .severe:
+                "High-confidence issue. Quarantine plant, inspect nearby plants, and begin treatment now."
 
-        case .unknown:
-            "Low-confidence result. Retake photo and capture both leaf top and underside."
+            case .unknown:
+                "Low-confidence result. Retake photo and capture both leaf top and underside."
+            }
         }
 
         return PlantDiagnosis(
@@ -140,9 +250,43 @@ public final class PlantDiagnosticService {
             confidence: primary.confidence,
             severity: severity,
             recommendation: recommendation,
-            alternatives: Array(candidates.dropFirst().prefix(3))
+            alternatives: Array(candidates.dropFirst().prefix(3)),
+            condition: knownCondition
         )
     }
+
+    // MARK: - CoreML Model Loading
+
+    /// Attempt to load a custom PlantDiseaseClassifier CoreML model from the app bundle.
+    /// Returns nil if the model is not bundled (graceful fallback to generic Vision classifier).
+    private func loadCustomModel() -> VNCoreMLModel? {
+        // Try main bundle first
+        let bundles = [Bundle.main] + Bundle.allBundles
+
+        for bundle in bundles {
+            if let modelURL = bundle.url(forResource: "PlantDiseaseClassifier", withExtension: "mlmodelc") {
+                do {
+                    let mlModel = try MLModel(contentsOf: modelURL)
+                    return try VNCoreMLModel(for: mlModel)
+                } catch {
+                    // Model found but failed to load — log and try next bundle
+                    continue
+                }
+            }
+        }
+
+        return nil
+    }
+
+    /// Returns the cached custom model, or attempts to load it once.
+    private func resolveCustomModel() -> VNCoreMLModel? {
+        if didAttemptModelLoad { return customModel }
+        didAttemptModelLoad = true
+        customModel = loadCustomModel()
+        return customModel
+    }
+
+    // MARK: - Classification
 
     private func classify(image: PlatformImage) async throws -> [PlantClassificationCandidate] {
         #if canImport(UIKit)
@@ -153,7 +297,52 @@ public final class PlantDiagnosticService {
         }
         #endif
 
-        return try await withCheckedThrowingContinuation { continuation in
+        // Try custom model first, fall back to generic Vision classifier
+        if let vnModel = resolveCustomModel() {
+            return try await classifyWithCustomModel(cgImage: cgImage, model: vnModel)
+        }
+
+        return try await classifyWithVision(cgImage: cgImage)
+    }
+
+    /// Classify using the custom CoreML model via VNCoreMLRequest.
+    private func classifyWithCustomModel(
+        cgImage: CGImage,
+        model: VNCoreMLModel
+    ) async throws -> [PlantClassificationCandidate] {
+        try await withCheckedThrowingContinuation { continuation in
+            let request = VNCoreMLRequest(model: model) { request, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                    return
+                }
+
+                let observations = request.results as? [VNClassificationObservation] ?? []
+                let mapped = observations.prefix(5).map {
+                    PlantClassificationCandidate(label: $0.identifier, confidence: $0.confidence)
+                }
+
+                if mapped.isEmpty {
+                    continuation.resume(throwing: PlantDiagnosticError.noClassification)
+                } else {
+                    continuation.resume(returning: mapped)
+                }
+            }
+
+            request.imageCropAndScaleOption = .centerCrop
+
+            do {
+                let handler = VNImageRequestHandler(cgImage: cgImage, orientation: .up)
+                try handler.perform([request])
+            } catch {
+                continuation.resume(throwing: error)
+            }
+        }
+    }
+
+    /// Classify using the generic Vision VNClassifyImageRequest (fallback).
+    private func classifyWithVision(cgImage: CGImage) async throws -> [PlantClassificationCandidate] {
+        try await withCheckedThrowingContinuation { continuation in
             let request = VNClassifyImageRequest { request, error in
                 if let error {
                     continuation.resume(throwing: error)

--- a/GrowWisePackage/Sources/GrowWiseServices/PlantDiseaseKnowledge.swift
+++ b/GrowWisePackage/Sources/GrowWiseServices/PlantDiseaseKnowledge.swift
@@ -1,0 +1,508 @@
+import Foundation
+
+// MARK: - Plant Condition Model
+
+/// A single plant disease, pest, or deficiency entry in the knowledge base.
+public struct PlantCondition: Sendable, Equatable {
+    /// Label matching the ML model output (e.g. "powdery_mildew").
+    public let label: String
+    /// Human-readable name shown in the UI.
+    public let commonName: String
+    /// Brief description of the condition.
+    public let description: String
+    /// Observable visual symptoms.
+    public let symptoms: [String]
+    /// Recommended treatment steps.
+    public let treatments: [String]
+    /// Prevention tips for future occurrences.
+    public let prevention: [String]
+    /// Typical severity when this condition is confirmed.
+    public let severity: PlantDiagnosis.Severity
+
+    public init(
+        label: String,
+        commonName: String,
+        description: String,
+        symptoms: [String],
+        treatments: [String],
+        prevention: [String],
+        severity: PlantDiagnosis.Severity
+    ) {
+        self.label = label
+        self.commonName = commonName
+        self.description = description
+        self.symptoms = symptoms
+        self.treatments = treatments
+        self.prevention = prevention
+        self.severity = severity
+    }
+}
+
+// MARK: - Knowledge Base
+
+/// Static knowledge base mapping ML model output labels to detailed condition information.
+public enum PlantDiseaseKnowledge {
+    /// All known conditions indexed by their ML label.
+    public static let conditions: [String: PlantCondition] = {
+        var map: [String: PlantCondition] = [:]
+        for condition in allConditions {
+            map[condition.label] = condition
+        }
+        return map
+    }()
+
+    /// Look up a condition by its ML label. Returns nil for unknown labels.
+    public static func condition(for label: String) -> PlantCondition? {
+        conditions[label.lowercased()]
+    }
+
+    /// All conditions in the knowledge base.
+    public static let allConditions: [PlantCondition] = diseases + pests + deficiencies
+
+    // MARK: - Diseases
+
+    public static let diseases: [PlantCondition] = [
+        PlantCondition(
+            label: "powdery_mildew",
+            commonName: "Powdery Mildew",
+            description: "A fungal disease that forms a white, powdery coating on leaf surfaces. Thrives in warm, dry climates with cool nights and high humidity.",
+            symptoms: [
+                "White or gray powdery spots on leaves and stems",
+                "Yellowing and curling of affected leaves",
+                "Stunted new growth",
+                "Premature leaf drop",
+            ],
+            treatments: [
+                "Remove and destroy heavily infected leaves",
+                "Apply neem oil spray (1 tbsp per quart of water) every 7-14 days",
+                "Use potassium bicarbonate solution as a fungicide alternative",
+                "Improve air circulation around the plant",
+            ],
+            prevention: [
+                "Space plants to allow adequate airflow",
+                "Water at the base rather than overhead",
+                "Choose mildew-resistant cultivars",
+                "Avoid excessive nitrogen fertilization",
+            ],
+            severity: .moderate
+        ),
+        PlantCondition(
+            label: "leaf_spot",
+            commonName: "Leaf Spot",
+            description: "A group of fungal or bacterial diseases causing distinct spots on foliage. Common in warm, humid conditions.",
+            symptoms: [
+                "Brown or black circular spots on leaves",
+                "Yellow halos around spots",
+                "Spots may merge into larger blighted areas",
+                "Premature defoliation in severe cases",
+            ],
+            treatments: [
+                "Remove and discard infected leaves immediately",
+                "Apply copper-based fungicide every 7-10 days",
+                "Avoid wetting foliage when watering",
+                "Thin dense growth to improve air circulation",
+            ],
+            prevention: [
+                "Water plants at soil level early in the day",
+                "Mulch around plants to prevent soil splash",
+                "Rotate crops annually",
+                "Sanitize pruning tools between plants",
+            ],
+            severity: .mild
+        ),
+        PlantCondition(
+            label: "early_blight",
+            commonName: "Early Blight",
+            description: "A fungal disease caused by Alternaria solani, primarily affecting tomatoes and potatoes. Produces characteristic concentric ring patterns.",
+            symptoms: [
+                "Dark brown spots with concentric rings (target pattern)",
+                "Lower leaves affected first, progressing upward",
+                "Yellowing tissue around lesions",
+                "Stem lesions near soil line",
+            ],
+            treatments: [
+                "Remove infected lower leaves immediately",
+                "Apply chlorothalonil or copper fungicide on a 7-day schedule",
+                "Stake plants to keep foliage off the ground",
+                "Ensure adequate potassium in soil to strengthen plant defenses",
+            ],
+            prevention: [
+                "Use certified disease-free seed or transplants",
+                "Practice 3-year crop rotation away from solanaceous crops",
+                "Mulch heavily to prevent soil splash onto leaves",
+                "Water with drip irrigation to keep foliage dry",
+            ],
+            severity: .moderate
+        ),
+        PlantCondition(
+            label: "late_blight",
+            commonName: "Late Blight",
+            description: "A devastating oomycete disease caused by Phytophthora infestans. Spreads rapidly in cool, wet conditions and can destroy entire crops within days.",
+            symptoms: [
+                "Water-soaked, dark green to brown lesions on leaves",
+                "White fuzzy mold on leaf undersides in humid conditions",
+                "Rapid browning and collapse of stems",
+                "Brown, firm rot on fruit or tubers",
+            ],
+            treatments: [
+                "Remove and destroy all infected plants immediately — do not compost",
+                "Apply mancozeb or chlorothalonil fungicide preventively",
+                "Harvest any remaining unaffected fruit promptly",
+                "Monitor neighboring plants daily for 2 weeks",
+            ],
+            prevention: [
+                "Plant resistant varieties when available",
+                "Avoid overhead irrigation entirely",
+                "Ensure excellent air circulation with wide spacing",
+                "Destroy volunteer potatoes and tomatoes each spring",
+            ],
+            severity: .severe
+        ),
+        PlantCondition(
+            label: "root_rot",
+            commonName: "Root Rot",
+            description: "A soil-borne fungal disease caused by Pythium, Phytophthora, or Fusarium species. Attacks roots in waterlogged or poorly drained soils.",
+            symptoms: [
+                "Wilting despite adequate soil moisture",
+                "Yellowing and dropping of lower leaves",
+                "Soft, brown, mushy roots instead of firm white ones",
+                "Stunted growth and general decline",
+            ],
+            treatments: [
+                "Unpot the plant and trim all brown, mushy roots with sterile scissors",
+                "Repot in fresh, well-draining soil mix",
+                "Apply a systemic fungicide drench (e.g., mefenoxam)",
+                "Reduce watering frequency and ensure pot has drainage holes",
+            ],
+            prevention: [
+                "Use well-draining potting mix with perlite or pumice",
+                "Never let pots sit in standing water",
+                "Allow soil to dry slightly between waterings",
+                "Sterilize pots and tools before reuse",
+            ],
+            severity: .severe
+        ),
+        PlantCondition(
+            label: "rust",
+            commonName: "Rust",
+            description: "A fungal disease producing rust-colored pustules on leaves. Spread by wind and thrives in humid conditions with moderate temperatures.",
+            symptoms: [
+                "Orange, yellow, or reddish-brown pustules on leaf undersides",
+                "Corresponding yellow spots on upper leaf surfaces",
+                "Distorted or curled leaves",
+                "Premature leaf drop and weakened plants",
+            ],
+            treatments: [
+                "Remove and destroy infected leaves promptly",
+                "Apply sulfur-based fungicide or neem oil every 7-10 days",
+                "Avoid overhead watering to reduce humidity on foliage",
+                "Improve air circulation by pruning dense growth",
+            ],
+            prevention: [
+                "Select rust-resistant varieties",
+                "Space plants generously for airflow",
+                "Water early in the day at soil level",
+                "Clean up fallen leaves and debris each season",
+            ],
+            severity: .moderate
+        ),
+        PlantCondition(
+            label: "downy_mildew",
+            commonName: "Downy Mildew",
+            description: "An oomycete disease that thrives in cool, moist conditions. Produces grayish-purple fuzzy growth on leaf undersides.",
+            symptoms: [
+                "Angular yellow or pale green patches on upper leaf surfaces",
+                "Gray-purple fuzzy growth on corresponding lower surfaces",
+                "Leaves turn brown and crispy as lesions expand",
+                "Plant stunting and reduced yield",
+            ],
+            treatments: [
+                "Remove infected leaves and improve ventilation immediately",
+                "Apply phosphorous acid or copper-based fungicide",
+                "Reduce humidity around plants with wider spacing",
+                "Avoid working with plants when foliage is wet",
+            ],
+            prevention: [
+                "Choose resistant cultivars whenever possible",
+                "Provide morning sun exposure to dry dew quickly",
+                "Use drip irrigation instead of overhead sprinklers",
+                "Rotate crops on a 2-3 year cycle",
+            ],
+            severity: .moderate
+        ),
+        PlantCondition(
+            label: "black_spot",
+            commonName: "Black Spot",
+            description: "A fungal disease caused by Diplocarpon rosae, primarily affecting roses. Spreads through water splash and persists on fallen leaves.",
+            symptoms: [
+                "Round black spots with fringed margins on upper leaf surfaces",
+                "Yellowing tissue surrounding the spots",
+                "Progressive defoliation from the bottom up",
+                "Weakened plant with reduced flowering",
+            ],
+            treatments: [
+                "Prune and destroy all infected leaves and canes",
+                "Apply fungicide (myclobutanil or chlorothalonil) every 7-14 days",
+                "Clean up all fallen leaves around the base",
+                "Water at the root zone only",
+            ],
+            prevention: [
+                "Plant black-spot-resistant rose varieties",
+                "Ensure 3-4 feet spacing between rose bushes",
+                "Apply preventive fungicide in early spring",
+                "Mulch to prevent spore splash from soil",
+            ],
+            severity: .moderate
+        ),
+        PlantCondition(
+            label: "anthracnose",
+            commonName: "Anthracnose",
+            description: "A group of fungal diseases causing dark, sunken lesions on leaves, stems, and fruit. Favored by warm, wet weather.",
+            symptoms: [
+                "Dark, sunken, water-soaked lesions on leaves and stems",
+                "Tan to brown irregular dead areas along leaf veins",
+                "Curling and distortion of young leaves",
+                "Fruit with sunken spots and pink-orange spore masses",
+            ],
+            treatments: [
+                "Remove and destroy all affected plant parts",
+                "Apply copper fungicide or chlorothalonil at first sign",
+                "Avoid overhead irrigation during active infection",
+                "Prune to improve canopy airflow",
+            ],
+            prevention: [
+                "Use disease-free seed and resistant varieties",
+                "Practice crop rotation with non-susceptible plants",
+                "Remove plant debris at end of season",
+                "Avoid working with plants in wet conditions",
+            ],
+            severity: .moderate
+        ),
+        PlantCondition(
+            label: "fusarium_wilt",
+            commonName: "Fusarium Wilt",
+            description: "A soil-borne fungal disease caused by Fusarium oxysporum that blocks the plant's vascular system. Persists in soil for years.",
+            symptoms: [
+                "Wilting of one side of the plant or individual branches",
+                "Yellowing of lower leaves progressing upward",
+                "Brown discoloration inside stems when cut",
+                "Stunted growth and eventual plant death",
+            ],
+            treatments: [
+                "Remove and destroy infected plants — do not compost",
+                "Solarize soil with clear plastic for 4-6 weeks in summer",
+                "Apply beneficial Trichoderma fungi to soil as biocontrol",
+                "There is no chemical cure once a plant is infected",
+            ],
+            prevention: [
+                "Plant Fusarium-resistant varieties (look for 'F' on labels)",
+                "Maintain soil pH between 6.5-7.0",
+                "Practice long crop rotation (5+ years for susceptible crops)",
+                "Use raised beds with fresh soil if area is contaminated",
+            ],
+            severity: .severe
+        ),
+    ]
+
+    // MARK: - Pests
+
+    public static let pests: [PlantCondition] = [
+        PlantCondition(
+            label: "aphids",
+            commonName: "Aphids",
+            description: "Small, soft-bodied sap-sucking insects that cluster on new growth and leaf undersides. Reproduce rapidly and excrete sticky honeydew.",
+            symptoms: [
+                "Clusters of small green, black, or white insects on stems and leaf undersides",
+                "Curled, yellowed, or distorted new growth",
+                "Sticky honeydew residue on leaves and nearby surfaces",
+                "Black sooty mold growing on honeydew deposits",
+            ],
+            treatments: [
+                "Blast with a strong jet of water to dislodge aphids",
+                "Apply insecticidal soap or neem oil spray every 3-5 days",
+                "Release ladybugs or lacewings as biological control",
+                "For severe infestations, use pyrethrin-based insecticide",
+            ],
+            prevention: [
+                "Inspect new plants before introducing them to the garden",
+                "Encourage beneficial insects with companion planting",
+                "Avoid over-fertilizing with nitrogen (promotes tender growth)",
+                "Use reflective mulch to disorient flying aphids",
+            ],
+            severity: .mild
+        ),
+        PlantCondition(
+            label: "spider_mites",
+            commonName: "Spider Mites",
+            description: "Tiny arachnids (not insects) that pierce plant cells and suck out contents. Thrive in hot, dry conditions and are often found on leaf undersides.",
+            symptoms: [
+                "Fine stippling or speckling on upper leaf surfaces",
+                "Tiny white or yellow dots visible with magnification",
+                "Fine webbing between leaves and stems in heavy infestations",
+                "Leaves turning bronze, brown, and dropping prematurely",
+            ],
+            treatments: [
+                "Spray plants thoroughly with water, focusing on leaf undersides",
+                "Apply miticide or horticultural oil every 5-7 days for 3 cycles",
+                "Introduce predatory mites (Phytoseiulus persimilis) for biocontrol",
+                "Increase humidity around affected plants",
+            ],
+            prevention: [
+                "Mist plants regularly in hot, dry weather",
+                "Keep plants well-watered — drought-stressed plants are more vulnerable",
+                "Inspect leaf undersides weekly with a hand lens",
+                "Quarantine new plants for 2 weeks before placement",
+            ],
+            severity: .moderate
+        ),
+        PlantCondition(
+            label: "whiteflies",
+            commonName: "Whiteflies",
+            description: "Small, white-winged insects that feed on plant sap from leaf undersides. Fly up in a cloud when the plant is disturbed.",
+            symptoms: [
+                "Tiny white moths flying up when plant is touched",
+                "Yellowing and wilting of leaves",
+                "Sticky honeydew and sooty mold on leaf surfaces",
+                "Reduced plant vigor and stunted growth",
+            ],
+            treatments: [
+                "Use yellow sticky traps to capture adult whiteflies",
+                "Apply insecticidal soap or neem oil to leaf undersides",
+                "Introduce Encarsia formosa parasitic wasps for biocontrol",
+                "Vacuum adults off plants in early morning when sluggish",
+            ],
+            prevention: [
+                "Inspect transplants carefully before purchase",
+                "Remove weeds that can harbor whitefly populations",
+                "Use reflective aluminum mulch to repel adults",
+                "Avoid broad-spectrum insecticides that kill beneficial predators",
+            ],
+            severity: .mild
+        ),
+        PlantCondition(
+            label: "mealybugs",
+            commonName: "Mealybugs",
+            description: "Soft-bodied, waxy-coated insects that form cottony masses on stems and leaf axils. Suck plant sap and excrete honeydew.",
+            symptoms: [
+                "White, cottony masses in leaf axils, stem joints, and under leaves",
+                "Sticky honeydew and black sooty mold",
+                "Yellowing, wilting, and leaf drop",
+                "Stunted or distorted new growth",
+            ],
+            treatments: [
+                "Dab individual mealybugs with a cotton swab soaked in rubbing alcohol",
+                "Spray with insecticidal soap or neem oil, covering all crevices",
+                "Release Cryptolaemus (mealybug destroyer) beetles for biocontrol",
+                "For severe cases, apply systemic insecticide as a soil drench",
+            ],
+            prevention: [
+                "Quarantine new plants for at least 2 weeks",
+                "Inspect plants regularly, especially hidden crevices",
+                "Avoid overwatering and overfertilizing",
+                "Wipe leaves with a damp cloth monthly to detect early infestations",
+            ],
+            severity: .moderate
+        ),
+        PlantCondition(
+            label: "scale_insects",
+            commonName: "Scale Insects",
+            description: "Immobile, shell-covered insects that attach to stems and leaves to feed on sap. Hard to detect due to their camouflaged appearance.",
+            symptoms: [
+                "Small, brown or tan bumps on stems and leaf veins",
+                "Sticky honeydew on leaves and surfaces below the plant",
+                "Yellowing leaves and branch dieback",
+                "Slow decline in overall plant health",
+            ],
+            treatments: [
+                "Scrape off visible scale with a soft brush or fingernail",
+                "Apply horticultural oil spray to suffocate crawlers and adults",
+                "Use systemic imidacloprid as a soil drench for heavy infestations",
+                "Prune and discard heavily infested branches",
+            ],
+            prevention: [
+                "Inspect plants thoroughly before purchase",
+                "Encourage natural predators like parasitic wasps and ladybugs",
+                "Avoid over-fertilizing which promotes succulent growth",
+                "Monitor plants monthly, especially woody stems and leaf undersides",
+            ],
+            severity: .moderate
+        ),
+    ]
+
+    // MARK: - Nutrient Deficiencies
+
+    public static let deficiencies: [PlantCondition] = [
+        PlantCondition(
+            label: "nitrogen_deficiency",
+            commonName: "Nitrogen Deficiency",
+            description: "A macronutrient deficiency that impairs chlorophyll production and protein synthesis. Most common nutrient deficiency in plants.",
+            symptoms: [
+                "Uniform yellowing (chlorosis) of older, lower leaves first",
+                "Stunted, spindly growth with thin stems",
+                "Reduced leaf size and pale green color overall",
+                "Premature leaf drop starting from the bottom",
+            ],
+            treatments: [
+                "Apply balanced liquid fertilizer (e.g., 10-10-10) at half strength",
+                "Side-dress with composted manure or blood meal",
+                "Foliar spray with dilute fish emulsion for quick uptake",
+                "Add organic compost to improve long-term soil nitrogen",
+            ],
+            prevention: [
+                "Test soil annually and amend before planting",
+                "Incorporate nitrogen-fixing cover crops (clover, legumes)",
+                "Mulch with compost to slowly release nutrients",
+                "Avoid leaching by watering deeply but less frequently",
+            ],
+            severity: .moderate
+        ),
+        PlantCondition(
+            label: "iron_chlorosis",
+            commonName: "Iron Chlorosis",
+            description: "An iron deficiency causing interveinal chlorosis, most common in alkaline soils where iron becomes unavailable despite being present.",
+            symptoms: [
+                "Yellow leaves with distinctly green veins (interveinal chlorosis)",
+                "New growth affected first, unlike nitrogen deficiency",
+                "Leaf edges may turn brown and crispy in severe cases",
+                "Stunted growth and reduced flowering or fruiting",
+            ],
+            treatments: [
+                "Apply chelated iron (Fe-EDDHA) as a soil drench",
+                "Foliar spray with ferrous sulfate solution for quick relief",
+                "Lower soil pH with sulfur or acidifying fertilizer",
+                "Add iron sulfate granules around the root zone",
+            ],
+            prevention: [
+                "Test soil pH and maintain between 5.5-6.5 for susceptible plants",
+                "Use acidifying mulches like pine needles or oak leaves",
+                "Choose iron-efficient plant varieties for alkaline soils",
+                "Avoid overwatering which can reduce iron availability",
+            ],
+            severity: .mild
+        ),
+        PlantCondition(
+            label: "potassium_deficiency",
+            commonName: "Potassium Deficiency",
+            description: "A macronutrient deficiency affecting water regulation, disease resistance, and fruit quality. Common in sandy or heavily cropped soils.",
+            symptoms: [
+                "Brown scorching and curling of leaf edges (marginal necrosis)",
+                "Older leaves affected first, progressing inward",
+                "Weak stems prone to lodging",
+                "Poor fruit development and reduced disease resistance",
+            ],
+            treatments: [
+                "Apply potassium sulfate (sulfate of potash) as a side dress",
+                "Use wood ash sparingly as an organic potassium source",
+                "Apply liquid seaweed extract as a foliar feed",
+                "Incorporate greensand into the soil for slow release",
+            ],
+            prevention: [
+                "Maintain adequate potassium with annual soil testing",
+                "Add compost regularly to improve nutrient retention",
+                "Avoid excessive calcium or magnesium which compete with potassium",
+                "Mulch to reduce nutrient leaching in sandy soils",
+            ],
+            severity: .moderate
+        ),
+    ]
+}

--- a/GrowWisePackage/Tests/GrowWiseServicesTests/PlantDiagnosticServiceTests.swift
+++ b/GrowWisePackage/Tests/GrowWiseServicesTests/PlantDiagnosticServiceTests.swift
@@ -1,5 +1,5 @@
-import XCTest
 @testable import GrowWiseServices
+import XCTest
 
 final class PlantDiagnosticServiceTests: XCTestCase {
     @MainActor
@@ -7,7 +7,7 @@ final class PlantDiagnosticServiceTests: XCTestCase {
         let service = PlantDiagnosticService()
         let diagnosis = service.summarize([
             PlantClassificationCandidate(label: "healthy_leaf", confidence: 0.93),
-            PlantClassificationCandidate(label: "leaf_spot", confidence: 0.24)
+            PlantClassificationCandidate(label: "leaf_spot", confidence: 0.24),
         ])
 
         XCTAssertEqual(diagnosis.primaryLabel, "healthy_leaf")
@@ -20,11 +20,14 @@ final class PlantDiagnosticServiceTests: XCTestCase {
         let service = PlantDiagnosticService()
         let diagnosis = service.summarize([
             PlantClassificationCandidate(label: "powdery_mildew", confidence: 0.89),
-            PlantClassificationCandidate(label: "leaf_rust", confidence: 0.33)
+            PlantClassificationCandidate(label: "leaf_rust", confidence: 0.33),
         ])
 
-        XCTAssertEqual(diagnosis.severity, .severe)
+        // powdery_mildew is in the knowledge base with .moderate severity
+        XCTAssertEqual(diagnosis.severity, .moderate)
         XCTAssertEqual(diagnosis.alternatives.count, 1)
+        XCTAssertNotNil(diagnosis.condition)
+        XCTAssertEqual(diagnosis.condition?.commonName, "Powdery Mildew")
     }
 
     @MainActor


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Link to the beads issue: `bd show GW-XXX` -->

Closes: <!-- GW-XXX -->

## Changes

<!-- List the key changes made -->

- 

## Testing Done

<!-- How was this tested? Check all that apply -->

- [ ] `cd GrowWisePackage && swift test` passes
- [ ] Manually tested on iOS Simulator (specify version/device)
- [ ] SwiftLint passes: `swiftlint lint --config .swiftlint.yml`
- [ ] SwiftFormat passes: `swiftformat --lint --config .swiftformat GrowWisePackage/Sources GrowWise`

## Architecture Impact

<!-- Does this change the data model, service interfaces, or concurrency model? -->

- [ ] No architectural changes
- [ ] SwiftData model changes (CloudKit-compatible?)
- [ ] New service or service interface change
- [ ] Concurrency model change (`@MainActor`, Actor, async/await)
- [ ] Security-sensitive change (Keychain, encryption, auth)

## Checklist

- [ ] Code follows MV architecture (no ViewModels)
- [ ] No `as!` force casts or force unwraps (`!`)
- [ ] No `try?` silencing errors in views
- [ ] All `@Model` properties are optional or have defaults (CloudKit compatibility)
- [ ] New UI elements have `.accessibilityIdentifier()`
- [ ] No print statements (use Logger/OSLog)
- [ ] TODO/FIXME comments include beads issue reference (e.g., `TODO(GW-123): ...`)

## Screenshots / Recording

<!-- For UI changes, include before/after screenshots or a screen recording -->
