### PR TITLE
fix: add/delete garden accessibility in GardenView (closes #256)

### DIFF
--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/GardenView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/GardenView.swift
@@ -48,7 +48,7 @@ public struct GardenView: View { // swiftlint:disable:this type_body_length
                 ScrollView {
                     VStack(alignment: .leading, spacing: 12) {
                         gardenHeader
-                        if viewModel.gardens.count > 1 {
+                        if viewModel.gardens.count >= 1 {
                             gardenPicker
                         }
                         gardenSummaryStrip
@@ -309,8 +309,19 @@ public struct GardenView: View { // swiftlint:disable:this type_body_length
                             }
                     }
                     .buttonStyle(.plain)
+                    .contextMenu {
+                        if viewModel.gardens.count > 1 {
+                            Button(role: .destructive) {
+                                gardenToDelete = garden
+                                showDeleteConfirmation = true
+                            } label: {
+                                Label("Delete Garden", systemImage: "trash")
+                            }
+                            .accessibilityIdentifier("garden_context_delete")
+                        }
+                    }
                     .accessibilityIdentifier(
-                        "garden_picker_\(garden.name?.lowercased().replacingOccurrences(of: " ", with: "_") ?? "unknown")"
+                        "garden_picker_chip_\(garden.name?.lowercased().replacingOccurrences(of: " ", with: "_") ?? "unknown")"
                     )
                 }
 
@@ -407,6 +418,15 @@ public struct GardenView: View { // swiftlint:disable:this type_body_length
                     .font(CultivationTheme.Fonts.body(14))
                     .foregroundStyle(CultivationTheme.Colors.textSecondary)
                     .multilineTextAlignment(.center)
+            }
+
+            if viewModel.gardens.isEmpty {
+                Button("Create Garden") {
+                    showCreateGarden = true
+                }
+                .buttonStyle(GradientButtonStyle())
+                .padding(.horizontal, 24)
+                .accessibilityIdentifier("garden_button_create_garden")
             }
 
             Button("Add Plant") {

--- a/docs/PRD-256-add-delete-garden.md
+++ b/docs/PRD-256-add-delete-garden.md
@@ -1,0 +1,47 @@
+# PRD #256: Cannot Add or Delete Garden
+
+## Issue
+Since the UI refresh, users cannot add or delete gardens in Cultivation (GrowWise).
+
+## Root Cause
+1. **Add garden**: The "New Garden" (`+`) button only appears in `gardenPicker`, which is gated by `viewModel.gardens.count > 1`. If user has 0 or 1 garden, the picker row is hidden — no way to add a garden.
+2. **Delete garden**: The `gardenToDelete` state exists and the alert confirmation is wired up, but no UI trigger sets it. The garden picker chips have no long-press, swipe, or context menu to initiate deletion.
+
+## Files to Modify
+- `GrowWisePackage/Sources/GrowWiseFeature/Views/GardenView.swift` — main view
+
+## Tasks
+
+### T1: Make "Add Garden" always accessible
+- If `gardens.count == 0`: Show the "Add Plant" empty state but also add a "Create Garden" CTA button before it (can't add plants without a garden)
+- If `gardens.count == 1`: Show the gardenPicker row (removes the `count > 1` gate). The single garden chip + "New" `+` button should always be visible.
+- If `gardens.count > 1`: Already works (picker is shown). No change needed.
+- **Approach**: Change the condition from `count > 1` to `count >= 1`, and add a "Create Garden" button in the empty state for `count == 0`.
+
+### T2: Add garden delete interaction
+- Add `.contextMenu` to each garden picker chip with a "Delete Garden" option
+- Tapping "Delete Garden" sets `gardenToDelete` and `showDeleteConfirmation = true`
+- The existing alert and `viewModel.deleteGarden()` call handles the rest
+- Do NOT allow deleting the last garden without at least one other garden existing (guard: `viewModel.gardens.count > 1`)
+- Add appropriate accessibility identifiers: `garden_context_delete`, `garden_picker_chip_{name}`
+
+### T3: Verify
+- Build: `xcodebuild -project GrowWise.xcodeproj -scheme GrowWise -destination 'generic/platform=iOS Simulator' build CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
+- The existing tests should pass
+- Manual verification: garden picker shows for 1+ gardens, add button works, context menu delete works
+
+## Constraints
+- Follow existing CultivationTheme design tokens (colors, fonts, spacing, radius)
+- Use existing animation patterns (`CultivationTheme.Animation.selection`)
+- Use `.buttonStyle(.plain)` on all custom buttons
+- Add accessibility identifiers following `{screen}_{element}_{descriptor}` snake_case convention
+- Do not modify `GardenViewModel` or `DataService` — the create/delete logic already works
+- Swift 6 strict concurrency — no Sendable violations
+
+## Definition of Done
+- [ ] "Add Garden" is accessible when 0 gardens exist
+- [ ] "Add Garden" is accessible when 1 garden exists (gardenPicker always visible)
+- [ ] Garden picker chips have context menu with "Delete Garden"
+- [ ] Cannot delete the only remaining garden
+- [ ] Build succeeds for iOS Simulator target
+- [ ] Accessibility identifiers added


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Link to the beads issue: `bd show GW-XXX` -->

Closes: <!-- GW-XXX -->

## Changes

<!-- List the key changes made -->

- 

## Testing Done

<!-- How was this tested? Check all that apply -->

- [ ] `cd GrowWisePackage && swift test` passes
- [ ] Manually tested on iOS Simulator (specify version/device)
- [ ] SwiftLint passes: `swiftlint lint --config .swiftlint.yml`
- [ ] SwiftFormat passes: `swiftformat --lint --config .swiftformat GrowWisePackage/Sources GrowWise`

## Architecture Impact

<!-- Does this change the data model, service interfaces, or concurrency model? -->

- [ ] No architectural changes
- [ ] SwiftData model changes (CloudKit-compatible?)
- [ ] New service or service interface change
- [ ] Concurrency model change (`@MainActor`, Actor, async/await)
- [ ] Security-sensitive change (Keychain, encryption, auth)

## Checklist

- [ ] Code follows MV architecture (no ViewModels)
- [ ] No `as!` force casts or force unwraps (`!`)
- [ ] No `try?` silencing errors in views
- [ ] All `@Model` properties are optional or have defaults (CloudKit compatibility)
- [ ] New UI elements have `.accessibilityIdentifier()`
- [ ] No print statements (use Logger/OSLog)
- [ ] TODO/FIXME comments include beads issue reference (e.g., `TODO(GW-123): ...`)

## Screenshots / Recording

<!-- For UI changes, include before/after screenshots or a screen recording -->
