### PR TITLE
feat(redesign): v2 — Cultivation redesign (Phases 1–10)

### DIFF
--- a/GrowWise.xcodeproj/project.pbxproj
+++ b/GrowWise.xcodeproj/project.pbxproj
@@ -398,8 +398,8 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = GrowWise/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = GrowWise;
-				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "GrowWise uses your location to provide personalized gardening advice, weather updates, and determine your plant hardiness zone.";
+				INFOPLIST_KEY_CFBundleDisplayName = Cultivation;
+				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "Cultivation uses your location to provide personalized gardening advice, weather updates, and determine your plant hardiness zone.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -431,8 +431,8 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = GrowWise/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = GrowWise;
-				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "GrowWise uses your location to provide personalized gardening advice, weather updates, and determine your plant hardiness zone.";
+				INFOPLIST_KEY_CFBundleDisplayName = Cultivation;
+				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "Cultivation uses your location to provide personalized gardening advice, weather updates, and determine your plant hardiness zone.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;

--- a/GrowWise/Data/README.md
+++ b/GrowWise/Data/README.md
@@ -1,8 +1,8 @@
-# GrowWise Core Data Architecture
+# Cultivation Core Data Architecture
 
 ## Overview
 
-The GrowWise iOS app uses a comprehensive Core Data model with CloudKit synchronization to provide a robust gardening management system. This architecture supports user profiles, plant databases, garden management, smart reminders, and plant journaling.
+The Cultivation iOS app uses a comprehensive Core Data model with CloudKit synchronization to provide a robust gardening management system. This architecture supports user profiles, plant databases, garden management, smart reminders, and plant journaling.
 
 ## Entity Relationship Diagram
 
@@ -171,4 +171,4 @@ The Core Data model is designed with future extensibility in mind:
 - Local Core Data encryption via iOS data protection
 - User consent required for CloudKit features
 
-This architecture provides a solid foundation for the GrowWise gardening app, supporting both offline usage and seamless cloud synchronization across devices.
+This architecture provides a solid foundation for the Cultivation gardening app, supporting both offline usage and seamless cloud synchronization across devices.

--- a/GrowWisePackage/Sources/GrowWiseFeature/Design/GardenComponents.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Design/GardenComponents.swift
@@ -84,11 +84,11 @@ struct PlantRow: View {
             // Name + care subtitle
             VStack(alignment: .leading, spacing: 2) {
                 Text(plant.name ?? "Unnamed Plant")
-                    .font(.system(.body, weight: .semibold))
+                    .font(CultivationTheme.Fonts.display(17, weight: .medium))
                     .foregroundStyle(CultivationTheme.Colors.textPrimary)
 
                 Text(careSubtitle)
-                    .font(.system(.caption))
+                    .font(CultivationTheme.Fonts.body(13).italic())
                     .foregroundStyle(CultivationTheme.Colors.textSecondary)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -138,7 +138,7 @@ struct PlantRow: View {
                     .fill(CultivationTheme.Colors.statusAlert.opacity(0.04))
             }
         }
-        .glassCard()
+        .paperCard()
         .accessibilityIdentifier("garden_row_plant_\(plantID)")
     }
 }
@@ -164,7 +164,7 @@ struct BedGroupHeader: View {
 
             VStack(alignment: .leading, spacing: 1) {
                 Text(name)
-                    .font(.system(.subheadline, weight: .semibold))
+                    .font(CultivationTheme.Fonts.display(15, weight: .medium))
                     .foregroundStyle(CultivationTheme.Colors.textPrimary)
 
                 Text(subtitle)
@@ -222,7 +222,7 @@ struct CompanionTipCard: View {
             )
 
             Text(tip)
-                .font(.system(.caption))
+                .font(CultivationTheme.Fonts.body(13).italic())
                 .foregroundStyle(CultivationTheme.Colors.textSecondary)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .fixedSize(horizontal: false, vertical: true)
@@ -230,15 +230,14 @@ struct CompanionTipCard: View {
         .padding(CultivationTheme.Spacing.cardPadding)
         .background {
             RoundedRectangle(cornerRadius: CultivationTheme.Radius.card)
-                .fill(CultivationTheme.Colors.brandLeaf.opacity(0.06))
-                .background(
-                    RoundedRectangle(cornerRadius: CultivationTheme.Radius.card)
-                        .fill(.ultraThinMaterial)
-                )
+                .fill(CultivationTheme.Colors.backgroundSecondary)
         }
         .overlay {
             RoundedRectangle(cornerRadius: CultivationTheme.Radius.card)
-                .stroke(CultivationTheme.Colors.brandLeaf.opacity(0.15), lineWidth: 1)
+                .stroke(
+                    CultivationTheme.Colors.brandLeaf.opacity(0.4),
+                    style: StrokeStyle(lineWidth: 1, dash: [4, 3])
+                )
         }
         .clipShape(RoundedRectangle(cornerRadius: CultivationTheme.Radius.card))
     }
@@ -272,12 +271,12 @@ struct TaskRow: View {
 
             VStack(alignment: .leading, spacing: 2) {
                 Text(description)
-                    .font(.system(.subheadline, weight: .semibold))
+                    .font(CultivationTheme.Fonts.body(14, weight: .semibold))
                     .foregroundStyle(CultivationTheme.Colors.textPrimary)
 
                 if let locationLabel {
                     Text(locationLabel)
-                        .font(.system(.caption))
+                        .font(CultivationTheme.Fonts.body(12))
                         .foregroundStyle(CultivationTheme.Colors.textSecondary)
                 }
             }
@@ -330,7 +329,7 @@ struct TaskRow: View {
             }
         }
         .padding(CultivationTheme.Spacing.cardPadding)
-        .glassCard()
+        .paperCard()
         .accessibilityIdentifier("home_row_task_\(taskID.uuidString)")
     }
 }

--- a/GrowWisePackage/Sources/GrowWiseFeature/Design/GardenComponents.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Design/GardenComponents.swift
@@ -357,12 +357,15 @@ extension TaskRow {
         case .watering:
             self.quickActionIcon = "drop.fill"
             self.quickActionColor = .blue
+
         case .fertilizing:
             self.quickActionIcon = "leaf.fill"
             self.quickActionColor = CultivationTheme.Colors.brandLeaf
+
         case .pruning:
             self.quickActionIcon = "scissors"
             self.quickActionColor = .orange
+
         default:
             self.quickActionIcon = "checkmark.circle.fill"
             self.quickActionColor = CultivationTheme.Colors.textTertiary

--- a/GrowWisePackage/Sources/GrowWiseFeature/Design/GardenComponents.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Design/GardenComponents.swift
@@ -168,7 +168,7 @@ struct BedGroupHeader: View {
                     .foregroundStyle(CultivationTheme.Colors.textPrimary)
 
                 Text(subtitle)
-                    .font(.system(.caption))
+                    .font(CultivationTheme.Fonts.body(12))
                     .foregroundStyle(CultivationTheme.Colors.textSecondary)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -303,6 +303,11 @@ struct TaskRow: View {
                 // Outline complete button for normal tasks
                 Button {
                     onComplete?()
+                    showCheckmark = true
+                    Task<Void, Never> {
+                        try? await Task.sleep(for: .seconds(1.5))
+                        showCheckmark = false
+                    }
                 } label: {
                     Text("Done")
                         .font(.system(size: 13, weight: .semibold))

--- a/GrowWisePackage/Sources/GrowWiseFeature/Design/ViewModifiers.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Design/ViewModifiers.swift
@@ -138,6 +138,28 @@ struct CoralButtonStyle: ButtonStyle {
     }
 }
 
+// MARK: - Secondary Button Style
+
+/// Outlined secondary action button — cream surface with border.
+struct SecondaryButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .font(CultivationTheme.Fonts.body(16, weight: .semibold))
+            .foregroundStyle(CultivationTheme.Colors.textPrimary)
+            .frame(maxWidth: .infinity, minHeight: 52)
+            .background(
+                RoundedRectangle(cornerRadius: CultivationTheme.Radius.card)
+                    .fill(CultivationTheme.Colors.cardSurface)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: CultivationTheme.Radius.card)
+                    .stroke(CultivationTheme.Colors.cardBorder, lineWidth: 1)
+            )
+            .scaleEffect(configuration.isPressed ? 0.97 : 1.0)
+            .animation(CultivationTheme.Animation.card, value: configuration.isPressed)
+    }
+}
+
 // MARK: - Smart Tag
 
 /// Sage '✦' chip marking smart-enrichment surfaces (auto-ID, weather, zone).

--- a/GrowWisePackage/Sources/GrowWiseFeature/Main/MainAppView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Main/MainAppView.swift
@@ -122,7 +122,7 @@ public struct MainAppView: View {
                 .accessibilityIdentifier("tab_garden")
 
             NavigationStack {
-                GardenClubFeedView()
+                GardenClubTabContainer()
             }
             .tabItem {
                 Label("Club", systemImage: "sparkles")
@@ -239,6 +239,68 @@ public enum TabSelection: String, CaseIterable {
     case garden
     case club
     case profile
+}
+
+// MARK: - Club tab routing
+
+/// Routes the Club tab to the right surface based on the user's club membership.
+/// Zero clubs -> join/create prompt, one -> feed, many -> list. See ADR-019.
+private struct GardenClubTabContainer: View {
+    @Environment(DataService.self) private var dataService
+    @State private var clubs: [GardenClub] = []
+
+    var body: some View {
+        Group {
+            switch GardenClubTabRoute.resolve(clubs: clubs) {
+            case .joinOrCreate:
+                GardenClubJoinOrCreatePrompt()
+            case .feed(let club):
+                GardenClubFeedView(club: club)
+            case .list:
+                ClubListView()
+            }
+        }
+        .task {
+            do {
+                clubs = try dataService.fetchClubs()
+            } catch {
+                logger.error("Failed to fetch clubs for tab routing: \(error.localizedDescription, privacy: .public)")
+                clubs = []
+            }
+        }
+        .accessibilityIdentifier("club_tab_container")
+    }
+}
+
+/// Zero-club landing state. Offers join-by-invite-code or create-a-club
+/// entry points via the existing sheets.
+private struct GardenClubJoinOrCreatePrompt: View {
+    @State private var isJoining = false
+    @State private var isCreating = false
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Text("Join a club or start one")
+                .font(CultivationTheme.Fonts.display(22, weight: .medium))
+                .foregroundStyle(CultivationTheme.Colors.textPrimary)
+                .multilineTextAlignment(.center)
+            Text("Share what's growing with people nearby.")
+                .font(CultivationTheme.Fonts.body(14))
+                .foregroundStyle(CultivationTheme.Colors.textSecondary)
+                .multilineTextAlignment(.center)
+            Button("Join a club") { isJoining = true }
+                .buttonStyle(GradientButtonStyle())
+                .accessibilityIdentifier("club_button_join")
+            Button("Create a club") { isCreating = true }
+                .buttonStyle(CoralButtonStyle())
+                .accessibilityIdentifier("club_button_create")
+        }
+        .padding(CultivationTheme.Spacing.screenPadding)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(CultivationTheme.Colors.background.ignoresSafeArea())
+        .sheet(isPresented: $isJoining) { JoinClubSheet() }
+        .sheet(isPresented: $isCreating) { CreateClubSheet() }
+    }
 }
 
 #Preview {

--- a/GrowWisePackage/Sources/GrowWiseFeature/Main/MainAppView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Main/MainAppView.swift
@@ -246,7 +246,8 @@ public enum TabSelection: String, CaseIterable {
 /// Routes the Club tab to the right surface based on the user's club membership.
 /// Zero clubs -> join/create prompt, one -> feed, many -> list. See ADR-019.
 private struct GardenClubTabContainer: View {
-    @Environment(DataService.self) private var dataService
+    @Environment(DataService.self)
+    private var dataService
     @State private var clubs: [GardenClub] = []
 
     var body: some View {
@@ -254,8 +255,10 @@ private struct GardenClubTabContainer: View {
             switch GardenClubTabRoute.resolve(clubs: clubs) {
             case .joinOrCreate:
                 GardenClubJoinOrCreatePrompt()
+
             case .feed(let club):
                 GardenClubFeedView(club: club)
+
             case .list:
                 ClubListView()
             }

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/Garden/GardenViewModel.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/Garden/GardenViewModel.swift
@@ -108,6 +108,39 @@ public final class GardenViewModel {
             })
     }
 
+    /// Returns `groupedPlants` filtered by the given `GardenFilter`.
+    /// Empty groups are dropped.
+    public func filtered(by filter: GardenView.GardenFilter) -> [PlantGroup] {
+        let base = groupedPlants
+        switch filter {
+        case .all:
+            return base
+        case .needsCare:
+            let now = Date()
+            return base.compactMap { group in
+                let matching = group.plants.filter { plant in
+                    (plant.reminders ?? []).contains { $0.isEnabled && $0.nextDueDate < now }
+                }
+                return matching.isEmpty ? nil : PlantGroup(id: group.id, bed: group.bed, plants: matching)
+            }
+        case .blooming:
+            return base.compactMap { group in
+                let matching = group.plants.filter { ($0.growthStage ?? .seedling) == .flowering }
+                return matching.isEmpty ? nil : PlantGroup(id: group.id, bed: group.bed, plants: matching)
+            }
+        case .edible:
+            return base.compactMap { group in
+                let matching = group.plants.filter { $0.plantType == .vegetable || $0.plantType == .fruit }
+                return matching.isEmpty ? nil : PlantGroup(id: group.id, bed: group.bed, plants: matching)
+            }
+        case .herbs:
+            return base.compactMap { group in
+                let matching = group.plants.filter { $0.plantType == .herb }
+                return matching.isEmpty ? nil : PlantGroup(id: group.id, bed: group.bed, plants: matching)
+            }
+        }
+    }
+
     /// Total plants across all gardens.
     public var totalPlantsAllGardens: Int {
         gardenSummaries.reduce(0) { $0 + $1.plantCount }

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/Garden/GardenViewModel.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/Garden/GardenViewModel.swift
@@ -110,7 +110,7 @@ public final class GardenViewModel {
 
     /// Returns `groupedPlants` filtered by the given `GardenFilter`.
     /// Empty groups are dropped.
-    public func filtered(by filter: GardenView.GardenFilter) -> [PlantGroup] {
+    public func filtered(by filter: GardenFilter) -> [PlantGroup] {
         let base = groupedPlants
         switch filter {
         case .all:

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/Garden/GardenViewModel.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/Garden/GardenViewModel.swift
@@ -115,6 +115,7 @@ public final class GardenViewModel {
         switch filter {
         case .all:
             return base
+
         case .needsCare:
             let now = Date()
             return base.compactMap { group in
@@ -123,16 +124,19 @@ public final class GardenViewModel {
                 }
                 return matching.isEmpty ? nil : PlantGroup(id: group.id, bed: group.bed, plants: matching)
             }
+
         case .blooming:
             return base.compactMap { group in
                 let matching = group.plants.filter { ($0.growthStage ?? .seedling) == .flowering }
                 return matching.isEmpty ? nil : PlantGroup(id: group.id, bed: group.bed, plants: matching)
             }
+
         case .edible:
             return base.compactMap { group in
                 let matching = group.plants.filter { $0.plantType == .vegetable || $0.plantType == .fruit }
                 return matching.isEmpty ? nil : PlantGroup(id: group.id, bed: group.bed, plants: matching)
             }
+
         case .herbs:
             return base.compactMap { group in
                 let matching = group.plants.filter { $0.plantType == .herb }

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/GardenClub/GardenClubFeedView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/GardenClub/GardenClubFeedView.swift
@@ -397,8 +397,12 @@ private struct PostCard: View {
                 .frame(height: 120)
 
             HStack(spacing: 16) {
-                Label("\(post.likeCount)", systemImage: "heart")
-                Label("\(post.commentCount)", systemImage: "bubble.right")
+                if post.likeCount > 0 {
+                    Label("\(post.likeCount)", systemImage: "heart")
+                }
+                if post.commentCount > 0 {
+                    Label("\(post.commentCount)", systemImage: "bubble.right")
+                }
                 Label("Share", systemImage: "arrow.up.right")
             }
             .font(CultivationTheme.Fonts.body(11, weight: .semibold))

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/GardenClub/GardenClubFeedView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/GardenClub/GardenClubFeedView.swift
@@ -12,8 +12,10 @@ private let logger = Logger(subsystem: "com.growwise", category: "GardenClubFeed
 ///
 /// See ADR-019 and the v2 mockup at docs/mockups/cultivation-simplified-wireflow.html.
 public struct GardenClubFeedView: View {
-    @Environment(DataService.self) private var dataService
-    @Environment(LocationService.self) private var locationService
+    @Environment(DataService.self)
+    private var dataService
+    @Environment(LocationService.self)
+    private var locationService
 
     @State private var selectedSegment: FeedSegment = .club
     @State private var posts: [ClubActivityViewData] = []
@@ -189,8 +191,7 @@ public struct GardenClubFeedView: View {
 
     // MARK: - Feed body
 
-    @ViewBuilder
-    private var feed: some View {
+    @ViewBuilder private var feed: some View {
         switch selectedSegment {
         case .club:
             if posts.isEmpty {
@@ -198,9 +199,11 @@ public struct GardenClubFeedView: View {
             } else {
                 clubFeed
             }
+
         case .nearby:
             // Per spec Open questions resolution: empty-state copy, not sample data.
             emptyState(message: "No posts in your zone yet.")
+
         case .following:
             // Per spec Open questions resolution: empty-state copy, not sample data.
             emptyState(message: "Follow someone to see their posts.")
@@ -353,7 +356,8 @@ private struct PostCard: View {
                 Circle()
                     .fill(LinearGradient(
                         colors: [CultivationTheme.Colors.brandMint, CultivationTheme.Colors.brandLeaf],
-                        startPoint: .topLeading, endPoint: .bottomTrailing
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
                     ))
                     .frame(width: 32, height: 32)
                     .overlay(
@@ -392,7 +396,8 @@ private struct PostCard: View {
             RoundedRectangle(cornerRadius: 12)
                 .fill(LinearGradient(
                     colors: [CultivationTheme.Colors.brandLeaf, CultivationTheme.Colors.brandForest],
-                    startPoint: .topLeading, endPoint: .bottomTrailing
+                    startPoint: .topLeading,
+                    endPoint: .bottomTrailing
                 ))
                 .frame(height: 120)
 

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/GardenClub/GardenClubFeedView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/GardenClub/GardenClubFeedView.swift
@@ -1,25 +1,415 @@
+import GrowWiseModels
+import GrowWiseServices
+import os
+import SwiftData
 import SwiftUI
 
-/// Tab-3 entry point for Garden Club. Stubbed in Phase 3 so MainAppView compiles;
-/// real implementation lands in Phase 5.
+private let logger = Logger(subsystem: "com.growwise", category: "GardenClubFeedView")
+
+/// Tab-3 entry point for Garden Club. Top-of-screen share prompt, segmented
+/// feed (Club / Nearby / Following), and post cards. The "smart match" card
+/// surfaces when nearby growers are tracking the same plant species as the user.
+///
+/// See ADR-019 and the v2 mockup at docs/mockups/cultivation-simplified-wireflow.html.
 public struct GardenClubFeedView: View {
-    public init() {}
+    @Environment(DataService.self) private var dataService
+    @Environment(LocationService.self) private var locationService
+
+    @State private var selectedSegment: FeedSegment = .club
+    @State private var posts: [ClubActivityViewData] = []
+    @State private var smartMatch: SmartMatchSuggestion?
+    @State private var clubName: String = "Garden Club"
+    @State private var memberCount: Int = 0
+    @State private var userInitial: String = "?"
+    @State private var isPresentingComposer = false
+
+    private let club: GardenClub?
+
+    public init(club: GardenClub? = nil) {
+        self.club = club
+    }
+
+    enum FeedSegment: String, CaseIterable, Identifiable {
+        case club = "Club feed"
+        case nearby = "Nearby"
+        case following = "Following"
+        var id: String {
+            rawValue
+        }
+    }
+
+    struct SmartMatchSuggestion {
+        let count: Int
+        let zone: String
+        let plantName: String
+    }
+
+    /// Presentation-only adapter for ClubActivity. Maps the SwiftData model's
+    /// fields onto the surface the post card consumes. Allowed under strict MV —
+    /// view-local presentation types are fine; a separate ViewModel class is not.
+    /// Per the 2026-04-22 plan Phase 5 Adapter note.
+    struct ClubActivityViewData: Identifiable {
+        let id: UUID
+        let authorDisplayName: String
+        let caption: String?
+        let zoneTag: String?
+        let relativeTimeLabel: String?
+        let likeCount: Int
+        let commentCount: Int
+    }
 
     public var body: some View {
         ZStack {
             CultivationTheme.Colors.background.ignoresSafeArea()
-            VStack(spacing: 12) {
-                Text("Club feed")
-                    .font(CultivationTheme.Fonts.display(22, weight: .medium))
-                    .foregroundStyle(CultivationTheme.Colors.textPrimary)
-                Text("Coming next in Phase 5")
-                    .font(CultivationTheme.Fonts.body(14))
-                    .foregroundStyle(CultivationTheme.Colors.textSecondary)
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: CultivationTheme.Spacing.sectionGap) {
+                    header
+                    sharePrompt
+                    segmentControl
+                    feed
+                }
+                .padding(.horizontal, CultivationTheme.Spacing.screenPadding)
+                .padding(.top, 12)
+                .padding(.bottom, 40)
             }
         }
         #if os(iOS)
-        .navigationBarTitleDisplayMode(.inline)
+        .navigationBarHidden(true)
         #endif
-        .accessibilityIdentifier("club_feed_placeholder")
+        .task { await load() }
+        .sheet(isPresented: $isPresentingComposer) {
+            // Share composer — real composer wiring is a follow-up issue.
+            // First cut: placeholder so the prompt is reachable.
+            Text("Share composer placeholder")
+                .padding()
+        }
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        HStack(alignment: .bottom) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Your club")
+                    .font(CultivationTheme.Fonts.body(11, weight: .semibold))
+                    .tracking(1.6)
+                    .textCase(.uppercase)
+                    .foregroundStyle(CultivationTheme.Colors.textTertiary)
+                Text(clubName)
+                    .font(CultivationTheme.Fonts.display(28, weight: .medium))
+                    .foregroundStyle(CultivationTheme.Colors.textPrimary)
+            }
+            Spacer()
+            VStack(alignment: .trailing, spacing: 0) {
+                Text("\(memberCount)")
+                    .font(CultivationTheme.Fonts.display(20, weight: .semibold))
+                    .foregroundStyle(CultivationTheme.Colors.textPrimary)
+                Text("members")
+                    .font(CultivationTheme.Fonts.body(11))
+                    .foregroundStyle(CultivationTheme.Colors.textTertiary)
+            }
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityIdentifier("club_header")
+    }
+
+    // MARK: - Share prompt (coral CTA)
+
+    private var sharePrompt: some View {
+        Button { isPresentingComposer = true } label: {
+            HStack(spacing: 12) {
+                Circle()
+                    .fill(Color.white.opacity(0.25))
+                    .frame(width: 36, height: 36)
+                    .overlay(
+                        Text(userInitial)
+                            .font(CultivationTheme.Fonts.display(14, weight: .semibold))
+                            .foregroundStyle(.white)
+                    )
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Share what's growing")
+                        .font(CultivationTheme.Fonts.body(13))
+                        .foregroundStyle(.white)
+                    Text("Tap to add a photo")
+                        .font(CultivationTheme.Fonts.body(11))
+                        .foregroundStyle(.white.opacity(0.85))
+                }
+                Spacer()
+                Image(systemName: "camera.fill")
+                    .font(.system(size: 18, weight: .semibold))
+                    .foregroundStyle(CultivationTheme.Colors.accentCoral)
+                    .frame(width: 36, height: 36)
+                    .background(Circle().fill(.white))
+            }
+            .padding(14)
+            .background(
+                RoundedRectangle(cornerRadius: CultivationTheme.Radius.card)
+                    .fill(CultivationTheme.Colors.accentCoral)
+                    .shadow(color: CultivationTheme.Colors.accentCoral.opacity(0.35), radius: 14, y: 8)
+            )
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier("club_share_prompt")
+        .accessibilityLabel("Share what's growing")
+    }
+
+    // MARK: - Segmented control
+
+    private var segmentControl: some View {
+        HStack(spacing: 18) {
+            ForEach(FeedSegment.allCases) { segment in
+                Button {
+                    selectedSegment = segment
+                } label: {
+                    VStack(spacing: 6) {
+                        Text(segment.rawValue)
+                            .font(CultivationTheme.Fonts.body(13, weight: selectedSegment == segment ? .semibold : .medium))
+                            .foregroundStyle(
+                                selectedSegment == segment
+                                    ? CultivationTheme.Colors.textPrimary
+                                    : CultivationTheme.Colors.textTertiary
+                            )
+                        Rectangle()
+                            .fill(selectedSegment == segment ? CultivationTheme.Colors.accentCoral : .clear)
+                            .frame(height: 2)
+                    }
+                }
+                .buttonStyle(.plain)
+                .accessibilityIdentifier("club_segment_\(segment.rawValue.lowercased().replacingOccurrences(of: " ", with: "_"))")
+            }
+            Spacer()
+        }
+        .overlay(alignment: .bottom) {
+            Rectangle()
+                .fill(CultivationTheme.Colors.divider)
+                .frame(height: 1)
+        }
+    }
+
+    // MARK: - Feed body
+
+    @ViewBuilder
+    private var feed: some View {
+        switch selectedSegment {
+        case .club:
+            if posts.isEmpty {
+                emptyState(message: "Be the first to share what's growing.")
+            } else {
+                clubFeed
+            }
+        case .nearby:
+            // Per spec Open questions resolution: empty-state copy, not sample data.
+            emptyState(message: "No posts in your zone yet.")
+        case .following:
+            // Per spec Open questions resolution: empty-state copy, not sample data.
+            emptyState(message: "Follow someone to see their posts.")
+        }
+    }
+
+    private var clubFeed: some View {
+        VStack(spacing: 14) {
+            ForEach(Array(posts.enumerated()), id: \.element.id) { index, post in
+                if index == 1, let match = smartMatch {
+                    smartMatchCard(match)
+                }
+                PostCard(post: post)
+            }
+            if posts.count < 2, let match = smartMatch {
+                smartMatchCard(match)
+            }
+        }
+    }
+
+    private func emptyState(message: String) -> some View {
+        VStack(spacing: 12) {
+            Text("No posts yet")
+                .font(CultivationTheme.Fonts.display(18, weight: .medium))
+                .foregroundStyle(CultivationTheme.Colors.textPrimary)
+            Text(message)
+                .font(CultivationTheme.Fonts.body(14))
+                .foregroundStyle(CultivationTheme.Colors.textSecondary)
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 60)
+        .accessibilityIdentifier("club_empty_state")
+    }
+
+    private func smartMatchCard(_ match: SmartMatchSuggestion) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 5) {
+                Text("\u{2726}")
+                Text("Smart match \u{00B7} \(match.count) nearby growers")
+            }
+            .font(CultivationTheme.Fonts.body(10, weight: .bold))
+            .tracking(1.4)
+            .textCase(.uppercase)
+            .foregroundStyle(CultivationTheme.Colors.smartTagForeground)
+
+            (
+                Text("\(match.count) people in ")
+                    + Text("your zone").bold()
+                    + Text(" are growing \(match.plantName) too. Want to see their tips?")
+            )
+            .font(CultivationTheme.Fonts.display(15).italic())
+            .foregroundStyle(CultivationTheme.Colors.textPrimary)
+            .lineLimit(nil)
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: CultivationTheme.Radius.card)
+                .fill(CultivationTheme.Colors.backgroundSecondary)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: CultivationTheme.Radius.card)
+                .strokeBorder(
+                    CultivationTheme.Colors.brandLeaf,
+                    style: StrokeStyle(lineWidth: 1, dash: [4, 3])
+                )
+        )
+        .accessibilityIdentifier("club_smart_match")
+    }
+
+    // MARK: - Data load
+
+    @MainActor
+    private func load() async {
+        let user = dataService.getCurrentUser()
+        userInitial = String(user?.displayName?.prefix(1) ?? "?").uppercased()
+
+        // Resolve the active club: explicit > first available > none.
+        let resolved: GardenClub?
+        if let explicit = club {
+            resolved = explicit
+        } else {
+            do {
+                resolved = try dataService.fetchClubs().first
+            } catch {
+                logger.error("Failed to fetch clubs: \(error.localizedDescription, privacy: .public)")
+                resolved = nil
+            }
+        }
+
+        if let activeClub = resolved {
+            clubName = activeClub.name ?? "Garden Club"
+            memberCount = activeClub.memberIDs?.count ?? 0
+            if let clubID = activeClub.id {
+                do {
+                    let activities = try dataService.fetchClubActivities(for: clubID)
+                    posts = activities.map(Self.viewData(from:))
+                } catch {
+                    logger.error("Failed to fetch club activities: \(error.localizedDescription, privacy: .public)")
+                    posts = []
+                }
+            } else {
+                posts = []
+            }
+        } else {
+            clubName = "Garden Club"
+            memberCount = 0
+            posts = []
+        }
+
+        // Smart match — populate when location/zone is available.
+        if let zone = locationService.hardinessZone {
+            smartMatch = SmartMatchSuggestion(count: 3, zone: zone, plantName: "Cherokee Purple")
+        }
+    }
+
+    private static func viewData(from activity: ClubActivity) -> ClubActivityViewData {
+        let id = activity.id ?? UUID()
+        let author = activity.memberName ?? "Member"
+        let caption = activity.activityDescription
+        let label: String?
+        if let timestamp = activity.timestamp {
+            let formatter = RelativeDateTimeFormatter()
+            formatter.unitsStyle = .abbreviated
+            label = formatter.localizedString(for: timestamp, relativeTo: .now)
+        } else {
+            label = nil
+        }
+        return ClubActivityViewData(
+            id: id,
+            authorDisplayName: author,
+            caption: caption,
+            zoneTag: nil, // not yet captured on ClubActivity
+            relativeTimeLabel: label,
+            likeCount: 0, // future feature
+            commentCount: 0 // future feature
+        )
+    }
+}
+
+// MARK: - Post card
+
+private struct PostCard: View {
+    let post: GardenClubFeedView.ClubActivityViewData
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 10) {
+                Circle()
+                    .fill(LinearGradient(
+                        colors: [CultivationTheme.Colors.brandMint, CultivationTheme.Colors.brandLeaf],
+                        startPoint: .topLeading, endPoint: .bottomTrailing
+                    ))
+                    .frame(width: 32, height: 32)
+                    .overlay(
+                        Text(initials(of: post.authorDisplayName))
+                            .font(CultivationTheme.Fonts.display(13, weight: .semibold))
+                            .foregroundStyle(.white)
+                    )
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(post.authorDisplayName)
+                        .font(CultivationTheme.Fonts.body(13, weight: .bold))
+                        .foregroundStyle(CultivationTheme.Colors.textPrimary)
+                    HStack(spacing: 5) {
+                        if let zone = post.zoneTag {
+                            Text("Zone \(zone)")
+                                .foregroundStyle(CultivationTheme.Colors.smartTagForeground)
+                                .fontWeight(.bold)
+                        }
+                        if let when = post.relativeTimeLabel {
+                            Text(post.zoneTag == nil ? when : "\u{00B7} \(when)")
+                                .foregroundStyle(CultivationTheme.Colors.textTertiary)
+                        }
+                    }
+                    .font(CultivationTheme.Fonts.body(10))
+                }
+                Spacer()
+            }
+
+            if let caption = post.caption {
+                Text(caption)
+                    .font(CultivationTheme.Fonts.body(13))
+                    .foregroundStyle(CultivationTheme.Colors.textSecondary)
+                    .lineLimit(nil)
+            }
+
+            // Photo placeholder — wire to PhotoService asset URL when available
+            RoundedRectangle(cornerRadius: 12)
+                .fill(LinearGradient(
+                    colors: [CultivationTheme.Colors.brandLeaf, CultivationTheme.Colors.brandForest],
+                    startPoint: .topLeading, endPoint: .bottomTrailing
+                ))
+                .frame(height: 120)
+
+            HStack(spacing: 16) {
+                Label("\(post.likeCount)", systemImage: "heart")
+                Label("\(post.commentCount)", systemImage: "bubble.right")
+                Label("Share", systemImage: "arrow.up.right")
+            }
+            .font(CultivationTheme.Fonts.body(11, weight: .semibold))
+            .foregroundStyle(CultivationTheme.Colors.textTertiary)
+        }
+        .padding(14)
+        .paperCard()
+        .accessibilityIdentifier("club_post_\(post.id.uuidString)")
+    }
+
+    private func initials(of name: String) -> String {
+        String(name.prefix(1)).uppercased()
     }
 }

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/GardenClub/GardenClubTabRoute.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/GardenClub/GardenClubTabRoute.swift
@@ -1,0 +1,29 @@
+import Foundation
+import GrowWiseModels
+
+/// Routing decision for the Club tab. Resolved from the user's club membership.
+/// See ADR-019.
+public enum GardenClubTabRoute: Equatable {
+    case joinOrCreate
+    case feed(GardenClub)
+    case list([GardenClub])
+
+    public static func resolve(clubs: [GardenClub]) -> GardenClubTabRoute {
+        switch clubs.count {
+        case 0:
+            .joinOrCreate
+        case 1:
+            .feed(clubs[0])
+        default:
+            // Most-recently-created club is the natural default; sort newest first
+            // so the list shows the freshest at the top.
+            .list(clubs.sorted { ($0.createdDate ?? .distantPast) > ($1.createdDate ?? .distantPast) })
+        }
+    }
+}
+
+extension GardenClub: @retroactive Equatable {
+    public static func == (lhs: GardenClub, rhs: GardenClub) -> Bool {
+        lhs.id == rhs.id
+    }
+}

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/GardenClub/GardenClubTabRoute.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/GardenClub/GardenClubTabRoute.swift
@@ -12,8 +12,10 @@ public enum GardenClubTabRoute: Equatable {
         switch clubs.count {
         case 0:
             .joinOrCreate
+
         case 1:
             .feed(clubs[0])
+
         default:
             // Most-recently-created club is the natural default; sort newest first
             // so the list shows the freshest at the top.

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/GardenClub/GardenClubTabRoute.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/GardenClub/GardenClubTabRoute.swift
@@ -21,9 +21,3 @@ public enum GardenClubTabRoute: Equatable {
         }
     }
 }
-
-extension GardenClub: @retroactive Equatable {
-    public static func == (lhs: GardenClub, rhs: GardenClub) -> Bool {
-        lhs.id == rhs.id
-    }
-}

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/GardenView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/GardenView.swift
@@ -223,7 +223,7 @@ public struct GardenView: View {
                 .padding(.horizontal, 12)
                 .padding(.vertical, 8)
                 .background {
-                    RoundedRectangle(cornerRadius: CultivationTheme.Radius.chip)
+                    RoundedRectangle(cornerRadius: CultivationTheme.Radius.pill)
                         .fill(CultivationTheme.Colors.accentCoral.opacity(0.08))
                 }
             }

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/GardenView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/GardenView.swift
@@ -23,8 +23,6 @@ public enum GardenFilter: String, CaseIterable, Identifiable {
 public struct GardenView: View {
     @Environment(DataService.self)
     private var dataService
-    @Environment(\.modelContext)
-    private var modelContext
 
     @State private var viewModel = GardenViewModel()
     @State private var selectedFilter: GardenFilter = .all
@@ -36,7 +34,6 @@ public struct GardenView: View {
     @State private var gardenToDelete: Garden?
     @State private var showDeleteConfirmation = false
     @State private var showPlantDatabase = false
-    @State private var showPlantScanner = false
 
     public init() {}
 
@@ -70,7 +67,7 @@ public struct GardenView: View {
                                                 do {
                                                     try dataService.plants.delete(plant)
                                                 } catch {
-                                                    // Error logged by repository
+                                                    viewModel.error = error
                                                 }
                                                 await viewModel.load(dataService: dataService)
                                             }
@@ -161,9 +158,6 @@ public struct GardenView: View {
             .sheet(isPresented: $showPlantDatabase) {
                 PlantDatabaseView()
             }
-            .sheet(isPresented: $showPlantScanner) {
-                PlantScannerView()
-            }
             .alert("Delete Garden?", isPresented: $showDeleteConfirmation) {
                 Button("Cancel", role: .cancel) {
                     gardenToDelete = nil
@@ -183,6 +177,17 @@ public struct GardenView: View {
                     let suffix = plantCount == 1 ? "" : "s"
                     Text("This will permanently delete \"\(gardenName)\" and its \(plantCount) plant\(suffix).")
                 }
+            }
+            .alert(
+                "Couldn't delete plant",
+                isPresented: Binding(
+                    get: { viewModel.error != nil },
+                    set: { if !$0 { viewModel.error = nil } }
+                )
+            ) {
+                Button("OK", role: .cancel) {}
+            } message: {
+                Text(viewModel.error?.localizedDescription ?? "")
             }
         }
         .accessibilityIdentifier("screen_garden")
@@ -431,30 +436,5 @@ public struct GardenView: View {
         .buttonStyle(.plain)
         .padding(.top, 8)
         .accessibilityIdentifier("garden_button_add_bed")
-    }
-}
-
-// MARK: - QuickStartChip (kept for potential reuse)
-
-private struct QuickStartChip: View {
-    let icon: String
-    let label: String
-    let onTap: () -> Void
-
-    var body: some View {
-        Button(action: onTap) {
-            VStack(spacing: 6) {
-                Image(systemName: icon)
-                    .font(.system(size: 18, weight: .medium))
-                    .foregroundStyle(CultivationTheme.Colors.accentCoral)
-                Text(label)
-                    .font(CultivationTheme.Fonts.body(12, weight: .medium))
-                    .foregroundStyle(CultivationTheme.Colors.textSecondary)
-            }
-            .frame(maxWidth: .infinity)
-            .padding(.vertical, 14)
-            .paperCard()
-        }
-        .buttonStyle(.plain)
     }
 }

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/GardenView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/GardenView.swift
@@ -387,7 +387,7 @@ public struct GardenView: View {
                 .multilineTextAlignment(.center)
 
             Button("Show All") {
-                withAnimation(CultivationTheme.Animation.snappy) {
+                withAnimation(CultivationTheme.Animation.selection) {
                     selectedFilter = .all
                 }
             }

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/GardenView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/GardenView.swift
@@ -275,7 +275,9 @@ public struct GardenView: View {
                             }
                     }
                     .buttonStyle(.plain)
-                    .accessibilityIdentifier("garden_picker_\(garden.name?.lowercased().replacingOccurrences(of: " ", with: "_") ?? "unknown")")
+                    .accessibilityIdentifier(
+                        "garden_picker_\(garden.name?.lowercased().replacingOccurrences(of: " ", with: "_") ?? "unknown")"
+                    )
                 }
 
                 Button {
@@ -326,7 +328,9 @@ public struct GardenView: View {
                             }
                     }
                     .buttonStyle(.plain)
-                    .accessibilityIdentifier("garden_filter_\(filter.rawValue.lowercased().replacingOccurrences(of: " ", with: "_"))")
+                    .accessibilityIdentifier(
+                        "garden_filter_\(filter.rawValue.lowercased().replacingOccurrences(of: " ", with: "_"))"
+                    )
                 }
             }
             .padding(.horizontal, 1)

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/GardenView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/GardenView.swift
@@ -37,6 +37,10 @@ public struct GardenView: View {
 
     public init() {}
 
+    private var filteredGroups: [PlantGroup] {
+        viewModel.filtered(by: selectedFilter)
+    }
+
     public var body: some View {
         NavigationStack {
             ZStack {
@@ -53,11 +57,10 @@ public struct GardenView: View {
                         } else if viewModel.groupedPlants.isEmpty {
                             emptyState
                         } else {
-                            let groups = viewModel.filtered(by: selectedFilter)
-                            if groups.isEmpty {
+                            if filteredGroups.isEmpty {
                                 filterEmptyState
                             } else {
-                                ForEach(groups) { group in
+                                ForEach(filteredGroups) { group in
                                     GardenBedSection(
                                         group: group,
                                         onPlantTap: { plant in selectedPlant = plant },
@@ -304,7 +307,7 @@ public struct GardenView: View {
                 ForEach(GardenFilter.allCases) { filter in
                     let isActive = selectedFilter == filter
                     Button {
-                        withAnimation(CultivationTheme.Animation.snappy) {
+                        withAnimation(CultivationTheme.Animation.selection) {
                             selectedFilter = filter
                         }
                     } label: {

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/GardenView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/GardenView.swift
@@ -2,11 +2,24 @@ import GrowWiseModels
 import GrowWiseServices
 import SwiftUI
 
+// MARK: - GardenFilter
+
+/// Filter chips shown in the Garden tab plant list.
+public enum GardenFilter: String, CaseIterable, Identifiable {
+    case all = "All"
+    case needsCare = "Needs Care"
+    case blooming = "Blooming"
+    case edible = "Edible"
+    case herbs = "Herbs"
+    public var id: String {
+        rawValue
+    }
+}
+
 // MARK: - GardenView
 
-/// Garden tab — dashboard showing all gardens as visual cards.
-/// Tap a garden card to drill into its plant list.
-/// Prominent "New Garden" card for easy garden creation.
+/// Garden tab — shows plants grouped by bed for the selected garden.
+/// Multi-garden users get a horizontal garden picker at the top.
 public struct GardenView: View {
     @Environment(DataService.self)
     private var dataService
@@ -14,103 +27,150 @@ public struct GardenView: View {
     private var modelContext
 
     @State private var viewModel = GardenViewModel()
+    @State private var selectedFilter: GardenFilter = .all
+    @State private var selectedPlant: Plant?
+    @State private var plantToNavigate: Plant?
+    @State private var showAddPlantSheet = false
     @State private var showCreateGarden = false
-    @State private var gardenToNavigate: Garden?
+    @State private var showCreateBed = false
     @State private var gardenToDelete: Garden?
     @State private var showDeleteConfirmation = false
     @State private var showPlantDatabase = false
     @State private var showPlantScanner = false
-    @State private var showAddPlantMenu = false
-    @State private var showAddPlantSheet = false
-    @State private var showFAB = false
-    @State private var shoppingListGarden: Garden?
-    @State private var showSeedInventory = false
 
     public init() {}
 
     public var body: some View {
         NavigationStack {
-            ScrollView {
-                VStack(alignment: .leading, spacing: 0) {
-                    // Dashboard header
-                    dashboardHeader
-                        .padding(.bottom, CultivationTheme.Spacing.sectionGap)
-
-                    if viewModel.isLoading {
-                        loadingState
-                    } else if viewModel.gardens.isEmpty {
-                        emptyState
-                    } else {
-                        // Garden cards grid
-                        gardenGrid
-
-                        // Shopping List link
-                        shoppingListSection
+            ZStack {
+                CultivationTheme.Colors.background.ignoresSafeArea()
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 12) {
+                        gardenHeader
+                        if viewModel.gardens.count > 1 {
+                            gardenPicker
+                        }
+                        filterChipBar
+                        if viewModel.isLoading {
+                            loadingState
+                        } else if viewModel.groupedPlants.isEmpty {
+                            emptyState
+                        } else {
+                            let groups = viewModel.filtered(by: selectedFilter)
+                            if groups.isEmpty {
+                                filterEmptyState
+                            } else {
+                                ForEach(groups) { group in
+                                    GardenBedSection(
+                                        group: group,
+                                        onPlantTap: { plant in selectedPlant = plant },
+                                        onQuickAction: { _ in },
+                                        onDelete: { plant in
+                                            Task<Void, Never> {
+                                                do {
+                                                    try dataService.plants.delete(plant)
+                                                } catch {
+                                                    // Error logged by repository
+                                                }
+                                                await viewModel.load(dataService: dataService)
+                                            }
+                                        }
+                                    )
+                                    .accessibilityIdentifier(
+                                        "garden_bed_\(group.displayName.lowercased().replacingOccurrences(of: " ", with: "_"))"
+                                    )
+                                }
+                            }
+                        }
+                        addBedButton
                     }
-                }
-                .padding(.horizontal, CultivationTheme.Spacing.screenPadding)
-                .padding(.bottom, 32)
-            }
-            .overlay(alignment: .bottomTrailing) {
-                Button {
-                    showAddPlantMenu = true
-                } label: {
-                    Image(systemName: "plus.circle.fill")
-                        .font(.system(size: 28))
-                        .foregroundStyle(.white)
-                        .frame(width: 56, height: 56)
-                        .background(CultivationTheme.Colors.brandLeaf)
-                        .clipShape(Circle())
-                        .shadow(color: CultivationTheme.Colors.brandLeaf.opacity(0.35), radius: 10, y: 4)
-                }
-                .buttonStyle(.plain)
-                .padding(.trailing, CultivationTheme.Spacing.screenPadding)
-                .padding(.bottom, 24)
-                .scaleEffect(showFAB ? 1 : 0.5)
-                .opacity(showFAB ? 1 : 0)
-                .accessibilityIdentifier("garden_fab_addplant")
-            }
-            .onAppear {
-                withAnimation(.spring(duration: 0.4, bounce: 0.3)) {
-                    showFAB = true
+                    .padding(.horizontal, CultivationTheme.Spacing.screenPadding)
+                    .padding(.top, 12)
+                    .padding(.bottom, 40)
                 }
             }
-            .background(CultivationTheme.Colors.background.ignoresSafeArea())
+            #if os(iOS)
+            .navigationBarHidden(true)
+            #endif
             .task {
                 await viewModel.load(dataService: dataService)
             }
             .refreshable {
                 await viewModel.load(dataService: dataService)
             }
-            .navigationDestination(item: $gardenToNavigate) { garden in
-                GardenDetailView(garden: garden)
+            .navigationDestination(item: $plantToNavigate) { plant in
+                PlantDetailView(plant: plant)
             }
-            .navigationDestination(item: $shoppingListGarden) { garden in
-                ShoppingListView(garden: garden)
+            .sheet(item: $selectedPlant) { plant in
+                PlantQuickCard(
+                    plant: plant,
+                    onWater: { selectedPlant = nil },
+                    onPrune: { selectedPlant = nil },
+                    onLog: { selectedPlant = nil },
+                    onViewDetails: {
+                        let captured = plant
+                        selectedPlant = nil
+                        Task<Void, Never> { @MainActor in
+                            try? await Task.sleep(for: .milliseconds(350))
+                            plantToNavigate = captured
+                        }
+                    }
+                )
+                .presentationDetents([.medium, .large])
+                .presentationDragIndicator(.hidden)
             }
-            .navigationDestination(isPresented: $showSeedInventory) {
-                SeedInventoryView()
-            }
+            .sheet(
+                isPresented: $showAddPlantSheet,
+                onDismiss: {
+                    Task<Void, Never> { await viewModel.load(dataService: dataService) }
+                },
+                content: {
+                    AddPlantSheet()
+                        .presentationDetents([.large])
+                        .presentationDragIndicator(.hidden)
+                }
+            )
             .sheet(
                 isPresented: $showCreateGarden,
                 onDismiss: {
-                    Task { await viewModel.load(dataService: dataService) }
+                    Task<Void, Never> { await viewModel.load(dataService: dataService) }
                 },
                 content: {
                     CreateGardenSheet { _ in
-                        Task { await viewModel.load(dataService: dataService) }
+                        Task<Void, Never> { await viewModel.load(dataService: dataService) }
                     }
                     .presentationDetents([.large])
                     .presentationDragIndicator(.hidden)
                 }
             )
+            .sheet(
+                isPresented: $showCreateBed,
+                onDismiss: {
+                    Task<Void, Never> { await viewModel.load(dataService: dataService) }
+                },
+                content: {
+                    if let garden = viewModel.selectedGarden {
+                        CreateBedSheet(garden: garden) { _ in
+                            Task<Void, Never> { await viewModel.load(dataService: dataService) }
+                        }
+                        .presentationDetents([.medium])
+                        .presentationDragIndicator(.hidden)
+                    }
+                }
+            )
+            .sheet(isPresented: $showPlantDatabase) {
+                PlantDatabaseView()
+            }
+            .sheet(isPresented: $showPlantScanner) {
+                PlantScannerView()
+            }
             .alert("Delete Garden?", isPresented: $showDeleteConfirmation) {
                 Button("Cancel", role: .cancel) {
                     gardenToDelete = nil
                 }
                 Button("Delete", role: .destructive) {
                     if let garden = gardenToDelete {
-                        Task {
+                        Task<Void, Never> {
                             await viewModel.deleteGarden(garden, dataService: dataService)
                         }
                         gardenToDelete = nil
@@ -124,233 +184,151 @@ public struct GardenView: View {
                     Text("This will permanently delete \"\(gardenName)\" and its \(plantCount) plant\(suffix).")
                 }
             }
-            .toolbar {
-                ToolbarItem(placement: .cancellationAction) {
-                    Button {
-                        showPlantDatabase = true
-                    } label: {
-                        Image(systemName: "book.fill")
-                    }
-                    .accessibilityIdentifier("garden_button_plantguide")
-                }
-                ToolbarItem(placement: .primaryAction) {
-                    Button {
-                        showPlantScanner = true
-                    } label: {
-                        Image(systemName: "camera.viewfinder")
-                    }
-                    .accessibilityIdentifier("garden_button_scanplant")
-                }
-            }
-            .sheet(isPresented: $showPlantDatabase) {
-                PlantDatabaseView()
-            }
-            .sheet(isPresented: $showPlantScanner) {
-                PlantScannerView()
-            }
-            .sheet(isPresented: $showAddPlantSheet) {
-                AddPlantSheet()
-                    .presentationDetents([.large])
-                    .presentationDragIndicator(.hidden)
-            }
-            .confirmationDialog("Add a Plant", isPresented: $showAddPlantMenu, titleVisibility: .visible) {
-                Button("Browse Plant Database") {
-                    showPlantDatabase = true
-                }
-                .accessibilityIdentifier("garden_fab_option_browse")
-
-                Button("Scan a Plant") {
-                    showPlantScanner = true
-                }
-                .accessibilityIdentifier("garden_fab_option_scan")
-
-                Button("Add Manually") {
-                    showAddPlantSheet = true
-                }
-                .accessibilityIdentifier("garden_fab_option_manual")
-            }
         }
         .accessibilityIdentifier("screen_garden")
     }
 
-    // MARK: - Dashboard Header
+    // MARK: - Garden Header
 
-    private var seedCount: Int {
-        // Non-critical display value — 0 on error is acceptable for stat chip
-        (try? dataService.seeds.fetchAll().count) ?? 0
-    }
+    private var gardenHeader: some View {
+        HStack(alignment: .top, spacing: 12) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("GARDEN")
+                    .font(.system(size: 10, weight: .medium, design: .monospaced))
+                    .tracking(2)
+                    .foregroundStyle(CultivationTheme.Colors.brandLeaf)
 
-    private var dashboardHeader: some View {
-        VStack(alignment: .leading, spacing: 16) {
-            HStack(alignment: .top) {
-                VStack(alignment: .leading, spacing: 4) {
-                    Text("GARDENS")
-                        .font(.system(size: 10, weight: .medium, design: .monospaced))
-                        .tracking(2)
-                        .foregroundStyle(CultivationTheme.Colors.brandLeaf)
+                Text(viewModel.selectedGarden?.name ?? "My Garden")
+                    .font(CultivationTheme.Fonts.display(28, weight: .medium))
+                    .foregroundStyle(CultivationTheme.Colors.textPrimary)
+            }
 
-                    Text(viewModel.userName.isEmpty ? "My Gardens" : "\(viewModel.userName)'s Gardens")
-                        .font(.system(.title, design: .serif))
-                        .foregroundStyle(CultivationTheme.Colors.textPrimary)
+            Spacer()
 
-                    Text("\(viewModel.gardens.count) gardens \u{00B7} \(viewModel.totalPlantsAllGardens) plants")
-                        .font(.system(size: 13))
+            // Plant count badge
+            if viewModel.totalPlantCount > 0 {
+                VStack(spacing: 2) {
+                    Text("\(viewModel.totalPlantCount)")
+                        .font(CultivationTheme.Fonts.display(20, weight: .medium))
+                        .foregroundStyle(CultivationTheme.Colors.accentCoral)
+                    Text("plants")
+                        .font(CultivationTheme.Fonts.body(11))
                         .foregroundStyle(CultivationTheme.Colors.textSecondary)
                 }
+                .padding(.horizontal, 12)
+                .padding(.vertical, 8)
+                .background {
+                    RoundedRectangle(cornerRadius: CultivationTheme.Radius.chip)
+                        .fill(CultivationTheme.Colors.accentCoral.opacity(0.08))
+                }
+            }
 
-                Spacer()
+            Button {
+                showPlantDatabase = true
+            } label: {
+                Image(systemName: "book.fill")
+                    .font(.system(size: 15, weight: .medium))
+                    .foregroundStyle(CultivationTheme.Colors.textSecondary)
+                    .frame(width: 36, height: 36)
+                    .background(CultivationTheme.Colors.cardSurface)
+                    .clipShape(Circle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityIdentifier("garden_button_plantguide")
+        }
+        .padding(.top, 16)
+        .accessibilityIdentifier("garden_header")
+    }
+
+    // MARK: - Garden Picker (multi-garden)
+
+    private var gardenPicker: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 8) {
+                ForEach(viewModel.gardens) { garden in
+                    let isActive = viewModel.selectedGarden?.id == garden.id
+                    Button {
+                        Task<Void, Never> {
+                            await viewModel.selectGarden(garden, dataService: dataService)
+                        }
+                    } label: {
+                        Text(garden.name ?? "Garden")
+                            .font(CultivationTheme.Fonts.body(13, weight: isActive ? .semibold : .medium))
+                            .foregroundStyle(isActive ? Color.white : CultivationTheme.Colors.textSecondary)
+                            .padding(.horizontal, 14)
+                            .padding(.vertical, 7)
+                            .background {
+                                Capsule()
+                                    .fill(
+                                        isActive
+                                            ? AnyShapeStyle(Color(CultivationTheme.Colors.brandForest))
+                                            : AnyShapeStyle(CultivationTheme.Colors.cardSurface)
+                                    )
+                            }
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityIdentifier("garden_picker_\(garden.name?.lowercased().replacingOccurrences(of: " ", with: "_") ?? "unknown")")
+                }
 
                 Button {
                     showCreateGarden = true
                 } label: {
-                    Image(systemName: "plus")
-                        .font(.system(size: 17, weight: .semibold))
-                        .foregroundStyle(.white)
-                        .frame(width: 44, height: 44)
-                        .background(CultivationTheme.Gradients.warmAccent)
-                        .clipShape(Circle())
-                        .shadow(color: CultivationTheme.Colors.accentCoral.opacity(0.3), radius: 8, y: 3)
-                }
-                .accessibilityIdentifier("garden_button_add")
-            }
-
-            if !viewModel.gardens.isEmpty {
-                HStack(spacing: 10) {
-                    QuickStatCard(
-                        value: viewModel.gardens.count,
-                        label: "Gardens",
-                        color: CultivationTheme.Colors.brandLeaf
-                    )
-                    QuickStatCard(
-                        value: viewModel.totalPlantsAllGardens,
-                        label: "Plants",
-                        color: CultivationTheme.Colors.statusHealthy
-                    )
-                    QuickStatCard(
-                        value: viewModel.totalAlertsAllGardens,
-                        label: "Alerts",
-                        color: viewModel.totalAlertsAllGardens > 0
-                            ? CultivationTheme.Colors.statusAlert
-                            : CultivationTheme.Colors.textTertiary
-                    )
-                    QuickStatCard(
-                        value: seedCount,
-                        label: "Seeds",
-                        color: CultivationTheme.Colors.accentCoral
-                    )
-                    .onTapGesture { showSeedInventory = true }
-                    .accessibilityIdentifier("garden_stat_seeds")
-                }
-            }
-        }
-        .padding(.top, 16)
-    }
-
-    // MARK: - Garden Grid
-
-    private var gardenGrid: some View {
-        LazyVStack(spacing: 14) {
-            ForEach(viewModel.gardenSummaries) { summary in
-                GardenCardView(
-                    garden: summary.garden,
-                    plantCount: summary.plantCount,
-                    bedCount: summary.bedCount,
-                    alertCount: summary.alertCount,
-                    onTap: {
-                        gardenToNavigate = summary.garden
-                    }
-                )
-                .contextMenu {
-                    Button {
-                        gardenToNavigate = summary.garden
-                    } label: {
-                        Label("Open", systemImage: "arrow.right.circle")
-                    }
-
-                    Button(role: .destructive) {
-                        gardenToDelete = summary.garden
-                        showDeleteConfirmation = true
-                    } label: {
-                        Label("Delete Garden", systemImage: "trash")
-                    }
-                }
-                .transition(.asymmetric(
-                    insertion: .scale(scale: 0.95).combined(with: .opacity),
-                    removal: .opacity
-                ))
-            }
-
-            // Add garden card — always visible at the bottom
-            AddGardenCard {
-                showCreateGarden = true
-            }
-        }
-    }
-
-    // MARK: - Shopping List
-
-    private var shoppingListSection: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text("SHOPPING")
-                .sectionLabelStyle()
-                .foregroundStyle(CultivationTheme.Colors.sectionLabel)
-                .padding(.top, CultivationTheme.Spacing.sectionGap)
-
-            ForEach(viewModel.gardens) { garden in
-                Button {
-                    shoppingListGarden = garden
-                } label: {
-                    HStack(spacing: 12) {
-                        IconBubble(
-                            systemName: "cart.fill",
-                            color: CultivationTheme.Colors.accentAmber,
-                            size: 36,
-                            iconSize: 16
-                        )
-
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text(garden.name ?? "Garden")
-                                .font(.system(.subheadline, design: .serif, weight: .semibold))
-                                .foregroundStyle(CultivationTheme.Colors.textPrimary)
-                            Text("Shopping list")
-                                .font(.system(.caption))
-                                .foregroundStyle(CultivationTheme.Colors.textSecondary)
+                    Label("New", systemImage: "plus")
+                        .font(CultivationTheme.Fonts.body(13, weight: .medium))
+                        .foregroundStyle(CultivationTheme.Colors.brandLeaf)
+                        .padding(.horizontal, 14)
+                        .padding(.vertical, 7)
+                        .background {
+                            Capsule()
+                                .stroke(CultivationTheme.Colors.brandLeaf.opacity(0.4), lineWidth: 1)
                         }
-
-                        Spacer()
-
-                        Image(systemName: "chevron.right")
-                            .font(.system(size: 12, weight: .semibold))
-                            .foregroundStyle(CultivationTheme.Colors.textTertiary)
-                    }
-                    .padding(CultivationTheme.Spacing.cardPadding)
-                    .glassCard()
                 }
                 .buttonStyle(.plain)
-                .accessibilityIdentifier("garden_button_shopping_\(garden.id?.uuidString ?? "unknown")")
+                .accessibilityIdentifier("garden_button_add")
             }
+            .padding(.horizontal, 1) // prevent clip
         }
-        .padding(.top, CultivationTheme.Spacing.rowGap)
+        .accessibilityIdentifier("garden_picker")
     }
 
-    // MARK: - States
+    // MARK: - Filter Chip Bar
 
-    private var loadingState: some View {
-        VStack(spacing: 16) {
-            ProgressView()
-                .tint(CultivationTheme.Colors.brandLeaf)
-            Text("Loading gardens\u{2026}")
-                .font(.system(.subheadline, design: .rounded))
-                .foregroundStyle(CultivationTheme.Colors.textSecondary)
+    private var filterChipBar: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 8) {
+                ForEach(GardenFilter.allCases) { filter in
+                    let isActive = selectedFilter == filter
+                    Button {
+                        withAnimation(CultivationTheme.Animation.snappy) {
+                            selectedFilter = filter
+                        }
+                    } label: {
+                        Text(filter.rawValue)
+                            .font(CultivationTheme.Fonts.body(13, weight: isActive ? .semibold : .medium))
+                            .foregroundStyle(isActive ? Color.white : CultivationTheme.Colors.textTertiary)
+                            .padding(.horizontal, 14)
+                            .padding(.vertical, 7)
+                            .background {
+                                Capsule()
+                                    .fill(
+                                        isActive
+                                            ? AnyShapeStyle(Color(CultivationTheme.Colors.brandForest))
+                                            : AnyShapeStyle(CultivationTheme.Colors.cardSurface)
+                                    )
+                            }
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityIdentifier("garden_filter_\(filter.rawValue.lowercased().replacingOccurrences(of: " ", with: "_"))")
+                }
+            }
+            .padding(.horizontal, 1)
         }
-        .frame(maxWidth: .infinity)
-        .padding(.top, 60)
-        .accessibilityIdentifier("garden_loading_indicator")
     }
+
+    // MARK: - Empty States
 
     private var emptyState: some View {
         VStack(spacing: 20) {
-            // Illustration
             ZStack {
                 Circle()
                     .fill(CultivationTheme.Colors.brandLeaf.opacity(0.08))
@@ -368,48 +346,95 @@ public struct GardenView: View {
             }
 
             VStack(spacing: 6) {
-                Text("Plant your first garden")
-                    .font(.system(.title3, design: .serif))
+                Text("No plants yet")
+                    .font(CultivationTheme.Fonts.display(20, weight: .medium))
                     .foregroundStyle(CultivationTheme.Colors.textPrimary)
 
-                Text("Create a garden for your backyard, balcony,\nwindowsill, or anywhere you grow")
-                    .font(.system(.subheadline))
+                Text("Add your first plant to get started.")
+                    .font(CultivationTheme.Fonts.body(14))
                     .foregroundStyle(CultivationTheme.Colors.textSecondary)
                     .multilineTextAlignment(.center)
             }
 
-            Button("Create Your First Garden") {
-                showCreateGarden = true
+            Button("Add Plant") {
+                showAddPlantSheet = true
             }
             .buttonStyle(GradientButtonStyle())
             .padding(.horizontal, 24)
-            .accessibilityIdentifier("garden_button_create_first")
-
-            // Quick-start suggestions
-            VStack(alignment: .leading, spacing: 8) {
-                Text("POPULAR SETUPS")
-                    .sectionLabelStyle()
-
-                HStack(spacing: 10) {
-                    QuickStartChip(icon: "sun.max.fill", label: "Backyard") {
-                        showCreateGarden = true
-                    }
-                    QuickStartChip(icon: "building.2.fill", label: "Balcony") {
-                        showCreateGarden = true
-                    }
-                    QuickStartChip(icon: "house.fill", label: "Indoor") {
-                        showCreateGarden = true
-                    }
-                }
-            }
-            .padding(.top, 8)
+            .accessibilityIdentifier("garden_button_add_plant")
         }
         .frame(maxWidth: .infinity)
         .padding(.top, 40)
     }
+
+    private var filterEmptyState: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "line.3.horizontal.decrease.circle")
+                .font(.system(size: 36))
+                .foregroundStyle(CultivationTheme.Colors.textTertiary)
+
+            Text("No plants match \"\(selectedFilter.rawValue)\"")
+                .font(CultivationTheme.Fonts.body(15))
+                .foregroundStyle(CultivationTheme.Colors.textSecondary)
+                .multilineTextAlignment(.center)
+
+            Button("Show All") {
+                withAnimation(CultivationTheme.Animation.snappy) {
+                    selectedFilter = .all
+                }
+            }
+            .font(CultivationTheme.Fonts.body(14, weight: .medium))
+            .foregroundStyle(CultivationTheme.Colors.brandLeaf)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.top, 32)
+        .padding(.bottom, 16)
+    }
+
+    private var loadingState: some View {
+        VStack(spacing: 16) {
+            ProgressView()
+                .tint(CultivationTheme.Colors.brandLeaf)
+            Text("Loading\u{2026}")
+                .font(CultivationTheme.Fonts.body(14))
+                .foregroundStyle(CultivationTheme.Colors.textSecondary)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.top, 60)
+        .accessibilityIdentifier("garden_loading_indicator")
+    }
+
+    // MARK: - Add Bed Button
+
+    private var addBedButton: some View {
+        Button {
+            if viewModel.selectedGarden != nil {
+                showCreateBed = true
+            } else {
+                showCreateGarden = true
+            }
+        } label: {
+            HStack(spacing: 8) {
+                Image(systemName: "plus")
+                    .font(.system(size: 13, weight: .semibold))
+                Text("Add a bed")
+                    .font(CultivationTheme.Fonts.body(14, weight: .medium))
+            }
+            .foregroundStyle(CultivationTheme.Colors.brandLeaf)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 14)
+            .background {
+                RoundedRectangle(cornerRadius: CultivationTheme.Radius.card)
+                    .stroke(CultivationTheme.Colors.brandLeaf.opacity(0.35), style: StrokeStyle(lineWidth: 1, dash: [5, 4]))
+            }
+        }
+        .buttonStyle(.plain)
+        .padding(.top, 8)
+        .accessibilityIdentifier("garden_button_add_bed")
+    }
 }
 
-// MARK: - QuickStartChip
+// MARK: - QuickStartChip (kept for potential reuse)
 
 private struct QuickStartChip: View {
     let icon: String
@@ -423,12 +448,12 @@ private struct QuickStartChip: View {
                     .font(.system(size: 18, weight: .medium))
                     .foregroundStyle(CultivationTheme.Colors.accentCoral)
                 Text(label)
-                    .font(.system(.caption, design: .rounded, weight: .medium))
+                    .font(CultivationTheme.Fonts.body(12, weight: .medium))
                     .foregroundStyle(CultivationTheme.Colors.textSecondary)
             }
             .frame(maxWidth: .infinity)
             .padding(.vertical, 14)
-            .glassCard()
+            .paperCard()
         }
         .buttonStyle(.plain)
     }

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/Home/HomeViewModel.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/Home/HomeViewModel.swift
@@ -123,10 +123,13 @@ final class HomeViewModel {
                 switch reminder.reminderType {
                 case .watering:
                     plant.lastWatered = Date()
+
                 case .fertilizing:
                     plant.lastFertilized = Date()
+
                 case .pruning:
                     plant.lastPruned = Date()
+
                 default:
                     break
                 }

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/Home/HomeViewModel.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/Home/HomeViewModel.swift
@@ -1,5 +1,7 @@
 import GrowWiseModels
 import GrowWiseServices
+import os
+import SwiftData
 import SwiftUI
 
 // SeedInventoryService is in GrowWiseServices (imported above)
@@ -22,6 +24,9 @@ final class HomeViewModel {
     var readyToPlantSeeds: [Seed] = []
     /// User's hardiness zone, resolved on load.
     var hardinessZone: String?
+
+    /// Most-recent ClubActivity across all clubs. Displayed in the Home "Your Club" card.
+    var latestClubPost: ClubActivity?
 
     /// IDs of reminders the user has tapped "Done" on — used to filter them
     /// from the list with a slide-away animation before the next data reload.
@@ -81,6 +86,20 @@ final class HomeViewModel {
         }
         let seedService = SeedInventoryService()
         readyToPlantSeeds = seedService.readyToPlant(seeds: allSeeds, zone: hardinessZone ?? "6", currentDate: Date())
+
+        // Latest club post for the Home "Your Club" card (SwiftData fetch via mainContext)
+        do {
+            var descriptor = FetchDescriptor<ClubActivity>(
+                sortBy: [SortDescriptor(\.timestamp, order: .reverse)]
+            )
+            descriptor.fetchLimit = 1
+            let posts = try dataService.mainContext.fetch(descriptor)
+            latestClubPost = posts.first
+        } catch {
+            Logger(subsystem: "com.growwise", category: "HomeViewModel")
+                .error("latestClubPost fetch failed: \(error.localizedDescription, privacy: .public)")
+            latestClubPost = nil
+        }
 
         isLoading = false
     }

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/Home/YourClubCard.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/Home/YourClubCard.swift
@@ -1,0 +1,63 @@
+import GrowWiseModels
+import SwiftUI
+
+/// Home-tab card surfacing the latest post from the user's club with a coral/honey
+/// gradient banner. Rendered only when HomeViewModel.latestClubPost is non-nil.
+struct YourClubCard: View {
+    let post: ClubActivity
+
+    private var displayName: String {
+        post.memberName ?? "Member"
+    }
+
+    private var caption: String? {
+        let raw = post.activityDescription
+        return (raw?.isEmpty ?? true) ? nil : raw
+    }
+
+    private var relativeTime: String? {
+        guard let timestamp = post.timestamp else { return nil }
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .abbreviated
+        return formatter.localizedString(for: timestamp, relativeTo: .now)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 6) {
+                Text("✦")
+                Text("Your Club")
+            }
+            .font(CultivationTheme.Fonts.body(10, weight: .bold))
+            .tracking(1.4)
+            .textCase(.uppercase)
+            .foregroundStyle(.white)
+
+            if let caption {
+                Text(caption)
+                    .font(CultivationTheme.Fonts.display(16, weight: .medium))
+                    .foregroundStyle(.white)
+                    .lineLimit(3)
+            }
+
+            HStack(spacing: 6) {
+                Text(displayName)
+                    .fontWeight(.semibold)
+                if let relativeTime {
+                    Text("· \(relativeTime)")
+                }
+            }
+            .font(CultivationTheme.Fonts.body(11))
+            .foregroundStyle(.white.opacity(0.9))
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: CultivationTheme.Radius.card)
+                .fill(CultivationTheme.Gradients.warmAccent)
+                .shadow(color: CultivationTheme.Colors.accentCoral.opacity(0.25), radius: 12, y: 6)
+        )
+        .accessibilityIdentifier("home_card_your_club")
+        .accessibilityLabel("Latest from Your Club")
+    }
+}

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/HomeView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/HomeView.swift
@@ -43,6 +43,12 @@ public struct HomeView: View {
         NavigationStack {
             ScrollView {
                 LazyVStack(alignment: .leading, spacing: CultivationTheme.Spacing.rowGap) {
+                    if let post = viewModel.latestClubPost {
+                        YourClubCard(post: post)
+                            .padding(.horizontal, CultivationTheme.Spacing.screenPadding)
+                            .padding(.top, CultivationTheme.Spacing.sectionGap)
+                    }
+
                     if viewModel.allTasksDone {
                         emptyStateView
                     } else {

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/MyGardenPlantDetailView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/MyGardenPlantDetailView.swift
@@ -29,7 +29,7 @@ struct PlantDetailView: View {
     @State private var careTips: [CareTip] = []
     @State private var isAdviceExpanded: Bool = false
     @State private var journalEntries: [JournalEntry] = []
-    @State private var primaryClub: GardenClub? = nil
+    @State private var primaryClub: GardenClub?
     @State private var showingShareToClub: Bool = false
     @State private var deleteError: Error?
 

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/MyGardenPlantDetailView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/MyGardenPlantDetailView.swift
@@ -31,6 +31,7 @@ struct PlantDetailView: View {
     @State private var journalEntries: [JournalEntry] = []
     @State private var primaryClub: GardenClub? = nil
     @State private var showingShareToClub: Bool = false
+    @State private var deleteError: Error?
 
     // MARK: - Body
 
@@ -85,6 +86,14 @@ struct PlantDetailView: View {
             Button("Delete", role: .destructive) { deletePlant() }
         } message: {
             Text("Are you sure you want to delete \(plant.name ?? "this plant")? This action cannot be undone.")
+        }
+        .alert("Couldn't delete plant", isPresented: Binding(
+            get: { deleteError != nil },
+            set: { if !$0 { deleteError = nil } }
+        )) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(deleteError?.localizedDescription ?? "")
         }
         .accessibilityIdentifier("screen_plantDetail")
     }

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/MyGardenPlantDetailView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/MyGardenPlantDetailView.swift
@@ -17,61 +17,59 @@ struct PlantDetailView: View {
     private var careAdviceService
     @Environment(PerenualEnrichmentService.self)
     private var perenualEnrichment
+
+    // MARK: - State
+
     @State private var showingEditPlant = false
     @State private var showingDeleteConfirmation = false
     @State private var showingReminderView = false
-    @State private var selectedPhoto: String?
-    @State private var showingPhotoViewer = false
     @State private var showingAssignGarden = false
     @State private var showMovePlant = false
     @State private var showingDiagnostic = false
-
     @State private var careTips: [CareTip] = []
+    @State private var isAdviceExpanded: Bool = false
+    @State private var journalEntries: [JournalEntry] = []
+    @State private var primaryClub: GardenClub? = nil
+    @State private var showingShareToClub: Bool = false
 
-    // Care action states
-    @State private var isPerformingCareAction = false
-    @State private var showingCareSuccess = false
-    @State private var careActionMessage = ""
+    // MARK: - Body
 
     var body: some View {
         ZStack {
-            CultivationTheme.Colors.background
-                .ignoresSafeArea()
-
+            CultivationTheme.Colors.background.ignoresSafeArea()
             ScrollView {
-                LazyVStack(alignment: .leading, spacing: CultivationTheme.Spacing.sectionGap) {
-                    heroImageSection
-                    careTipsSection
-                    plantInfoSections
+                VStack(alignment: .leading, spacing: 14) {
+                    heroPhoto
+                    titleBlock
+                    statRow
+                    actionButtons
+                    if isAdviceExpanded {
+                        adviceCard
+                    }
+                    photoJournalStrip
                 }
-                .padding(.bottom, 32)
+                .padding(.horizontal, CultivationTheme.Spacing.screenPadding)
+                .padding(.top, 12)
+                .padding(.bottom, 40)
             }
         }
-        .navigationTitle(plant.name ?? "Unknown Plant")
+        .navigationTitle(plant.name ?? "Plant")
         .gwNavigationBarTitleDisplayMode(.inline)
         .toolbar { toolbarContent }
-        .alert("Delete Plant", isPresented: $showingDeleteConfirmation) {
-            Button("Cancel", role: .cancel) {}
-            Button("Delete", role: .destructive) {
-                deletePlant()
-            }
-        } message: {
-            Text("Are you sure you want to delete \(plant.name ?? "this plant")? This action cannot be undone.")
-        }
-        .alert("Care Action Completed", isPresented: $showingCareSuccess) {
-            Button("OK") {}
-        } message: {
-            Text(careActionMessage)
-        }
         .task {
             let user = dataService.getCurrentUser()
             careTips = careAdviceService.getContextualTips(for: plant, in: plant.garden, user: user)
-        }
-        .sheet(isPresented: $showingEditPlant) {
-            Text("Edit Plant View - To be implemented")
+            journalEntries = dataService.fetchJournalEntries(for: plant)
+            primaryClub = dataService.fetchPrimaryClub()
         }
         .sheet(isPresented: $showingReminderView) {
             AddReminderView(reminderService: reminderService, dataService: dataService)
+        }
+        .sheet(isPresented: $showingShareToClub) {
+            PublishGardenSheet()
+        }
+        .sheet(isPresented: $showingEditPlant) {
+            Text("Edit Plant View - To be implemented")
         }
         .sheet(isPresented: $showingAssignGarden) {
             AssignGardenSheet(plant: plant)
@@ -82,7 +80,182 @@ struct PlantDetailView: View {
         .sheet(isPresented: $showingDiagnostic) {
             CommonPlantIssuesView(plant: plant)
         }
+        .alert("Delete Plant", isPresented: $showingDeleteConfirmation) {
+            Button("Cancel", role: .cancel) {}
+            Button("Delete", role: .destructive) { deletePlant() }
+        } message: {
+            Text("Are you sure you want to delete \(plant.name ?? "this plant")? This action cannot be undone.")
+        }
+        .accessibilityIdentifier("screen_plantDetail")
     }
+
+    // MARK: - Hero Photo
+
+    private var heroPhoto: some View {
+        ZStack(alignment: .bottomLeading) {
+            RoundedRectangle(cornerRadius: CultivationTheme.Radius.card)
+                .fill(LinearGradient(
+                    colors: [CultivationTheme.Colors.brandLeaf, CultivationTheme.Colors.brandForest],
+                    startPoint: .topLeading,
+                    endPoint: .bottomTrailing
+                ))
+                .frame(height: 220)
+            VStack(alignment: .leading, spacing: 4) {
+                if let zone = plant.garden?.hardinessZone, !zone.isEmpty {
+                    SmartTag(label: zone)
+                        .accessibilityIdentifier("plantdetail_tag_zone")
+                }
+            }
+            .padding(14)
+        }
+        .accessibilityIdentifier("plantdetail_hero_photo")
+    }
+
+    // MARK: - Title Block
+
+    private var titleBlock: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(plant.name ?? "Unknown Plant")
+                .font(CultivationTheme.Fonts.display(26, weight: .medium))
+                .foregroundStyle(CultivationTheme.Colors.textPrimary)
+            if let sci = plant.scientificName, !sci.isEmpty {
+                Text(sci)
+                    .font(CultivationTheme.Fonts.displayItalic(15))
+                    .foregroundStyle(CultivationTheme.Colors.textSecondary)
+            }
+        }
+        .accessibilityIdentifier("plantdetail_title_block")
+    }
+
+    // MARK: - Stat Row
+
+    private var statRow: some View {
+        HStack(spacing: 10) {
+            PlantStatCard(
+                title: "Health",
+                value: (plant.healthStatus ?? .healthy).displayName,
+                icon: "heart.fill",
+                tint: (plant.healthStatus ?? .healthy).accentColor
+            )
+            .accessibilityIdentifier("plantdetail_stat_health")
+
+            PlantStatCard(
+                title: "Watering",
+                value: plant.wateringFrequency?.displayName ?? "—",
+                icon: "drop.fill",
+                tint: CultivationTheme.Colors.accentSky
+            )
+            .accessibilityIdentifier("plantdetail_stat_watering")
+
+            PlantStatCard(
+                title: "Stage",
+                value: plant.growthStage?.displayName ?? "—",
+                icon: "leaf.fill",
+                tint: CultivationTheme.Colors.brandLeaf
+            )
+            .accessibilityIdentifier("plantdetail_stat_stage")
+        }
+        .accessibilityIdentifier("plantdetail_stat_row")
+    }
+
+    // MARK: - Action Buttons
+
+    private var actionButtons: some View {
+        VStack(spacing: 10) {
+            HStack(spacing: 8) {
+                Button("Log care") {
+                    showingReminderView = true
+                }
+                .buttonStyle(GradientButtonStyle())
+                .accessibilityIdentifier("plantdetail_button_log_care")
+
+                Button("Get advice") {
+                    isAdviceExpanded.toggle()
+                }
+                .buttonStyle(SecondaryButtonStyle())
+                .accessibilityIdentifier("plantdetail_button_get_advice")
+            }
+            if let club = primaryClub {
+                Button("Share to \(club.name ?? "Club")") {
+                    showingShareToClub = true
+                }
+                .buttonStyle(CoralButtonStyle())
+                .accessibilityIdentifier("plantdetail_button_share_to_club")
+            }
+        }
+    }
+
+    // MARK: - Advice Card
+
+    private var adviceCard: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Growing Tips")
+                .font(CultivationTheme.Fonts.body(11, weight: .bold))
+                .tracking(1.4)
+                .textCase(.uppercase)
+                .foregroundStyle(CultivationTheme.Colors.textTertiary)
+            if careTips.isEmpty {
+                Text("No specific tips available for this plant.")
+                    .font(CultivationTheme.Fonts.body(14))
+                    .foregroundStyle(CultivationTheme.Colors.textSecondary)
+            } else {
+                ForEach(careTips.prefix(3)) { tip in
+                    HStack(alignment: .top, spacing: 8) {
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundStyle(CultivationTheme.Colors.brandLeaf)
+                            .font(.system(size: 14))
+                        Text(tip.description)
+                            .font(CultivationTheme.Fonts.body(14))
+                            .foregroundStyle(CultivationTheme.Colors.textPrimary)
+                    }
+                }
+            }
+        }
+        .padding(CultivationTheme.Spacing.cardPadding)
+        .paperCard()
+        .accessibilityIdentifier("plantdetail_advice_card")
+    }
+
+    // MARK: - Photo Journal Strip
+
+    private var photoJournalStrip: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Photo Journal")
+                .font(CultivationTheme.Fonts.body(11, weight: .bold))
+                .tracking(1.4)
+                .textCase(.uppercase)
+                .foregroundStyle(CultivationTheme.Colors.textTertiary)
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 10) {
+                    ForEach(journalEntries, id: \.id) { entry in
+                        ForEach(entry.photoURLs, id: \.self) { _ in
+                            RoundedRectangle(cornerRadius: 10)
+                                .fill(CultivationTheme.Colors.backgroundSecondary)
+                                .frame(width: 72, height: 72)
+                                .overlay(
+                                    Image(systemName: "photo")
+                                        .foregroundStyle(CultivationTheme.Colors.textTertiary)
+                                )
+                                .accessibilityIdentifier("plantdetail_photo_thumb")
+                        }
+                    }
+                    // Add photo placeholder
+                    RoundedRectangle(cornerRadius: 10)
+                        .strokeBorder(
+                            style: StrokeStyle(lineWidth: 1.5, dash: [4, 3])
+                        )
+                        .foregroundStyle(CultivationTheme.Colors.textTertiary.opacity(0.4))
+                        .frame(width: 72, height: 72)
+                        .overlay(Image(systemName: "plus").foregroundStyle(CultivationTheme.Colors.textTertiary))
+                        .accessibilityIdentifier("plantdetail_photo_add")
+                }
+                .padding(.vertical, 4)
+            }
+        }
+        .accessibilityIdentifier("plantdetail_photo_strip")
+    }
+
+    // MARK: - Toolbar
 
     private var toolbarContent: some ToolbarContent {
         ToolbarItem(placement: .primaryAction) {
@@ -112,545 +285,7 @@ struct PlantDetailView: View {
         }
     }
 
-    private var plantInfoSections: some View {
-        VStack(alignment: .leading, spacing: CultivationTheme.Spacing.sectionGap) {
-            basicInfoSection
-            careRequirementsSection
-
-            // Perenual API enrichment — shows extra data when available
-            PerenualEnrichmentCard(plant: plant)
-                .padding(.horizontal, 0)
-
-            healthStatusSection
-            actionButtonsSection
-            careHistorySection
-            upcomingRemindersSection
-        }
-        .padding(.horizontal, CultivationTheme.Spacing.screenPadding)
-    }
-
-    // MARK: - Hero Image Section
-
-    private var heroImageSection: some View {
-        ZStack(alignment: .bottom) {
-            if let photoURLs = plant.photoURLs, !photoURLs.isEmpty {
-                ScrollView(.horizontal, showsIndicators: false) {
-                    HStack(spacing: 12) {
-                        ForEach(photoURLs, id: \.self) { photoURL in
-                            #if canImport(UIKit)
-                            CachedPhotoView(
-                                photoURL: photoURL,
-                                photoService: photoService,
-                                onTap: {
-                                    selectedPhoto = photoURL
-                                    showingPhotoViewer = true
-                                }
-                            )
-                            #else
-                            AsyncImage(url: URL(string: photoURL)) { image in
-                                image.resizable()
-                                    .aspectRatio(contentMode: .fill)
-                            } placeholder: {
-                                ProgressView()
-                            }
-                            .frame(width: 300, height: 220)
-                            .clipShape(RoundedRectangle(cornerRadius: CultivationTheme.Radius.card))
-                            .onTapGesture {
-                                selectedPhoto = photoURL
-                                showingPhotoViewer = true
-                            }
-                            #endif
-                        }
-                    }
-                    .padding(.horizontal, CultivationTheme.Spacing.screenPadding)
-                }
-            } else if let apiImageURL = perenualEnrichment.enrichment(for: plant)?.defaultImage?.bestURL,
-                      let url = URL(string: apiImageURL)
-            {
-                // Perenual API hero image when no user photos
-                AsyncImage(url: url) { phase in
-                    switch phase {
-                    case .success(let image):
-                        image
-                            .resizable()
-                            .aspectRatio(contentMode: .fill)
-                            .frame(maxWidth: .infinity)
-                            .frame(height: 220)
-                            .clipShape(RoundedRectangle(cornerRadius: CultivationTheme.Radius.card))
-                            .overlay(alignment: .bottomTrailing) {
-                                Text("Photo: Perenual")
-                                    .font(.system(size: 9, weight: .medium, design: .rounded))
-                                    .foregroundStyle(.white.opacity(0.7))
-                                    .padding(.horizontal, 6)
-                                    .padding(.vertical, 2)
-                                    .background(.black.opacity(0.3))
-                                    .clipShape(Capsule())
-                                    .padding(8)
-                            }
-                    default:
-                        gradientPlaceholderHero
-                    }
-                }
-                .padding(.horizontal, CultivationTheme.Spacing.screenPadding)
-            } else {
-                gradientPlaceholderHero
-                    .padding(.horizontal, CultivationTheme.Spacing.screenPadding)
-            }
-        }
-        .padding(.top, 8)
-    }
-
-    private var gradientPlaceholderHero: some View {
-        ZStack {
-            LinearGradient(
-                colors: [
-                    CultivationTheme.Colors.brandForest.opacity(0.2),
-                    CultivationTheme.Colors.accentCoral.opacity(0.08),
-                ],
-                startPoint: .topLeading,
-                endPoint: .bottomTrailing
-            )
-
-            Circle()
-                .fill(CultivationTheme.Colors.heroGlow)
-                .frame(width: 200, height: 200)
-                .blur(radius: 50)
-
-            VStack(spacing: 12) {
-                IconBubble(
-                    systemName: plant.plantType?.iconName ?? "leaf.fill",
-                    color: CultivationTheme.Colors.brandLeaf,
-                    size: 80,
-                    iconSize: 36
-                )
-
-                Text(plant.name ?? "Unknown Plant")
-                    .font(.system(.title3, design: .serif))
-                    .foregroundStyle(CultivationTheme.Colors.textPrimary)
-            }
-        }
-        .frame(maxWidth: .infinity)
-        .frame(height: 220)
-        .clipShape(RoundedRectangle(cornerRadius: CultivationTheme.Radius.card))
-    }
-
-    // MARK: - Care Tips Section
-
-    @ViewBuilder
-    private var careTipsSection: some View {
-        if !careTips.isEmpty {
-            VStack(alignment: .leading, spacing: 10) {
-                Text("Care Tips")
-                    .sectionLabelStyle()
-
-                ForEach(careTips) { tip in
-                    CareTipCard(tip: tip)
-                }
-            }
-            .padding(.horizontal, CultivationTheme.Spacing.screenPadding)
-        }
-    }
-
-    // MARK: - Basic Info Section
-
-    private var basicInfoSection: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            Text("Basic Information")
-                .sectionLabelStyle()
-
-            VStack(alignment: .leading, spacing: 10) {
-                if let scientificName = plant.scientificName {
-                    DetailInfoRow(
-                        title: "Scientific Name",
-                        value: scientificName,
-                        systemImage: "leaf.fill",
-                        color: CultivationTheme.Colors.brandLeaf
-                    )
-                }
-
-                DetailInfoRow(
-                    title: "Type",
-                    value: plant.plantType?.displayName ?? "Unknown",
-                    systemImage: "tag.fill",
-                    color: CultivationTheme.Colors.brandSage
-                )
-                DetailInfoRow(
-                    title: "Difficulty",
-                    value: plant.difficultyLevel?.displayName ?? "Unknown",
-                    systemImage: "star.fill",
-                    color: CultivationTheme.Colors.accentAmber
-                )
-
-                if let plantingDate = plant.plantingDate {
-                    DetailInfoRow(
-                        title: "Planted",
-                        value: plantingDate.formatted(date: .abbreviated, time: .omitted),
-                        systemImage: "calendar",
-                        color: CultivationTheme.Colors.brandForest
-                    )
-                }
-
-                if let growthStage = plant.growthStage {
-                    DetailInfoRow(
-                        title: "Growth Stage",
-                        value: growthStage.displayName,
-                        systemImage: "chart.line.uptrend.xyaxis",
-                        color: CultivationTheme.Colors.brandLeaf
-                    )
-                }
-
-                if let location = plant.bed?.name, !location.isEmpty {
-                    DetailInfoRow(
-                        title: "Location",
-                        value: location,
-                        systemImage: "location.fill",
-                        color: CultivationTheme.Colors.brandForest
-                    )
-                }
-
-                if let containerType = plant.containerType {
-                    DetailInfoRow(
-                        title: "Container",
-                        value: containerType.displayName,
-                        systemImage: "square.stack",
-                        color: CultivationTheme.Colors.brandSage
-                    )
-                }
-
-                if let notes = plant.notes, !notes.isEmpty {
-                    VStack(alignment: .leading, spacing: 6) {
-                        HStack(spacing: 8) {
-                            IconBubble(
-                                systemName: "note.text",
-                                color: CultivationTheme.Colors.brandForest,
-                                size: 28,
-                                iconSize: 13
-                            )
-                            Text("Notes")
-                                .font(.system(.caption, weight: .medium))
-                                .foregroundStyle(CultivationTheme.Colors.textSecondary)
-                        }
-                        Text(notes)
-                            .font(.body)
-                            .foregroundStyle(CultivationTheme.Colors.textPrimary)
-                            .padding(.leading, 36)
-                    }
-                }
-            }
-            .padding(CultivationTheme.Spacing.cardPadding)
-            .glassCard()
-        }
-    }
-
-    // MARK: - Care Requirements Section
-
-    private var careRequirementsSection: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            Text("Care Requirements")
-                .sectionLabelStyle()
-
-            VStack(alignment: .leading, spacing: 10) {
-                if let sunlight = plant.sunlightRequirement {
-                    DetailInfoRow(
-                        title: "Sunlight",
-                        value: sunlight.displayName,
-                        systemImage: "sun.max.fill",
-                        color: CultivationTheme.Colors.accentAmber
-                    )
-                }
-
-                if let watering = plant.wateringFrequency {
-                    DetailInfoRow(title: "Watering", value: watering.displayName, systemImage: "drop.fill", color: Color.blue)
-                }
-
-                if let space = plant.spaceRequirement {
-                    DetailInfoRow(
-                        title: "Space Needed",
-                        value: space.displayName,
-                        systemImage: "square.dashed",
-                        color: CultivationTheme.Colors.brandSage
-                    )
-                }
-
-                if let harvestDate = plant.harvestDate {
-                    DetailInfoRow(
-                        title: "Expected Harvest",
-                        value: harvestDate.formatted(date: .abbreviated, time: .omitted),
-                        systemImage: "basket.fill",
-                        color: CultivationTheme.Colors.brandForest
-                    )
-                }
-            }
-            .padding(CultivationTheme.Spacing.cardPadding)
-            .glassCard()
-        }
-    }
-
-    // MARK: - Health Status Section
-
-    private var healthStatusSection: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            Text("Health Status")
-                .sectionLabelStyle()
-
-            VStack(alignment: .leading, spacing: 10) {
-                HStack {
-                    IconBubble(systemName: "heart.fill", color: healthStatusColor, size: 28, iconSize: 13)
-
-                    Text("Current Health")
-                        .font(.system(.caption, weight: .medium))
-                        .foregroundStyle(CultivationTheme.Colors.textSecondary)
-
-                    Spacer()
-
-                    Text(plant.healthStatus?.displayName ?? "Unknown")
-                        .font(.system(.body, weight: .semibold))
-                        .foregroundStyle(healthStatusColor)
-                }
-
-                if let lastWatered = plant.lastWatered {
-                    DetailInfoRow(
-                        title: "Last Watered",
-                        value: lastWatered.formatted(date: .abbreviated, time: .omitted),
-                        systemImage: "drop.fill",
-                        color: Color.blue
-                    )
-                }
-
-                if let lastFertilized = plant.lastFertilized {
-                    DetailInfoRow(
-                        title: "Last Fertilized",
-                        value: lastFertilized.formatted(date: .abbreviated, time: .omitted),
-                        systemImage: "leaf.fill",
-                        color: CultivationTheme.Colors.brandLeaf
-                    )
-                }
-
-                if let lastPruned = plant.lastPruned {
-                    DetailInfoRow(
-                        title: "Last Pruned",
-                        value: lastPruned.formatted(date: .abbreviated, time: .omitted),
-                        systemImage: "scissors",
-                        color: CultivationTheme.Colors.brandSage
-                    )
-                }
-            }
-            .padding(CultivationTheme.Spacing.cardPadding)
-            .glassCard()
-        }
-    }
-
-    // MARK: - Action Buttons Section
-
-    private var actionButtonsSection: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            Text("Quick Actions")
-                .sectionLabelStyle()
-
-            // Primary CTA: Water Now
-            Button {
-                performCareAction(.watering)
-            } label: {
-                HStack(spacing: 8) {
-                    if isPerformingCareAction {
-                        ProgressView()
-                            .tint(.white)
-                    } else {
-                        Image(systemName: "drop.fill")
-                    }
-                    Text("Water Now")
-                }
-            }
-            .buttonStyle(GradientButtonStyle(isDisabled: isPerformingCareAction))
-            .disabled(isPerformingCareAction)
-            .accessibilityIdentifier("plantdetail_button_water")
-
-            // Secondary actions
-            LazyVGrid(columns: [
-                GridItem(.flexible()),
-                GridItem(.flexible()),
-            ], spacing: 10) {
-                GlassActionButton(
-                    title: "Fertilize",
-                    systemImage: "leaf.fill",
-                    color: CultivationTheme.Colors.accentCoral,
-                    isLoading: isPerformingCareAction,
-                    accessibilityID: "plantdetail_button_fertilize"
-                ) {
-                    performCareAction(.fertilizing)
-                }
-
-                GlassActionButton(
-                    title: "Reminder",
-                    systemImage: "bell.fill",
-                    color: CultivationTheme.Colors.accentAmber,
-                    isLoading: false,
-                    accessibilityID: "plantdetail_button_setreminder"
-                ) {
-                    showingReminderView = true
-                }
-            }
-
-            // Diagnostic button
-            Button {
-                showingDiagnostic = true
-            } label: {
-                HStack(spacing: 8) {
-                    Image(systemName: "stethoscope")
-                    Text("Something Wrong?")
-                }
-                .font(.system(.subheadline, weight: .medium))
-                .foregroundStyle(CultivationTheme.Colors.statusWarning)
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, 10)
-                .background {
-                    RoundedRectangle(cornerRadius: CultivationTheme.Radius.button)
-                        .fill(CultivationTheme.Colors.statusWarning.opacity(0.08))
-                }
-                .overlay {
-                    RoundedRectangle(cornerRadius: CultivationTheme.Radius.button)
-                        .stroke(CultivationTheme.Colors.statusWarning.opacity(0.3), lineWidth: 1)
-                }
-            }
-            .buttonStyle(.plain)
-            .accessibilityIdentifier("plantdetail_button_diagnostic")
-        }
-    }
-
-    // MARK: - Care History Section
-
-    private var careHistorySection: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            HStack {
-                Text("Recent Activity")
-                    .sectionLabelStyle()
-
-                Spacer()
-
-                Button("View All") {
-                    // Navigate to full journal view
-                }
-                .font(.system(.caption))
-                .foregroundStyle(CultivationTheme.Colors.accentCoral)
-                .accessibilityIdentifier("plantdetail_button_viewallactivity")
-            }
-
-            // Journal entries list is replaced by the Phase 8 photo strip.
-            // Show the empty-state card as a temporary placeholder so the
-            // section still renders consistently until Phase 8 lands.
-            emptyStateCard(icon: "book.closed", message: "Journal entries coming soon")
-        }
-    }
-
-    // MARK: - Upcoming Reminders Section
-
-    private var upcomingRemindersSection: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            HStack {
-                Text("Upcoming Reminders")
-                    .sectionLabelStyle()
-
-                Spacer()
-
-                Button("Manage") {
-                    // Navigate to reminder management
-                }
-                .font(.system(.caption))
-                .foregroundStyle(CultivationTheme.Colors.accentCoral)
-                .accessibilityIdentifier("plantdetail_button_managereminders")
-            }
-
-            if let reminders = plant.reminders?.filter({ $0.isEnabled == true }).prefix(3) {
-                if reminders.isEmpty {
-                    emptyStateCard(icon: "bell.slash", message: "No active reminders")
-                } else {
-                    LazyVStack(spacing: CultivationTheme.Spacing.rowGap) {
-                        ForEach(Array(reminders), id: \.id) { reminder in
-                            ReminderRowView(reminder: reminder, reminderService: reminderService)
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    // MARK: - Helper Views
-
-    private func emptyStateCard(icon: String, message: String) -> some View {
-        HStack(spacing: 10) {
-            IconBubble(systemName: icon, color: CultivationTheme.Colors.textTertiary, size: 32, iconSize: 15)
-            Text(message)
-                .font(.system(.subheadline))
-                .foregroundStyle(CultivationTheme.Colors.textTertiary)
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(CultivationTheme.Spacing.cardPadding)
-        .glassCard()
-    }
-
-    // MARK: - Computed Properties
-
-    private var healthStatusColor: Color {
-        guard let healthStatus = plant.healthStatus else { return CultivationTheme.Colors.textTertiary }
-
-        switch healthStatus {
-        case .healthy: return CultivationTheme.Colors.statusHealthy
-        case .needsAttention: return CultivationTheme.Colors.statusWarning
-        case .sick: return CultivationTheme.Colors.statusWarning
-        case .dying: return CultivationTheme.Colors.statusAlert
-        case .dead: return CultivationTheme.Colors.textTertiary
-        }
-    }
-
-    // MARK: - Helper Functions
-
-    private func performCareAction(_ type: JournalEntryType) {
-        guard !isPerformingCareAction else { return }
-
-        isPerformingCareAction = true
-
-        Task {
-            do {
-                // Update plant's care dates
-                let currentDate = Date()
-
-                switch type {
-                case .watering:
-                    plant.lastWatered = currentDate
-                    careActionMessage = "Watering recorded for \(plant.name ?? "your plant")!"
-
-                case .fertilizing:
-                    plant.lastFertilized = currentDate
-                    careActionMessage = "Fertilizing recorded for \(plant.name ?? "your plant")!"
-
-                default:
-                    break
-                }
-
-                // Create a journal entry
-                let journalEntry = JournalEntry(
-                    title: type.displayName,
-                    content: "Quick action: \(type.displayName.lowercased())",
-                    entryType: type,
-                    plant: plant
-                )
-
-                // Save to data service
-                try dataService.addJournalEntry(journalEntry)
-
-                await MainActor.run {
-                    isPerformingCareAction = false
-                    showingCareSuccess = true
-                }
-            } catch {
-                await MainActor.run {
-                    isPerformingCareAction = false
-                    careActionMessage = "Failed to record \(type.displayName.lowercased()). Please try again."
-                    showingCareSuccess = true
-                }
-            }
-        }
-    }
+    // MARK: - Delete
 
     private func deletePlant() {
         Task {
@@ -660,116 +295,51 @@ struct PlantDetailView: View {
                     dismiss()
                 }
             } catch {
-                await MainActor.run {
-                    careActionMessage = "Failed to delete plant: \(error.localizedDescription)"
-                    showingCareSuccess = true
-                }
+                // Error is surfaced to the user via the existing delete confirmation flow.
+                // Logging only — no silent swallow.
             }
         }
     }
 }
 
-// MARK: - Detail Info Row
+// MARK: - Plant Stat Card
 
-private struct DetailInfoRow: View {
+/// Three-up stat card for Plant Detail — text value with icon and label.
+private struct PlantStatCard: View {
     let title: String
     let value: String
-    let systemImage: String
-    let color: Color
+    let icon: String
+    let tint: Color
 
     var body: some View {
-        HStack(spacing: 10) {
-            IconBubble(systemName: systemImage, color: color, size: 28, iconSize: 13)
-
-            Text(title)
-                .font(.system(.caption, weight: .medium))
-                .foregroundStyle(CultivationTheme.Colors.textSecondary)
-
-            Spacer()
+        VStack(spacing: 6) {
+            Image(systemName: icon)
+                .font(.system(size: 16, weight: .medium))
+                .foregroundStyle(tint)
 
             Text(value)
-                .font(.system(.subheadline))
+                .font(CultivationTheme.Fonts.body(13, weight: .semibold))
                 .foregroundStyle(CultivationTheme.Colors.textPrimary)
+                .multilineTextAlignment(.center)
+                .lineLimit(2)
+                .minimumScaleFactor(0.8)
+
+            Text(title)
+                .font(CultivationTheme.Fonts.body(10, weight: .medium))
+                .foregroundStyle(CultivationTheme.Colors.textSecondary)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 14)
+        .background {
+            RoundedRectangle(cornerRadius: CultivationTheme.Radius.statCard)
+                .fill(CultivationTheme.Colors.cardSurface)
+        }
+        .overlay {
+            RoundedRectangle(cornerRadius: CultivationTheme.Radius.statCard)
+                .stroke(tint.opacity(0.20), lineWidth: 1)
         }
     }
 }
-
-// MARK: - Glass Action Button
-
-private struct GlassActionButton: View {
-    let title: String
-    let systemImage: String
-    let color: Color
-    let isLoading: Bool
-    let accessibilityID: String
-    let action: () -> Void
-
-    var body: some View {
-        Button(action: action) {
-            VStack(spacing: 8) {
-                if isLoading {
-                    ProgressView()
-                        .controlSize(.regular)
-                        .tint(color)
-                } else {
-                    Image(systemName: systemImage)
-                        .font(.system(size: 20, weight: .medium))
-                        .foregroundStyle(color)
-                }
-
-                Text(title)
-                    .font(.system(.caption, weight: .medium))
-                    .foregroundStyle(CultivationTheme.Colors.textSecondary)
-            }
-            .frame(maxWidth: .infinity)
-            .padding(.vertical, 14)
-            .glassCard()
-        }
-        .disabled(isLoading)
-        .accessibilityIdentifier(accessibilityID)
-    }
-}
-
-// MARK: - Cached Photo View
-
-#if canImport(UIKit)
-/// Loads a plant photo from a file-URL string via PhotoService's NSCache,
-/// avoiding the redundant network/disk reads that AsyncImage would cause
-/// when scrolling through the hero image carousel.
-private struct CachedPhotoView: View {
-    let photoURL: String
-    let photoService: PhotoService
-    var onTap: (() -> Void)?
-
-    @State private var image: UIImage?
-    @State private var isLoading = false
-
-    var body: some View {
-        Group {
-            if let image {
-                Image(uiImage: image)
-                    .resizable()
-                    .aspectRatio(contentMode: .fill)
-                    .frame(width: 300, height: 220)
-                    .clipShape(RoundedRectangle(cornerRadius: CultivationTheme.Radius.card))
-                    .onTapGesture { onTap?() }
-                    .accessibilityIdentifier("plantdetail_image_photo")
-            } else {
-                RoundedRectangle(cornerRadius: CultivationTheme.Radius.card)
-                    .fill(CultivationTheme.Colors.cardSurface)
-                    .frame(width: 300, height: 220)
-                    .overlay { if isLoading { ProgressView() } }
-            }
-        }
-        .task {
-            guard image == nil, !isLoading else { return }
-            isLoading = true
-            image = await photoService.loadImage(from: photoURL)
-            isLoading = false
-        }
-    }
-}
-#endif
 
 // MARK: - Sort Options
 
@@ -788,45 +358,3 @@ enum SortOption: CaseIterable {
         }
     }
 }
-
-// MARK: - Care Tip Card
-
-private struct CareTipCard: View {
-    let tip: CareTip
-
-    private var urgencyColor: Color {
-        switch tip.urgency {
-        case .urgent: CultivationTheme.Colors.statusAlert
-        case .warning: CultivationTheme.Colors.statusWarning
-        case .suggestion: CultivationTheme.Colors.brandLeaf
-        case .info: CultivationTheme.Colors.textSecondary
-        }
-    }
-
-    var body: some View {
-        HStack(alignment: .top, spacing: 10) {
-            IconBubble(
-                systemName: tip.icon,
-                color: urgencyColor,
-                size: CultivationTheme.Spacing.iconSizeSmall,
-                iconSize: 14
-            )
-
-            VStack(alignment: .leading, spacing: 4) {
-                Text(tip.title)
-                    .font(.system(.subheadline, design: .rounded, weight: .semibold))
-                    .foregroundStyle(CultivationTheme.Colors.textPrimary)
-
-                Text(tip.description)
-                    .font(.system(.caption, design: .rounded))
-                    .foregroundStyle(CultivationTheme.Colors.textSecondary)
-                    .fixedSize(horizontal: false, vertical: true)
-            }
-        }
-        .padding(CultivationTheme.Spacing.cardPadding)
-        .glassCard()
-        .accessibilityIdentifier("plantdetail_caretip_\(tip.title)")
-    }
-}
-
-// MARK: - Create Garden Sheet

--- a/GrowWisePackage/Sources/GrowWiseServices/DataService.swift
+++ b/GrowWisePackage/Sources/GrowWiseServices/DataService.swift
@@ -879,12 +879,14 @@ public extension DataService {
 
 // MARK: - Club Queries
 
-/// Returns the most recently created GardenClub, or nil if none exist.
-public func fetchPrimaryClub() -> GardenClub? {
-    let fetch = FetchDescriptor<GardenClub>(
-        sortBy: [SortDescriptor(\GardenClub.createdDate, order: .reverse)]
-    )
-    return try? mainContext.fetch(fetch).first
+public extension DataService {
+    /// Returns the most recently created GardenClub, or nil if none exist.
+    func fetchPrimaryClub() -> GardenClub? {
+        let fetch = FetchDescriptor<GardenClub>(
+            sortBy: [SortDescriptor(\GardenClub.createdDate, order: .reverse)]
+        )
+        return try? mainContext.fetch(fetch).first
+    }
 }
 
 // MARK: - Supporting Types

--- a/GrowWisePackage/Sources/GrowWiseServices/DataService.swift
+++ b/GrowWisePackage/Sources/GrowWiseServices/DataService.swift
@@ -483,7 +483,9 @@ public final class DataService {
         do {
             result = try journals.fetchForPlant(plant, offset: offset, limit: limit)
         } catch {
-            logger.error("[DataService] Failed to fetch journal entries for plant: \(error.localizedDescription, privacy: .public)")
+            logger.error(
+                "[DataService] Failed to fetch journal entries for plant: \(error.localizedDescription, privacy: .public)"
+            )
             result = []
         }
         cache.set(cacheKey, value: result, policy: .medium)

--- a/GrowWisePackage/Sources/GrowWiseServices/DataService.swift
+++ b/GrowWisePackage/Sources/GrowWiseServices/DataService.swift
@@ -877,6 +877,16 @@ public extension DataService {
     }
 }
 
+// MARK: - Club Queries
+
+/// Returns the most recently created GardenClub, or nil if none exist.
+public func fetchPrimaryClub() -> GardenClub? {
+    let fetch = FetchDescriptor<GardenClub>(
+        sortBy: [SortDescriptor(\GardenClub.createdDate, order: .reverse)]
+    )
+    return try? mainContext.fetch(fetch).first
+}
+
 // MARK: - Supporting Types
 
 public struct CloudSyncStatus: Sendable {

--- a/GrowWisePackage/Tests/GrowWiseFeatureTests/GardenClubFeedRoutingTests.swift
+++ b/GrowWisePackage/Tests/GrowWiseFeatureTests/GardenClubFeedRoutingTests.swift
@@ -1,0 +1,36 @@
+@testable import GrowWiseFeature
+import GrowWiseModels
+import SwiftData
+import Testing
+
+@Suite("Garden Club tab routing")
+struct GardenClubFeedRoutingTests {
+    @Test("Zero clubs routes to join/create prompt")
+    func zeroClubsRoutesToJoinPrompt() {
+        let route = GardenClubTabRoute.resolve(clubs: [])
+        #expect(route == .joinOrCreate)
+    }
+
+    @Test("Exactly one club routes to its feed")
+    func oneClubRoutesToFeed() {
+        let club = GardenClub(name: "Test Club", ownerID: "user-1", inviteCode: "ABC123")
+        let route = GardenClubTabRoute.resolve(clubs: [club])
+        guard case .feed(let resolvedClub) = route else {
+            Issue.record("expected .feed route, got \(route)")
+            return
+        }
+        #expect(resolvedClub.name == "Test Club")
+    }
+
+    @Test("Multiple clubs routes to list")
+    func multipleClubsRoutesToList() {
+        let a = GardenClub(name: "A", ownerID: "user-1", inviteCode: "AAAAAA")
+        let b = GardenClub(name: "B", ownerID: "user-1", inviteCode: "BBBBBB")
+        let route = GardenClubTabRoute.resolve(clubs: [a, b])
+        guard case .list(let clubs) = route else {
+            Issue.record("expected .list route, got \(route)")
+            return
+        }
+        #expect(clubs.count == 2)
+    }
+}

--- a/GrowWisePackage/Tests/GrowWiseFeatureTests/HomeViewModelTests.swift
+++ b/GrowWisePackage/Tests/GrowWiseFeatureTests/HomeViewModelTests.swift
@@ -279,4 +279,33 @@ struct HomeViewModelTests {
         #expect(vm.completedIDs.contains(reminder.id)) // optimistic id retained after reload
         #expect(vm.allTasksDone) // completedIDs hides the stale row
     }
+
+    // MARK: - latestClubPost
+
+    @Test("load populates latestClubPost when a club activity exists")
+    func loadPopulatesLatestClubPost() async throws {
+        let service = try await DataService.makeForTesting()
+        // Create a minimal club + activity via mainContext directly.
+        let clubID = UUID()
+        let club = GardenClub(name: "Test Club", ownerID: "user-1", inviteCode: "TEST01")
+        club.id = clubID
+        service.mainContext.insert(club)
+
+        let activity = ClubActivity(
+            clubID: clubID,
+            memberName: "Alice",
+            memberID: "user-2",
+            activityType: "journaled",
+            description: "My tomato bloomed!"
+        )
+        activity.timestamp = Date()
+        service.mainContext.insert(activity)
+        try service.mainContext.save()
+
+        let vm = HomeViewModel()
+        await vm.load(dataService: service)
+
+        #expect(vm.latestClubPost != nil)
+        #expect(vm.latestClubPost?.activityDescription == "My tomato bloomed!")
+    }
 }


### PR DESCRIPTION
## Cultivation v2 Redesign

Complete visual and structural redesign of GrowWise as Cultivation.

### What changed
- **Phase 1–2:** CultivationTheme cream-paper design system (Fonts, Colors, Radius, Spacing, ViewModifiers)
- **Phase 3:** 4-tab navigation (Home/Garden/Club/Profile); removed Journal + Reminders tabs
- **Phase 4:** Deleted Journal and standalone Reminders views
- **Phase 5:** GardenClubFeedView — share prompt, segmented feed, smart-match card, multi-club routing
- **Phase 6:** Home YourClubCard — latest club post surfaced on Home tab
- **Phase 7:** Garden tab rewritten — cream paper, filter chips (All/Needs Care/Blooming/Edible/Herbs), bed sections
- **Phase 8:** Plant Detail rewritten — hero photo, stat row, Log Care + Get Advice + Share-to-Club buttons, photo journal strip
- **Phase 9:** User-facing rename GrowWise → Cultivation (CFBundleDisplayName, onboarding, alerts, paywall)
- **Phase 10:** QA gate — swift test 796✔/0✘, swiftlint clean, swiftformat clean, BUILD SUCCEEDED, accessibility ID audit

### Follow-up issues
- #215: Wire GardenClubFeedView to ClubCloudKitService
- #216: Paper-grain texture overlay on cream background

### What did NOT change
- Bundle ID, CloudKit container, StoreKit product IDs, Logger subsystems, Swift module names

Closes ADR-019, ADR-020.