### PR TITLE
fix(#274): implement full reminder editing

### DIFF
--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/EditReminderView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/EditReminderView.swift
@@ -1,0 +1,58 @@
+import GrowWiseModels
+import GrowWiseServices
+import SwiftUI
+
+public struct EditReminderView: View {
+    let reminder: PlantReminder
+    let reminderService: ReminderService
+    let onSave: () -> Void
+    let onDelete: (PlantReminder) -> Void
+
+    @Environment(\.dismiss)
+    private var dismiss
+
+    public init(
+        reminder: PlantReminder,
+        reminderService: ReminderService,
+        onSave: @escaping () -> Void,
+        onDelete: @escaping (PlantReminder) -> Void
+    ) {
+        self.reminder = reminder
+        self.reminderService = reminderService
+        self.onSave = onSave
+        self.onDelete = onDelete
+    }
+
+    public var body: some View {
+        // Body filled in by Task 8.
+        Text("EditReminderView pending")
+    }
+}
+
+extension EditReminderView {
+    struct FormState: Equatable {
+        var title: String
+        var message: String
+        var type: ReminderType
+        var frequency: ReminderFrequency
+        var customDays: Int
+        var preferredTime: Date
+        var priority: ReminderPriority
+        var enableWeatherAdjustment: Bool
+        var isEnabled: Bool
+
+        static func initial(from reminder: PlantReminder) -> FormState {
+            FormState(
+                title: reminder.title,
+                message: reminder.message,
+                type: reminder.reminderType,
+                frequency: reminder.frequency,
+                customDays: reminder.customFrequencyDays ?? max(1, reminder.frequency.days),
+                preferredTime: reminder.preferredNotificationTime ?? reminder.nextDueDate,
+                priority: reminder.priority,
+                enableWeatherAdjustment: reminder.enableWeatherAdjustment,
+                isEnabled: reminder.isEnabled
+            )
+        }
+    }
+}

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/EditReminderView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/EditReminderView.swift
@@ -11,6 +11,20 @@ public struct EditReminderView: View {
     @Environment(\.dismiss)
     private var dismiss
 
+    @State private var title: String
+    @State private var message: String
+    @State private var reminderType: ReminderType
+    @State private var frequency: ReminderFrequency
+    @State private var customDays: Int
+    @State private var preferredTime: Date
+    @State private var priority: ReminderPriority
+    @State private var enableWeatherAdjustment: Bool
+    @State private var isPaused: Bool
+
+    @State private var isSaving = false
+    @State private var saveTask: Task<Void, Never>?
+    @State private var errorMessage: String?
+
     public init(
         reminder: PlantReminder,
         reminderService: ReminderService,
@@ -21,11 +35,393 @@ public struct EditReminderView: View {
         self.reminderService = reminderService
         self.onSave = onSave
         self.onDelete = onDelete
+        let initial = FormState.initial(from: reminder)
+        _title = State(initialValue: initial.title)
+        _message = State(initialValue: initial.message)
+        _reminderType = State(initialValue: initial.type)
+        _frequency = State(initialValue: initial.frequency)
+        _customDays = State(initialValue: initial.customDays)
+        _preferredTime = State(initialValue: initial.preferredTime)
+        _priority = State(initialValue: initial.priority)
+        _enableWeatherAdjustment = State(initialValue: initial.enableWeatherAdjustment)
+        _isPaused = State(initialValue: !initial.isEnabled)
     }
 
     public var body: some View {
-        // Body filled in by Task 8.
-        Text("EditReminderView pending")
+        NavigationStack {
+            ZStack {
+                CultivationTheme.Colors.backgroundSecondary
+                    .ignoresSafeArea()
+
+                ScrollView {
+                    VStack(spacing: CultivationTheme.Spacing.sectionGap) {
+                        Capsule()
+                            .fill(CultivationTheme.Colors.cardBorder)
+                            .frame(width: 36, height: 4)
+                            .padding(.top, 8)
+
+                        plantHeader
+                        reminderTypeSection
+                        frequencySection
+                        timingSection
+                        prioritySection
+                        customContentSection
+                        pauseSection
+
+                        Button(role: .destructive) {
+                            onDelete(reminder)
+                            dismiss()
+                        } label: {
+                            HStack(spacing: 8) {
+                                Image(systemName: "trash")
+                                Text("Delete Reminder")
+                            }
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 14)
+                        }
+                        .buttonStyle(.bordered)
+                        .tint(CultivationTheme.Colors.statusAlert)
+                        .padding(.horizontal, CultivationTheme.Spacing.screenPadding)
+                        .accessibilityIdentifier("editreminder_button_delete")
+
+                        Button {
+                            save()
+                        } label: {
+                            HStack(spacing: 8) {
+                                if isSaving {
+                                    ProgressView().tint(.white)
+                                } else {
+                                    Image(systemName: "checkmark.circle.fill")
+                                }
+                                Text(isSaving ? "Saving..." : "Save Changes")
+                            }
+                        }
+                        .buttonStyle(GradientButtonStyle(isDisabled: isSaving))
+                        .disabled(isSaving)
+                        .padding(.horizontal, CultivationTheme.Spacing.screenPadding)
+                        .accessibilityIdentifier("plantreminder_button_edit_save")
+                        .padding(.bottom, 24)
+                    }
+                }
+
+                if isSaving {
+                    ZStack {
+                        CultivationTheme.Colors.textPrimary.opacity(0.25)
+                            .ignoresSafeArea()
+                        VStack(spacing: 16) {
+                            ProgressView().scaleEffect(1.2)
+                            Text("Saving changes...")
+                                .font(.headline)
+                                .foregroundStyle(CultivationTheme.Colors.textPrimary)
+                        }
+                        .padding(32)
+                        .paperCard()
+                    }
+                }
+            }
+            .navigationTitle("Edit Reminder")
+            .gwNavigationBarTitleDisplayMode(.inline)
+            .onDisappear { saveTask?.cancel() }
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                        .accessibilityIdentifier("plantreminder_button_edit_cancel")
+                }
+            }
+            .alert("Error", isPresented: .constant(errorMessage != nil)) {
+                Button("OK") { errorMessage = nil }
+            } message: {
+                if let errorMessage {
+                    Text(errorMessage)
+                }
+            }
+        }
+    }
+
+    // MARK: - Plant header (read-only)
+
+    private var plantHeader: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Plant")
+                .sectionLabelStyle()
+                .padding(.horizontal, CultivationTheme.Spacing.screenPadding)
+
+            HStack(spacing: 12) {
+                IconBubble(
+                    systemName: plantIcon(for: reminder.plant),
+                    color: plantColor(for: reminder.plant),
+                    size: 36,
+                    iconSize: 16
+                )
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(reminder.plant?.name ?? "Unknown Plant")
+                        .font(.system(.headline, design: .serif))
+                        .foregroundStyle(CultivationTheme.Colors.textPrimary)
+                    Text(reminder.plant?.plantType?.displayName ?? "Unknown Type")
+                        .font(.system(.caption))
+                        .foregroundStyle(CultivationTheme.Colors.textSecondary)
+                }
+
+                Spacer()
+            }
+            .padding(CultivationTheme.Spacing.cardPadding)
+            .glassCard()
+            .padding(.horizontal, CultivationTheme.Spacing.screenPadding)
+        }
+    }
+
+    // MARK: - Form sections
+
+    private var reminderTypeSection: some View {
+        formSection(title: "Reminder Type") {
+            VStack(alignment: .leading, spacing: 10) {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 8) {
+                        ForEach(ReminderType.allCases, id: \.self) { type in
+                            GlassPill(
+                                label: type.displayName,
+                                isSelected: reminderType == type,
+                                accessibilityID: "editreminder_pill_type_\(type.rawValue)"
+                            ) {
+                                reminderType = type
+                            }
+                        }
+                    }
+                }
+                Text(reminderType.defaultMessage)
+                    .font(.system(.caption))
+                    .foregroundStyle(CultivationTheme.Colors.textTertiary)
+            }
+        }
+    }
+
+    private var frequencySection: some View {
+        formSection(title: "Frequency") {
+            VStack(alignment: .leading, spacing: 10) {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 8) {
+                        ForEach(frequencyOptions, id: \.self) { freq in
+                            GlassPill(
+                                label: freq.displayName,
+                                isSelected: frequency == freq,
+                                // swiftlint:disable:next line_length
+                                accessibilityID: "editreminder_pill_frequency_\(freq.displayName.lowercased().replacingOccurrences(of: " ", with: "_"))"
+                            ) {
+                                frequency = freq
+                            }
+                        }
+                    }
+                }
+
+                if case .custom = frequency {
+                    HStack {
+                        Text("Every")
+                            .font(.system(.subheadline))
+                            .foregroundStyle(CultivationTheme.Colors.textSecondary)
+                        Spacer()
+                        TextField("Days", value: $customDays, format: .number)
+                            .textFieldStyle(.roundedBorder)
+                            .frame(width: 80)
+                            .accessibilityIdentifier("editreminder_textfield_customdays")
+                        Text("days")
+                            .font(.system(.subheadline))
+                            .foregroundStyle(CultivationTheme.Colors.textSecondary)
+                    }
+                }
+            }
+        }
+    }
+
+    private var timingSection: some View {
+        formSection(title: "Timing") {
+            VStack(spacing: 12) {
+                HStack {
+                    IconBubble(systemName: "clock.fill", color: CultivationTheme.Colors.brandForest, size: 28, iconSize: 13)
+                    DatePicker("Preferred Time", selection: $preferredTime, displayedComponents: .hourAndMinute)
+                        .font(.system(.subheadline))
+                        .accessibilityIdentifier("editreminder_datepicker_time")
+                }
+
+                Divider().background(CultivationTheme.Colors.divider)
+
+                HStack {
+                    IconBubble(systemName: "cloud.sun.fill", color: CultivationTheme.Colors.accentAmber, size: 28, iconSize: 13)
+                    Text("Smart Weather Adjustment")
+                        .font(.system(.subheadline))
+                        .foregroundStyle(CultivationTheme.Colors.textPrimary)
+                    Spacer()
+                    Toggle("", isOn: $enableWeatherAdjustment)
+                        .accessibilityIdentifier("editreminder_toggle_weatheradjustment")
+                }
+            }
+        }
+    }
+
+    private var prioritySection: some View {
+        formSection(title: "Priority") {
+            HStack(spacing: 8) {
+                // swiftlint:disable:next identifier_name
+                ForEach(ReminderPriority.allCases, id: \.self) { p in
+                    GlassPill(
+                        label: p.displayName,
+                        isSelected: priority == p,
+                        accessibilityID: "editreminder_pill_priority_\(p.displayName.lowercased())"
+                    ) {
+                        priority = p
+                    }
+                }
+            }
+        }
+    }
+
+    private var customContentSection: some View {
+        formSection(title: "Title & Message") {
+            VStack(spacing: 12) {
+                HStack(spacing: 10) {
+                    IconBubble(systemName: "textformat", color: CultivationTheme.Colors.brandSage, size: 28, iconSize: 13)
+                    ValidatedTextField(
+                        "Title",
+                        text: $title,
+                        validation: { ValidationService.shared.validateText($0, fieldName: "Title", maxLength: 100) }
+                    )
+                    .accessibilityIdentifier("editreminder_textfield_title")
+                }
+
+                Divider().background(CultivationTheme.Colors.divider)
+
+                HStack(alignment: .top, spacing: 10) {
+                    IconBubble(systemName: "text.alignleft", color: CultivationTheme.Colors.brandSage, size: 28, iconSize: 13)
+                        .padding(.top, 2)
+
+                    ZStack(alignment: .topLeading) {
+                        TextEditor(text: $message)
+                            .frame(minHeight: 80)
+                            .font(.system(.body))
+                            .foregroundStyle(CultivationTheme.Colors.textPrimary)
+                            .scrollContentBackground(.hidden)
+                            .background(Color.clear)
+                            .accessibilityIdentifier("editreminder_texteditor_message")
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 8)
+                                    .stroke(CultivationTheme.Colors.cardBorder, lineWidth: 1)
+                            )
+                            .onChange(of: message) { _, newValue in
+                                let validation = ValidationService.shared.validateText(
+                                    newValue, fieldName: "Message", maxLength: 500
+                                )
+                                if !validation.isValid {
+                                    message = String(newValue.prefix(500))
+                                }
+                            }
+
+                        if message.isEmpty {
+                            Text("Message")
+                                .foregroundStyle(CultivationTheme.Colors.textTertiary)
+                                .padding(.horizontal, 4)
+                                .padding(.vertical, 8)
+                                .allowsHitTesting(false)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private var pauseSection: some View {
+        formSection(title: "Status") {
+            HStack {
+                IconBubble(systemName: "pause.circle.fill", color: CultivationTheme.Colors.textSecondary, size: 28, iconSize: 13)
+                Text("Pause Reminder")
+                    .font(.system(.subheadline))
+                    .foregroundStyle(CultivationTheme.Colors.textPrimary)
+                Spacer()
+                Toggle("", isOn: $isPaused)
+                    .accessibilityIdentifier("editreminder_toggle_pause")
+            }
+        }
+    }
+
+    // MARK: - Section builder
+
+    private func formSection(title: String, @ViewBuilder content: () -> some View) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title)
+                .sectionLabelStyle()
+                .padding(.horizontal, CultivationTheme.Spacing.screenPadding)
+            content()
+                .padding(CultivationTheme.Spacing.cardPadding)
+                .glassCard()
+                .padding(.horizontal, CultivationTheme.Spacing.screenPadding)
+        }
+    }
+
+    // MARK: - Computed
+
+    private var frequencyOptions: [ReminderFrequency] {
+        [.daily, .everyOtherDay, .twiceWeekly, .weekly, .biweekly, .monthly, .custom]
+    }
+
+    // MARK: - Helpers
+
+    private func plantIcon(for plant: Plant?) -> String {
+        switch plant?.plantType {
+        case .houseplant: "house.fill"
+        case .succulent: "circle.hexagongrid.fill"
+        case .herb: "leaf.fill"
+        case .vegetable: "carrot.fill"
+        case .flower: "camera.macro"
+        case .fruit: "apple.logo"
+        case .tree: "tree.fill"
+        case .shrub: "leaf.circle.fill"
+        case .none: "questionmark.circle.fill"
+        }
+    }
+
+    private func plantColor(for plant: Plant?) -> Color {
+        switch plant?.plantType {
+        case .houseplant, .herb, .shrub: CultivationTheme.Colors.brandLeaf
+        case .succulent: .mint
+        case .vegetable: .orange
+        case .flower: .pink
+        case .fruit: .red
+        case .tree: .brown
+        case .none: CultivationTheme.Colors.textTertiary
+        }
+    }
+
+    // MARK: - Save
+
+    private func save() {
+        isSaving = true
+        saveTask = Task<Void, Never> {
+            do {
+                try await reminderService.updateReminder(
+                    reminder,
+                    title: title,
+                    message: message,
+                    type: reminderType,
+                    frequency: frequency,
+                    customFrequencyDays: frequency == .custom ? customDays : nil,
+                    preferredTime: preferredTime,
+                    priority: priority,
+                    enableWeatherAdjustment: enableWeatherAdjustment,
+                    isEnabled: !isPaused
+                )
+                let impact = UIImpactFeedbackGenerator(style: .medium)
+                impact.impactOccurred()
+                await MainActor.run {
+                    isSaving = false
+                    onSave()
+                    dismiss()
+                }
+            } catch {
+                await MainActor.run {
+                    isSaving = false
+                    errorMessage = error.localizedDescription
+                }
+            }
+        }
     }
 }
 

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/PlantReminderDetailView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/PlantReminderDetailView.swift
@@ -78,7 +78,7 @@ public struct PlantReminderDetailView: View {
                     }
             }
             .sheet(item: $selectedReminder) { reminder in
-                EditReminderViewPlaceholder(
+                EditReminderView(
                     reminder: reminder,
                     reminderService: reminderService,
                     onSave: { loadReminders() },
@@ -674,37 +674,6 @@ struct SuggestionCard: View {
             RoundedRectangle(cornerRadius: 12)
                 .fill(Color(.tertiarySystemGroupedBackground))
         )
-    }
-}
-
-/// Placeholder for EditReminderView
-struct EditReminderViewPlaceholder: View {
-    let reminder: PlantReminder
-    let reminderService: ReminderService
-    let onSave: () -> Void
-    let onDelete: (PlantReminder) -> Void
-
-    @Environment(\.dismiss)
-    private var dismiss
-
-    var body: some View {
-        NavigationStack {
-            Text("Edit Reminder - Coming Soon")
-                .navigationTitle("Edit Reminder")
-                .toolbar {
-                    ToolbarItem(placement: .cancellationAction) {
-                        Button("Cancel") { dismiss() }
-                            .accessibilityIdentifier("plantreminder_button_edit_cancel")
-                    }
-                    ToolbarItem(placement: .primaryAction) {
-                        Button("Save") {
-                            onSave()
-                            dismiss()
-                        }
-                        .accessibilityIdentifier("plantreminder_button_edit_save")
-                    }
-                }
-        }
     }
 }
 

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/PlantReminderDetailView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/PlantReminderDetailView.swift
@@ -78,7 +78,7 @@ public struct PlantReminderDetailView: View {
                     }
             }
             .sheet(item: $selectedReminder) { reminder in
-                EditReminderView(
+                EditReminderViewPlaceholder(
                     reminder: reminder,
                     reminderService: reminderService,
                     onSave: { loadReminders() },
@@ -678,7 +678,7 @@ struct SuggestionCard: View {
 }
 
 /// Placeholder for EditReminderView
-struct EditReminderView: View {
+struct EditReminderViewPlaceholder: View {
     let reminder: PlantReminder
     let reminderService: ReminderService
     let onSave: () -> Void

--- a/GrowWisePackage/Tests/GrowWiseFeatureTests/EditReminderViewTests.swift
+++ b/GrowWisePackage/Tests/GrowWiseFeatureTests/EditReminderViewTests.swift
@@ -1,0 +1,88 @@
+import Foundation
+@testable import GrowWiseFeature
+@testable import GrowWiseModels
+import Testing
+
+@Suite("EditReminderView.FormState mapping")
+struct EditReminderViewTests {
+    @Test("FormState.initial maps all editable fields")
+    func mapsAllFields() {
+        let preferred = Date(timeIntervalSinceReferenceDate: 100_000)
+        let reminder = PlantReminder(
+            title: "Water the basil",
+            message: "Check for dry soil first",
+            reminderType: .watering,
+            frequency: .biweekly,
+            nextDueDate: Date(),
+            plant: nil
+        )
+        reminder.priority = .high
+        reminder.enableWeatherAdjustment = true
+        reminder.preferredNotificationTime = preferred
+        reminder.customFrequencyDays = nil
+        reminder.isEnabled = true
+
+        let state = EditReminderView.FormState.initial(from: reminder)
+
+        #expect(state.title == "Water the basil")
+        #expect(state.message == "Check for dry soil first")
+        #expect(state.type == .watering)
+        #expect(state.frequency == .biweekly)
+        #expect(state.preferredTime == preferred)
+        #expect(state.priority == .high)
+        #expect(state.enableWeatherAdjustment == true)
+        #expect(state.isEnabled == true)
+    }
+
+    @Test("FormState.initial uses nextDueDate when preferredNotificationTime is nil")
+    func defaultsPreferredTimeToNextDueDate() {
+        let dueDate = Date(timeIntervalSinceReferenceDate: 200_000)
+        let reminder = PlantReminder(
+            title: "Test",
+            message: "Test",
+            reminderType: .watering,
+            frequency: .weekly,
+            nextDueDate: dueDate,
+            plant: nil
+        )
+        reminder.preferredNotificationTime = nil
+
+        let state = EditReminderView.FormState.initial(from: reminder)
+
+        #expect(state.preferredTime == dueDate)
+    }
+
+    @Test("FormState.initial defaults customDays to frequency.days when nil")
+    func defaultsCustomDaysFromFrequency() {
+        let reminder = PlantReminder(
+            title: "Test",
+            message: "Test",
+            reminderType: .watering,
+            frequency: .weekly,
+            nextDueDate: Date(),
+            plant: nil
+        )
+        reminder.customFrequencyDays = nil
+
+        let state = EditReminderView.FormState.initial(from: reminder)
+
+        #expect(state.customDays == ReminderFrequency.weekly.days)
+    }
+
+    @Test("FormState.initial preserves customDays when set")
+    func preservesCustomDays() {
+        let reminder = PlantReminder(
+            title: "Test",
+            message: "Test",
+            reminderType: .watering,
+            frequency: .custom,
+            nextDueDate: Date(),
+            plant: nil
+        )
+        reminder.customFrequencyDays = 5
+
+        let state = EditReminderView.FormState.initial(from: reminder)
+
+        #expect(state.customDays == 5)
+    }
+}

--- a/GrowWisePackage/Tests/GrowWiseServicesTests/ReminderServiceUpdateTests.swift
+++ b/GrowWisePackage/Tests/GrowWiseServicesTests/ReminderServiceUpdateTests.swift
@@ -313,7 +313,7 @@ struct ReminderServiceUpdateTests {
             isEnabled: reminder.isEnabled
         )
 
-        #expect(reminder.message == "")
+        #expect(reminder.message.isEmpty)
     }
 
     // MARK: - Notification reschedule


### PR DESCRIPTION
## Summary
- Replace the "Edit Reminder - Coming Soon" placeholder with a full editing form modeled on AddReminderView.
- Add `ReminderService.updateReminder(...)` as the single entry point for mutation, nextDueDate recalculation, and notification rescheduling.
- Add `ReminderError.emptyTitle` and `.invalidCustomFrequency` cases for input validation.
- Add a "Pause Reminder" toggle backed by `isEnabled`, plus a destructive Delete button that delegates to the parent's existing confirmation alert.
- Add 14 service-layer tests covering validation, mutation, schedule recalc, message prefill on type change, and a notification-scheduling smoke test, plus 4 FormState mapping tests.

Closes #274.

## Decisions
- **Plant association is fixed** for an existing reminder. To re-target, users create a new reminder and delete the old. Brainstorming locked this in to avoid notification-rescheduling complexity around plant changes.
- **Notification side-effects** use the existing `shouldScheduleNotifications` gate; tests run with `notificationCenter: nil` (no real notification calls) and assert algorithm correctness rather than notification-call counts.
- **Message prefill:** when the user changes reminder type and leaves the message blank, the new type's `defaultMessage` is used so the body never references the prior type.

## Related
Pre-existing bug found while implementing this: `ReminderService.createSmartReminder` always stores frequency as `.custom` regardless of caller intent — filed as #279, out of scope here.

## Test plan
- [x] `swift test --package-path GrowWisePackage --filter ReminderServiceUpdateTests` — 14/14 pass locally
- [x] `swift test --package-path GrowWisePackage --filter EditReminderViewTests` — 4/4 pass locally
- [x] `swift test --package-path GrowWisePackage` — full suite green, no regressions
- [x] `swift build --package-path GrowWisePackage` succeeds
- [x] `swiftlint lint --strict --config .swiftlint.yml` reports 0 new violations on the touched test file (type_body_length warnings on EditReminderView mirror the existing AddReminderView pattern; not strict-blocking under CI)
- [ ] CI green (Build, Test, SwiftLint, SwiftFormat, Coverage Threshold, QA — iOS Simulator)
- [ ] Manual smoke (mac-mini sim): tap edit on a reminder → form pre-filled with current values → change frequency to "Daily" → Save → list shows updated due date. Re-open and toggle "Pause Reminder" → Save → list shows reminder grayed out. Re-open and tap "Delete Reminder" → parent confirmation alert → Delete → list updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)