### PR TITLE
Feature/cultivation 1.0

### DIFF
--- a/GrowWisePackage/Sources/GrowWiseFeature/Main/MainAppView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Main/MainAppView.swift
@@ -111,7 +111,7 @@ public struct MainAppView: View {
 
     private var mainTabView: some View {
         TabView(selection: $selectedTab) {
-            HomeView()
+            HomeView(selectedTab: $selectedTab)
                 .tabItem {
                     Label("Home", systemImage: "house.fill")
                 }

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/Garden/CommonPlantIssuesView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/Garden/CommonPlantIssuesView.swift
@@ -14,7 +14,7 @@ struct PlantIssue: Identifiable {
 // MARK: - CommonPlantIssuesView
 
 /// Shows common issues for a given plant type with symptoms and treatments.
-/// Includes a button to open PlantScannerView for camera-based diagnosis.
+/// Includes a button to open PlantScannerView for a camera-based plant health check.
 struct CommonPlantIssuesView: View {
     let plant: Plant
 

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/Garden/CommonPlantIssuesView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/Garden/CommonPlantIssuesView.swift
@@ -81,7 +81,7 @@ struct CommonPlantIssuesView: View {
                     .padding(.bottom, 32)
                 }
             }
-            .navigationTitle("Plant Diagnostics")
+            .navigationTitle("Plant Health Guidance")
             .gwNavigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .confirmationAction) {

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/GardenClub/ClubShareComposerSheet.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/GardenClub/ClubShareComposerSheet.swift
@@ -11,6 +11,7 @@ public struct ClubShareComposerSheet: View {
     @Environment(\.dismiss) private var dismiss
 
     let plant: Plant?
+    let initialCaption: String?
     var onPost: () -> Void = {}
 
     @State private var caption = ""
@@ -29,9 +30,13 @@ public struct ClubShareComposerSheet: View {
         return plant?.name
     }
 
-    public init(plant: Plant? = nil, onPost: @escaping () -> Void = {}) {
+    public init(plant: Plant? = nil, initialCaption: String? = nil, onPost: @escaping () -> Void = {}) {
         self.plant = plant
+        self.initialCaption = initialCaption
         self.onPost = onPost
+        if let ic = initialCaption {
+            _caption = State(initialValue: ic)
+        }
     }
 
     public var body: some View {

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/GardenClub/ClubShareComposerSheet.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/GardenClub/ClubShareComposerSheet.swift
@@ -127,6 +127,7 @@ public struct ClubShareComposerSheet: View {
                         )
                 }
                 .accessibilityLabel(includePlant ? "Remove plant context" : "Add plant context")
+                .accessibilityIdentifier("share_composer_button_plant_toggle")
             }
             .padding(.horizontal, 14)
             .padding(.vertical, 10)

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/GardenClub/ClubShareComposerSheet.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/GardenClub/ClubShareComposerSheet.swift
@@ -1,0 +1,226 @@
+import GrowWiseModels
+import GrowWiseServices
+import SwiftUI
+
+/// Sheet for composing and posting a new Garden Club activity.
+///
+/// Accepts an optional `plant` for pre-filling context. Calls `onPost` on
+/// success so the parent can refresh its feed.
+public struct ClubShareComposerSheet: View {
+    @Environment(DataService.self) private var dataService
+    @Environment(\.dismiss) private var dismiss
+
+    let plant: Plant?
+    var onPost: () -> Void = {}
+
+    @State private var caption = ""
+    @State private var includePlant = true
+    @State private var isPosting = false
+    @State private var errorMessage: String?
+    @State private var showError = false
+    @State private var clubName = "Your Club"
+
+    private var captionIsEmpty: Bool {
+        caption.trimmingCharacters(in: .whitespaces).isEmpty
+    }
+
+    private var resolvedPlantName: String? {
+        guard includePlant else { return nil }
+        return plant?.name
+    }
+
+    public init(plant: Plant? = nil, onPost: @escaping () -> Void = {}) {
+        self.plant = plant
+        self.onPost = onPost
+    }
+
+    public var body: some View {
+        NavigationStack {
+            ZStack {
+                CultivationTheme.Colors.background.ignoresSafeArea()
+                scrollContent
+            }
+            .navigationTitle("Share with \(clubName)")
+            .gwNavigationBarTitleDisplayMode(.inline)
+            .toolbar { toolbarContent }
+            .alert("Couldn't post", isPresented: $showError) {
+                Button("OK") { showError = false }
+                    .accessibilityIdentifier("share_composer_alert_error")
+            } message: {
+                Text(errorMessage ?? "Something went wrong.")
+            }
+            .task { loadClubName() }
+        }
+        .accessibilityIdentifier("screen_share_composer")
+    }
+
+    // MARK: - Scroll content
+
+    private var scrollContent: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: CultivationTheme.Spacing.sectionGap) {
+                captionSection
+                if plant != nil {
+                    plantContextSection
+                }
+                postFooterHint
+            }
+            .padding(.horizontal, CultivationTheme.Spacing.screenPadding)
+            .padding(.top, CultivationTheme.Spacing.sectionGap)
+            .padding(.bottom, 40)
+        }
+    }
+
+    // MARK: - Caption section
+
+    private var captionSection: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("What's growing?")
+                .sectionLabelStyle()
+                .padding(.leading, 4)
+
+            TextField(
+                "Share an update, tip, or harvest story…",
+                text: $caption,
+                axis: .vertical
+            )
+            .font(CultivationTheme.Fonts.body(15))
+            .foregroundStyle(CultivationTheme.Colors.textPrimary)
+            .lineLimit(5 ... 12)
+            .frame(minHeight: 120, alignment: .topLeading)
+            .padding(CultivationTheme.Spacing.cardPadding)
+            .glassCard()
+            .accessibilityIdentifier("share_composer_textfield_caption")
+        }
+    }
+
+    // MARK: - Plant context chip
+
+    private var plantContextSection: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Plant context")
+                .sectionLabelStyle()
+                .padding(.leading, 4)
+
+            HStack(spacing: 8) {
+                Image(systemName: "leaf.fill")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(CultivationTheme.Colors.brandSage)
+
+                Text(plant?.name ?? "")
+                    .font(CultivationTheme.Fonts.body(13, weight: .semibold))
+                    .foregroundStyle(CultivationTheme.Colors.brandSage)
+
+                Spacer()
+
+                Button {
+                    withAnimation(CultivationTheme.Animation.selection) {
+                        includePlant.toggle()
+                    }
+                } label: {
+                    Image(systemName: includePlant ? "xmark.circle.fill" : "plus.circle.fill")
+                        .font(.system(size: 16, weight: .medium))
+                        .foregroundStyle(
+                            includePlant
+                                ? CultivationTheme.Colors.textTertiary
+                                : CultivationTheme.Colors.brandSage
+                        )
+                }
+                .accessibilityLabel(includePlant ? "Remove plant context" : "Add plant context")
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 10)
+            .background(
+                RoundedRectangle(cornerRadius: CultivationTheme.Radius.pill)
+                    .fill(
+                        includePlant
+                            ? CultivationTheme.Colors.smartTagBackground
+                            : CultivationTheme.Colors.backgroundSecondary
+                    )
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: CultivationTheme.Radius.pill)
+                    .stroke(
+                        includePlant
+                            ? CultivationTheme.Colors.brandLeaf.opacity(0.4)
+                            : CultivationTheme.Colors.cardBorder,
+                        lineWidth: 1
+                    )
+            )
+            .accessibilityIdentifier("share_composer_chip_plant")
+        }
+    }
+
+    // MARK: - Footer hint
+
+    private var postFooterHint: some View {
+        Text("Your post will be visible to club members.")
+            .font(CultivationTheme.Fonts.body(12))
+            .foregroundStyle(CultivationTheme.Colors.textTertiary)
+            .frame(maxWidth: .infinity, alignment: .center)
+    }
+
+    // MARK: - Toolbar
+
+    @ToolbarContentBuilder
+    private var toolbarContent: some ToolbarContent {
+        ToolbarItem(placement: .cancellationAction) {
+            Button("Cancel") { dismiss() }
+                .foregroundStyle(CultivationTheme.Colors.textSecondary)
+                .accessibilityIdentifier("share_composer_button_cancel")
+        }
+        ToolbarItem(placement: .confirmationAction) {
+            postButton
+        }
+    }
+
+    @ViewBuilder
+    private var postButton: some View {
+        if isPosting {
+            ProgressView()
+                .tint(CultivationTheme.Colors.accentCoral)
+        } else {
+            Button("Post") {
+                Task<Void, Never> { await submitPost() }
+            }
+            .fontWeight(.semibold)
+            .foregroundStyle(
+                captionIsEmpty
+                    ? CultivationTheme.Colors.textTertiary
+                    : CultivationTheme.Colors.accentCoral
+            )
+            .disabled(captionIsEmpty)
+            .accessibilityIdentifier("share_composer_button_post")
+        }
+    }
+
+    // MARK: - Actions
+
+    @MainActor
+    private func submitPost() async {
+        let trimmed = caption.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else { return }
+
+        isPosting = true
+        defer { isPosting = false }
+
+        do {
+            try dataService.createClubPost(
+                caption: trimmed,
+                activityType: "shared",
+                plantName: resolvedPlantName
+            )
+            onPost()
+            dismiss()
+        } catch {
+            errorMessage = error.localizedDescription
+            showError = true
+        }
+    }
+
+    private func loadClubName() {
+        if let name = dataService.fetchPrimaryClub()?.name {
+            clubName = name
+        }
+    }
+}

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/GardenClub/GardenClubFeedView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/GardenClub/GardenClubFeedView.swift
@@ -86,10 +86,9 @@ public struct GardenClubFeedView: View { // swiftlint:disable:this type_body_len
         .task { await load() }
         .sheet(isPresented: $isPresentingComposer) {
             ClubShareComposerSheet(plant: nil, onPost: {
-                Task { await load() }
+                Task<Void, Never> { await load() }
             })
             .environment(dataService)
-            .environment(locationService)
         }
     }
 

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/GardenClub/GardenClubFeedView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/GardenClub/GardenClubFeedView.swift
@@ -85,10 +85,11 @@ public struct GardenClubFeedView: View { // swiftlint:disable:this type_body_len
         #endif
         .task { await load() }
         .sheet(isPresented: $isPresentingComposer) {
-            // Share composer — real composer wiring is a follow-up issue.
-            // First cut: placeholder so the prompt is reachable.
-            Text("Share composer placeholder")
-                .padding()
+            ClubShareComposerSheet(plant: nil, onPost: {
+                Task { await load() }
+            })
+            .environment(dataService)
+            .environment(locationService)
         }
     }
 

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/GardenView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/GardenView.swift
@@ -54,42 +54,46 @@ public struct GardenView: View { // swiftlint:disable:this type_body_length
                 ScrollView {
                     VStack(alignment: .leading, spacing: 12) {
                         gardenHeader
-                        if viewModel.gardens.count > 1 {
-                            gardenPicker
-                        }
-                        gardenSummaryStrip
-                        filterChipBar
                         if viewModel.isLoading {
                             loadingState
-                        } else if viewModel.groupedPlants.isEmpty {
-                            emptyState
+                        } else if viewModel.gardens.isEmpty {
+                            noGardenEmptyState
                         } else {
-                            if filteredGroups.isEmpty {
-                                filterEmptyState
+                            if viewModel.gardens.count > 1 {
+                                gardenPicker
+                            }
+                            gardenSummaryStrip
+                            filterChipBar
+                            if viewModel.groupedPlants.isEmpty {
+                                emptyState
                             } else {
-                                ForEach(filteredGroups) { group in
-                                    GardenBedSection(
-                                        group: group,
-                                        onPlantTap: { plant in selectedPlant = plant },
-                                        onQuickAction: { _ in },
-                                        onDelete: { plant in
-                                            Task<Void, Never> {
-                                                do {
-                                                    try dataService.plants.delete(plant)
-                                                } catch {
-                                                    viewModel.error = error
+                                if filteredGroups.isEmpty {
+                                    filterEmptyState
+                                } else {
+                                    ForEach(filteredGroups) { group in
+                                        GardenBedSection(
+                                            group: group,
+                                            onPlantTap: { plant in selectedPlant = plant },
+                                            onQuickAction: { _ in },
+                                            onDelete: { plant in
+                                                Task<Void, Never> {
+                                                    do {
+                                                        try dataService.plants.delete(plant)
+                                                    } catch {
+                                                        viewModel.error = error
+                                                    }
+                                                    await viewModel.load(dataService: dataService)
                                                 }
-                                                await viewModel.load(dataService: dataService)
                                             }
-                                        }
-                                    )
-                                    .accessibilityIdentifier(
-                                        "garden_bed_\(group.displayName.lowercased().replacingOccurrences(of: " ", with: "_"))"
-                                    )
+                                        )
+                                        .accessibilityIdentifier(
+                                            "garden_bed_\(group.displayName.lowercased().replacingOccurrences(of: " ", with: "_"))"
+                                        )
+                                    }
                                 }
                             }
+                            addBedButton
                         }
-                        addBedButton
                     }
                     .padding(.horizontal, CultivationTheme.Spacing.screenPadding)
                     .padding(.top, 12)
@@ -375,6 +379,40 @@ public struct GardenView: View { // swiftlint:disable:this type_body_length
     }
 
     // MARK: - Empty States
+
+    private var noGardenEmptyState: some View {
+        VStack(spacing: 20) {
+            ZStack {
+                Circle()
+                    .fill(CultivationTheme.Colors.brandLeaf.opacity(0.08))
+                    .frame(width: 120, height: 120)
+
+                Image(systemName: "house.and.flag.fill")
+                    .font(.system(size: 48))
+                    .foregroundStyle(CultivationTheme.Colors.brandLeaf)
+            }
+
+            VStack(spacing: 6) {
+                Text("Start your garden")
+                    .font(CultivationTheme.Fonts.display(20, weight: .medium))
+                    .foregroundStyle(CultivationTheme.Colors.textPrimary)
+
+                Text("Create a garden to track your plants, beds, and care schedules.")
+                    .font(CultivationTheme.Fonts.body(14))
+                    .foregroundStyle(CultivationTheme.Colors.textSecondary)
+                    .multilineTextAlignment(.center)
+            }
+
+            Button("Create Garden") {
+                showCreateGarden = true
+            }
+            .buttonStyle(GradientButtonStyle())
+            .padding(.horizontal, 24)
+            .accessibilityIdentifier("garden_button_create_first")
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.top, 40)
+    }
 
     private var emptyState: some View {
         VStack(spacing: 20) {

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/GardenView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/GardenView.swift
@@ -391,6 +391,7 @@ public struct GardenView: View { // swiftlint:disable:this type_body_length
                     .font(.system(size: 48))
                     .foregroundStyle(CultivationTheme.Colors.brandLeaf)
             }
+            .accessibilityHidden(true)
 
             VStack(spacing: 6) {
                 Text("Start your garden")

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/Home/HomeViewModel.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/Home/HomeViewModel.swift
@@ -124,7 +124,8 @@ final class HomeViewModel {
 
     // MARK: - Complete
 
-    func complete(reminder: PlantReminder, dataService: DataService) async {
+    @discardableResult
+    func complete(reminder: PlantReminder, dataService: DataService) async -> Bool {
         // Optimistic: slide the row away immediately
         _ = withAnimation(CultivationTheme.Animation.card) {
             completedIDs.insert(reminder.id)
@@ -157,11 +158,12 @@ final class HomeViewModel {
                 completedIDs.remove(reminder.id)
             }
             errorMessage = "Failed to complete reminder: \(error.localizedDescription)"
-            return
+            return false
         }
 
         // After animation settles, reload to get fresh state (updated nextDueDate etc.)
         try? await Task.sleep(nanoseconds: 400_000_000)
         await load(dataService: dataService)
+        return true
     }
 }

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/HomeView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/HomeView.swift
@@ -136,8 +136,8 @@ public struct HomeView: View {
         return HStack(spacing: 10) {
             Button {
                 Task<Void, Never> {
-                    await viewModel.complete(reminder: reminder, dataService: dataService)
-                    if dataService.fetchPrimaryClub() != nil {
+                    let succeeded = await viewModel.complete(reminder: reminder, dataService: dataService)
+                    if succeeded, dataService.fetchPrimaryClub() != nil {
                         careShareCaption = postCareCaption(for: reminder)
                         showCareShareSheet = true
                     }

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/HomeView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/HomeView.swift
@@ -13,6 +13,8 @@ public struct HomeView: View {
 
     @Binding var selectedTab: TabSelection
     @State private var viewModel = HomeViewModel()
+    @State private var showCareShareSheet = false
+    @State private var careShareCaption = ""
 
     public init(selectedTab: Binding<TabSelection>) {
         _selectedTab = selectedTab
@@ -68,6 +70,10 @@ public struct HomeView: View {
                     .accessibilityIdentifier("home_alert_button_ok")
             } message: {
                 Text(viewModel.errorMessage ?? "")
+            }
+            .sheet(isPresented: $showCareShareSheet) {
+                ClubShareComposerSheet(initialCaption: careShareCaption)
+                    .environment(dataService)
             }
             .accessibilityIdentifier("home_screen")
         }
@@ -131,6 +137,10 @@ public struct HomeView: View {
             Button {
                 Task<Void, Never> {
                     await viewModel.complete(reminder: reminder, dataService: dataService)
+                    if dataService.fetchPrimaryClub() != nil {
+                        careShareCaption = postCareCaption(for: reminder)
+                        showCareShareSheet = true
+                    }
                 }
             } label: {
                 RoundedRectangle(cornerRadius: 6)
@@ -323,6 +333,18 @@ public struct HomeView: View {
 
     private var seasonalContextTitle: String {
         seasonalContext.title
+    }
+
+    // MARK: - Share Prompt
+
+    private func postCareCaption(for reminder: PlantReminder) -> String {
+        let plantName = reminder.plant?.name ?? "my plant"
+        switch reminder.reminderType {
+        case .watering: return "Just watered \(plantName) 💧"
+        case .fertilizing: return "Fed \(plantName) today 🌿"
+        case .pruning: return "Pruned \(plantName) ✂️"
+        default: return "Took care of \(plantName) today"
+        }
     }
 
     // MARK: - Empty State

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/HomeView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/HomeView.swift
@@ -11,9 +11,12 @@ public struct HomeView: View {
     @Environment(LocationService.self)
     private var locationService
 
+    @Binding var selectedTab: TabSelection
     @State private var viewModel = HomeViewModel()
 
-    public init() {}
+    public init(selectedTab: Binding<TabSelection>) {
+        _selectedTab = selectedTab
+    }
 
     // MARK: - Body
 
@@ -25,14 +28,15 @@ public struct HomeView: View {
                         .padding(.horizontal, CultivationTheme.Spacing.screenPadding)
                         .padding(.top, CultivationTheme.Spacing.sectionGap)
 
-                    NavigationLink {
-                        GardenClubFeedView()
+                    Button {
+                        selectedTab = .club
                     } label: {
                         clubCard
                     }
                     .buttonStyle(.plain)
+                    .accessibilityLabel("Open Garden Club")
+                    .accessibilityIdentifier("home_card_club")
                     .padding(.horizontal, CultivationTheme.Spacing.screenPadding)
-                    .accessibilityIdentifier("home_button_your_club")
 
                     SeasonalTipCard()
                         .padding(.horizontal, CultivationTheme.Spacing.screenPadding)
@@ -381,6 +385,6 @@ private struct HomeClubPlaceholderCard: View {
 #Preview {
     // swiftlint:disable:next force_try
     let dataService = try! DataService()
-    HomeView()
+    HomeView(selectedTab: .constant(.home))
         .environment(dataService)
 }

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/MyGardenPlantDetailView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/MyGardenPlantDetailView.swift
@@ -64,7 +64,9 @@ struct PlantDetailView: View {
             AddReminderView(reminderService: reminderService, dataService: dataService)
         }
         .sheet(isPresented: $showingShareToClub) {
-            PublishGardenSheet()
+            // No feed to reload here; GardenClubFeedView reloads on .task when navigated back to.
+            ClubShareComposerSheet(plant: plant, onPost: {})
+                .environment(dataService)
         }
         .sheet(isPresented: $showingEditPlant) {
             Text("Edit Plant View - To be implemented")

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/MyGardenPlantDetailView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/MyGardenPlantDetailView.swift
@@ -20,7 +20,6 @@ struct PlantDetailView: View {
 
     // MARK: - State
 
-    @State private var showingEditPlant = false
     @State private var showingDeleteConfirmation = false
     @State private var showingReminderView = false
     @State private var showingAssignGarden = false
@@ -67,9 +66,6 @@ struct PlantDetailView: View {
             // No feed to reload here; GardenClubFeedView reloads on .task when navigated back to.
             ClubShareComposerSheet(plant: plant, onPost: {})
                 .environment(dataService)
-        }
-        .sheet(isPresented: $showingEditPlant) {
-            Text("Edit Plant View - To be implemented")
         }
         .sheet(isPresented: $showingAssignGarden) {
             AssignGardenSheet(plant: plant)
@@ -316,10 +312,6 @@ private extension PlantDetailView {
     var toolbarContent: some ToolbarContent {
         ToolbarItem(placement: .primaryAction) {
             Menu {
-                Button("Edit Plant") {
-                    showingEditPlant = true
-                }
-
                 Button("Assign to Garden") { showingAssignGarden = true }
 
                 Button {

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/PaywallView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/PaywallView.swift
@@ -18,9 +18,9 @@ public struct PaywallView: View {
 
     // Product IDs
     private let premiumMonthlyID = "com.growwise.premium.monthly"
-    private let premiumYearlyID = "com.growwise.premium.yearly"
+    private let premiumYearlyID = "com.growwise.premium.annual"
     private let proMonthlyID = "com.growwise.pro.monthly"
-    private let proYearlyID = "com.growwise.pro.yearly"
+    private let proYearlyID = "com.growwise.pro.annual"
 
     public init() {}
 

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/PaywallView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/PaywallView.swift
@@ -216,8 +216,8 @@ public struct PaywallView: View {
                 highlights: [
                     "Everything in Premium",
                     "Expert consultations",
-                    "Community features",
                     "Advanced analytics",
+                    "Priority support",
                 ],
                 color: CultivationTheme.Colors.accentAmber,
                 isCurrent: currentTierIs(.pro),
@@ -393,7 +393,7 @@ public struct PaywallView: View {
                 comparisonRow(feature: "Weather Adjust", free: false, premium: true, pro: true)
                 comparisonRow(feature: "Priority Support", free: false, premium: true, pro: true)
                 comparisonRow(feature: "Expert Consults", free: false, premium: false, pro: true)
-                comparisonRow(feature: "Community", free: false, premium: false, pro: true)
+                comparisonRow(feature: "Garden Clubs", free: true, premium: true, pro: true)
                 comparisonRow(feature: "Analytics", free: "Basic", premium: "Standard", pro: true, isLast: true)
             }
             .glassCard()

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/PaywallView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/PaywallView.swift
@@ -9,7 +9,7 @@ public struct PaywallView: View {
     @Environment(\.dismiss)
     private var dismiss
 
-    @State private var isYearly = false
+    @State private var isYearly = true
     @State private var selectedTier: SubscriptionTier?
     @State private var purchaseError: String?
     @State private var showPurchaseError = false
@@ -123,7 +123,7 @@ public struct PaywallView: View {
             }
             .accessibilityIdentifier("paywall_toggle_monthly")
 
-            toggleButton(label: "Yearly", isActive: isYearly, badge: "Save 44%") {
+            toggleButton(label: "Yearly", isActive: isYearly, badge: "Best Value") {
                 withAnimation(CultivationTheme.Animation.selection) {
                     isYearly = true
                 }
@@ -194,7 +194,7 @@ public struct PaywallView: View {
                 tier: .premium,
                 name: "Premium",
                 icon: "crown",
-                price: isYearly ? "$19.99" : "$2.99",
+                price: isYearly ? "$34.99" : "$2.99",
                 period: isYearly ? "/year" : "/month",
                 highlights: [
                     "Unlimited AI diagnoses",
@@ -221,7 +221,8 @@ public struct PaywallView: View {
                 ],
                 color: CultivationTheme.Colors.accentAmber,
                 isCurrent: currentTierIs(.pro),
-                isPopular: true
+                isPopular: true,
+                subtitle: "Coming soon"
             )
             .accessibilityIdentifier("paywall_card_pro")
         }
@@ -245,7 +246,8 @@ public struct PaywallView: View {
         highlights: [String],
         color: Color,
         isCurrent: Bool,
-        isPopular: Bool = false
+        isPopular: Bool = false,
+        subtitle: String? = nil
     ) -> some View {
         let isSelected = selectedTier == tier
 
@@ -297,6 +299,10 @@ public struct PaywallView: View {
                             Text("Free forever")
                                 .font(.system(.caption))
                                 .foregroundStyle(CultivationTheme.Colors.textSecondary)
+                        } else if let subtitle {
+                            Text(subtitle)
+                                .font(.system(.caption))
+                                .foregroundStyle(CultivationTheme.Colors.textTertiary)
                         }
                     }
 
@@ -485,7 +491,7 @@ public struct PaywallView: View {
         let tierName = tier == .pro ? "Pro" : "Premium"
         let price = tier == .pro
             ? (isYearly ? "$29.99/yr" : "$4.99/mo")
-            : (isYearly ? "$19.99/yr" : "$2.99/mo")
+            : (isYearly ? "$34.99/yr" : "$2.99/mo")
         return "Subscribe to \(tierName) — \(price)"
     }
 

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/PaywallView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/PaywallView.swift
@@ -184,7 +184,7 @@ public struct PaywallView: View {
                 icon: "leaf",
                 price: "$0",
                 period: "forever",
-                highlights: ["3 AI diagnoses/month", "Basic care reminders", "Up to 50 plants"],
+                highlights: ["3 Plant Health checks/month", "Basic care reminders", "Up to 50 plants"],
                 color: CultivationTheme.Colors.textSecondary,
                 isCurrent: !isActiveSubscriber
             )
@@ -197,7 +197,7 @@ public struct PaywallView: View {
                 price: isYearly ? "$34.99" : "$2.99",
                 period: isYearly ? "/year" : "/month",
                 highlights: [
-                    "Unlimited AI diagnoses",
+                    "Unlimited Plant Health checks",
                     "Smart reminders",
                     "Weather adjustments",
                     "Priority support",
@@ -387,7 +387,7 @@ public struct PaywallView: View {
                 Divider()
                     .background(CultivationTheme.Colors.divider)
 
-                comparisonRow(feature: "AI Diagnoses", free: "3/mo", premium: true, pro: true)
+                comparisonRow(feature: "Plant Health Guidance", free: "3/mo", premium: true, pro: true)
                 comparisonRow(feature: "Plant Limit", free: "50", premium: "500", pro: true)
                 comparisonRow(feature: "Smart Reminders", free: false, premium: true, pro: true)
                 comparisonRow(feature: "Weather Adjust", free: false, premium: true, pro: true)

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/PlantScannerView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/PlantScannerView.swift
@@ -42,7 +42,6 @@ public struct PlantScannerView: View {
                             Text("Primary Finding: \(diagnosis.primaryLabel)")
                                 .font(.headline)
                                 .accessibilityIdentifier("scannerPrimaryFinding")
-                            Text("Confidence: \(Int(diagnosis.confidence * 100))%")
                             Text("Severity: \(diagnosis.severity.rawValue.capitalized)")
                             Text(diagnosis.recommendation)
                                 .font(.subheadline)

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/ProfileView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/ProfileView.swift
@@ -26,7 +26,7 @@ public struct ProfileView: View {
 
     // Product IDs
     private let monthlyProductID = "com.growwise.premium.monthly"
-    private let yearlyProductID = "com.growwise.premium.yearly"
+    private let yearlyProductID = "com.growwise.premium.annual"
 
     public init() {}
 

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/ProfileView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/ProfileView.swift
@@ -384,7 +384,7 @@ public struct ProfileView: View {
                 }
                 Text("Unlock GrowWise Premium")
                     .font(.title3.bold())
-                Text("Get unlimited diagnoses, expert tips, and more.")
+                Text("Get unlimited care guidance, premium tips, and more.")
                     .font(.subheadline)
                     .foregroundColor(.secondary)
                     .multilineTextAlignment(.center)
@@ -403,8 +403,8 @@ public struct ProfileView: View {
                 planCard(
                     productID: yearlyProductID,
                     title: "Yearly",
-                    price: "$19.99/yr",
-                    detail: "Save 44% — only $1.67/mo",
+                    price: "$34.99/yr",
+                    detail: "Best value — only $2.92/mo",
                     accessibilityID: "profile_subscribe_yearly"
                 )
             }

--- a/GrowWisePackage/Sources/GrowWiseServices/DataService+GardenClub.swift
+++ b/GrowWisePackage/Sources/GrowWiseServices/DataService+GardenClub.swift
@@ -46,4 +46,52 @@ public extension DataService {
         let repo = ClubActivityRepository(context: mainContext)
         return try repo.fetchAll(for: clubID)
     }
+
+    // MARK: - Posting
+
+    /// Create and persist a new ClubActivity post for the current user's primary club.
+    /// - Parameters:
+    ///   - caption: The post body text (required, non-empty).
+    ///   - activityType: One of "shared", "watered", "harvested", "planted", etc.
+    ///   - plantName: Optional plant name prepended to the description.
+    /// - Throws: `CreateClubPostError.noClub` if the user is not in any club.
+    @discardableResult
+    func createClubPost(
+        caption: String,
+        activityType: String,
+        plantName: String? = nil
+    ) throws -> ClubActivity {
+        guard let club = fetchPrimaryClub(), let clubID = club.id else {
+            throw CreateClubPostError.noClub
+        }
+        let user = getCurrentUser()
+        let memberName = user?.displayName ?? "Gardener"
+        let memberID = user?.id.uuidString ?? UUID().uuidString
+        let description: String = if let plantName {
+            "\(plantName): \(caption)"
+        } else {
+            caption
+        }
+        let activity = ClubActivity(
+            clubID: clubID,
+            memberName: memberName,
+            memberID: memberID,
+            activityType: activityType,
+            description: description
+        )
+        let repo = ClubActivityRepository(context: mainContext)
+        try repo.save(activity)
+        return activity
+    }
+}
+
+public enum CreateClubPostError: Error, LocalizedError {
+    case noClub
+
+    public var errorDescription: String? {
+        switch self {
+        case .noClub:
+            "You're not in a club yet. Join or create one first."
+        }
+    }
 }

--- a/GrowWisePackage/Sources/GrowWiseServices/DataService.swift
+++ b/GrowWisePackage/Sources/GrowWiseServices/DataService.swift
@@ -907,7 +907,7 @@ public extension DataService {
 
     /// Returns the single most-recent ClubActivity across all clubs.
     /// Used by HomeViewModel to populate the "Your Club" card.
-    public func fetchLatestClubActivity() throws -> ClubActivity? {
+    func fetchLatestClubActivity() throws -> ClubActivity? {
         var descriptor = FetchDescriptor<ClubActivity>(
             sortBy: [SortDescriptor(\.timestamp, order: .reverse)]
         )

--- a/GrowWisePackage/Sources/GrowWiseServices/SubscriptionService.swift
+++ b/GrowWisePackage/Sources/GrowWiseServices/SubscriptionService.swift
@@ -22,14 +22,15 @@ public final class SubscriptionService {
     private var updateListenerTask: Task<Void, Never>?
     private let logger = Logger(subsystem: "com.growwise.storekit", category: "SubscriptionService")
 
-    /// Product IDs (must match App Store Connect)
+    /// Product IDs (must match App Store Connect).
+    /// .yearly IDs retained to load legacy subscriber entitlements; .annual IDs are the active purchase path for 1.0+.
     private let productIDs = [
         "com.growwise.premium.monthly",
-        "com.growwise.premium.yearly",
-        "com.growwise.premium.annual",
+        "com.growwise.premium.yearly", // legacy — kept for existing subscribers
+        "com.growwise.premium.annual", // active: $34.99/yr
         "com.growwise.pro.monthly",
-        "com.growwise.pro.yearly",
-        "com.growwise.pro.annual",
+        "com.growwise.pro.yearly", // legacy
+        "com.growwise.pro.annual", // active: $79.99/yr
     ]
 
     // MARK: - Initialization

--- a/GrowWisePackage/Sources/GrowWiseServices/SubscriptionService.swift
+++ b/GrowWisePackage/Sources/GrowWiseServices/SubscriptionService.swift
@@ -26,8 +26,10 @@ public final class SubscriptionService {
     private let productIDs = [
         "com.growwise.premium.monthly",
         "com.growwise.premium.yearly",
+        "com.growwise.premium.annual",
         "com.growwise.pro.monthly",
         "com.growwise.pro.yearly",
+        "com.growwise.pro.annual",
     ]
 
     // MARK: - Initialization

--- a/GrowWisePackage/Tests/GrowWiseServicesTests/DataServiceGardenClubTests.swift
+++ b/GrowWisePackage/Tests/GrowWiseServicesTests/DataServiceGardenClubTests.swift
@@ -1,0 +1,41 @@
+@testable import GrowWiseModels
+@testable import GrowWiseServices
+import Testing
+
+@Suite("DataService — createClubPost")
+@MainActor
+struct DataServiceGardenClubTests {
+    @Test("createClubPost throws noClub when user has no club")
+    func createClubPostThrowsWhenNoClub() async throws {
+        let service = try await DataService.makeForTesting()
+        #expect(throws: CreateClubPostError.noClub) {
+            try service.createClubPost(caption: "Hello", activityType: "shared")
+        }
+    }
+
+    @Test("createClubPost saves activity with caption when club exists")
+    func createClubPostSavesActivity() async throws {
+        let service = try await DataService.makeForTesting()
+
+        let club = try service.createClub(name: "Test Club", ownerID: "u1")
+        _ = club // ensure it's in SwiftData
+
+        let activity = try service.createClubPost(caption: "Tomatoes are coming in!", activityType: "shared")
+        #expect(activity.activityDescription == "Tomatoes are coming in!")
+        #expect(activity.activityType == "shared")
+        #expect(activity.clubID == club.id)
+    }
+
+    @Test("createClubPost prefixes plant name when provided")
+    func createClubPostWithPlantName() async throws {
+        let service = try await DataService.makeForTesting()
+        _ = try service.createClub(name: "Herb Garden Club", ownerID: "u1")
+
+        let activity = try service.createClubPost(
+            caption: "Looking healthy!",
+            activityType: "shared",
+            plantName: "Basil"
+        )
+        #expect(activity.activityDescription == "Basil: Looking healthy!")
+    }
+}


### PR DESCRIPTION
This pull request introduces several user experience improvements and new features, most notably the addition of the `ClubShareComposerSheet` for sharing posts to the Garden Club, enhancements to the Home and Garden views, and improved navigation and empty state handling. Below are the most important changes grouped by theme:

**New Features and Club Integration:**
- Added the new `ClubShareComposerSheet` component, enabling users to compose and post updates to their Garden Club, with support for plant context and error handling. This is now integrated into the Garden Club feed, Home view, and plant detail view. [[1]](diffhunk://#diff-c3ec3f4258723d29b7c2ff314c921e0af722c3ea7e37e2eb639bce13c0593846R1-R232) [[2]](diffhunk://#diff-442b605d548003d0945819584ec4ffdc6e676f85aba17bfb742ee1edb539f4deL88-R91) [[3]](diffhunk://#diff-be0857617904d6dbed4a86a720bae9e1a821a4a2e7432fdd4b303f85e754968aR74-R77) [[4]](diffhunk://#diff-a0dc502202bb49e3d17fe59732264c38053a34121a2184c87edca35798378795L67-R68)
- When completing a plant care reminder from the Home view, if the user belongs to a club, a share sheet is triggered with a pre-filled caption based on the completed action, encouraging sharing care activities. [[1]](diffhunk://#diff-10591ca354fbb41f8a62005d749cb87ac9952934377b500a7ec2665a438a4be6L127-R128) [[2]](diffhunk://#diff-10591ca354fbb41f8a62005d749cb87ac9952934377b500a7ec2665a438a4be6L160-R167) [[3]](diffhunk://#diff-be0857617904d6dbed4a86a720bae9e1a821a4a2e7432fdd4b303f85e754968aL129-R143) [[4]](diffhunk://#diff-be0857617904d6dbed4a86a720bae9e1a821a4a2e7432fdd4b303f85e754968aR338-R349)

**Navigation and UI Improvements:**
- Refactored `HomeView` to accept a `selectedTab` binding, allowing the Home screen's "Your Club" card to switch tabs directly rather than using a navigation link, improving navigation flow. [[1]](diffhunk://#diff-75f347dfaee9c478ea2f2193d441c554ea59a62533cc9b48b9cf56ab25ff6d97L114-R114) [[2]](diffhunk://#diff-be0857617904d6dbed4a86a720bae9e1a821a4a2e7432fdd4b303f85e754968aR14-R21) [[3]](diffhunk://#diff-be0857617904d6dbed4a86a720bae9e1a821a4a2e7432fdd4b303f85e754968aL28-L35) [[4]](diffhunk://#diff-be0857617904d6dbed4a86a720bae9e1a821a4a2e7432fdd4b303f85e754968aL384-R410)
- Updated the navigation title in `CommonPlantIssuesView` to "Plant Health Guidance" for better clarity.

**Garden and Plant Views:**
- Improved `GardenView`'s empty state handling: when no gardens exist, a new onboarding-style empty state is shown with a call-to-action to create a garden. The logic for showing loading, empty, and content states has been clarified and refactored. [[1]](diffhunk://#diff-fc8b99c8057838db830884bc633affa7b18ff73ad57b52bd7bec8a023f599d38R57-R67) [[2]](diffhunk://#diff-fc8b99c8057838db830884bc633affa7b18ff73ad57b52bd7bec8a023f599d38R97) [[3]](diffhunk://#diff-fc8b99c8057838db830884bc633affa7b18ff73ad57b52bd7bec8a023f599d38R383-R417)
- Removed the unused "Edit Plant" button from the plant detail view's toolbar, and updated the share sheet integration for sharing to the club from plant details. [[1]](diffhunk://#diff-a0dc502202bb49e3d17fe59732264c38053a34121a2184c87edca35798378795L23) [[2]](diffhunk://#diff-a0dc502202bb49e3d17fe59732264c38053a34121a2184c87edca35798378795L317-L320) [[3]](diffhunk://#diff-a0dc502202bb49e3d17fe59732264c38053a34121a2184c87edca35798378795L67-R68)

**Other UI/UX Tweaks:**
- Changed the default subscription selection in `PaywallView` to yearly, likely to encourage longer-term subscriptions.
- Minor documentation and copy improvements for clarity, such as updating the description of the camera-based plant health check.## Summary

<!-- What does this PR do? Link to the beads issue: `bd show GW-XXX` -->

Closes: <!-- GW-XXX -->

## Changes

<!-- List the key changes made -->

- 

## Testing Done

<!-- How was this tested? Check all that apply -->

- [ ] `cd GrowWisePackage && swift test` passes
- [ ] Manually tested on iOS Simulator (specify version/device)
- [ ] SwiftLint passes: `swiftlint lint --config .swiftlint.yml`
- [ ] SwiftFormat passes: `swiftformat --lint --config .swiftformat GrowWisePackage/Sources GrowWise`

## Architecture Impact

<!-- Does this change the data model, service interfaces, or concurrency model? -->

- [ ] No architectural changes
- [ ] SwiftData model changes (CloudKit-compatible?)
- [ ] New service or service interface change
- [ ] Concurrency model change (`@MainActor`, Actor, async/await)
- [ ] Security-sensitive change (Keychain, encryption, auth)

## Checklist

- [ ] Code follows MV architecture (no ViewModels)
- [ ] No `as!` force casts or force unwraps (`!`)
- [ ] No `try?` silencing errors in views
- [ ] All `@Model` properties are optional or have defaults (CloudKit compatibility)
- [ ] New UI elements have `.accessibilityIdentifier()`
- [ ] No print statements (use Logger/OSLog)
- [ ] TODO/FIXME comments include beads issue reference (e.g., `TODO(GW-123): ...`)

## Screenshots / Recording

<!-- For UI changes, include before/after screenshots or a screen recording -->
