### PR TITLE
Complete 1.0 release readiness

### DIFF
--- a/GrowWise/GrowWiseApp.swift
+++ b/GrowWise/GrowWiseApp.swift
@@ -30,9 +30,13 @@ struct CultivationApp: App {
             }()
         )
 
-        // Store Perenual API key securely on first launch
-        if !PerenualAPIService.hasAPIKey {
-            PerenualAPIService.storeAPIKey("sk-LSIM69d0612798a7616109")
+        // Store an optional bundled Perenual API key securely on first launch.
+        // Release builds must work without a bundled key; Perenual screens surface retryable errors.
+        if !PerenualAPIService.hasAPIKey,
+           let bundledKey = Bundle.main.object(forInfoDictionaryKey: "PERENUAL_API_KEY") as? String,
+           !bundledKey.isEmpty
+        {
+            PerenualAPIService.storeAPIKey(bundledKey)
         }
 
         let launchArgs = ProcessInfo.processInfo.arguments

--- a/GrowWisePackage/Sources/GrowWiseFeature/OnboardingFlow/OnboardingPersonalization.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/OnboardingFlow/OnboardingPersonalization.swift
@@ -1,0 +1,42 @@
+import GrowWiseModels
+
+enum OnboardingPersonalization {
+    static func modelGoals(from goals: Set<GardeningGoal>) -> [GrowWiseModels.GardeningGoal] {
+        goals
+            .map(\.modelGoal)
+            .sorted { $0.rawValue < $1.rawValue }
+    }
+
+    static func preferredPlantTypes(
+        goals: Set<GardeningGoal>,
+        interests: Set<PlantType>
+    ) -> [PlantType] {
+        let goalTypes = goals.flatMap(\.preferredPlantTypes)
+        return Array(Set(goalTypes).union(interests))
+            .sorted { $0.rawValue < $1.rawValue }
+    }
+}
+
+extension GardeningGoal {
+    var modelGoal: GrowWiseModels.GardeningGoal {
+        switch self {
+        case .growFood: .growFood
+        case .beautifySpace: .beautifySpace
+        case .learnSkills: .learnSkills
+        case .relaxation: .relaxation
+        case .sustainability: .sustainability
+        case .healingGarden: .medicinalHerbs
+        }
+    }
+
+    var preferredPlantTypes: [PlantType] {
+        switch self {
+        case .growFood: [.vegetable, .herb, .fruit]
+        case .beautifySpace: [.flower, .shrub, .tree]
+        case .learnSkills: [.vegetable, .herb, .flower, .houseplant]
+        case .relaxation: [.houseplant, .flower, .herb]
+        case .sustainability: [.vegetable, .herb, .fruit, .tree]
+        case .healingGarden: [.herb, .flower]
+        }
+    }
+}

--- a/GrowWisePackage/Sources/GrowWiseFeature/OnboardingFlow/OnboardingPersonalization.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/OnboardingFlow/OnboardingPersonalization.swift
@@ -15,6 +15,16 @@ enum OnboardingPersonalization {
         return Array(Set(goalTypes).union(interests))
             .sorted { $0.rawValue < $1.rawValue }
     }
+
+    static func defaultIsIndoor(for gardenType: GardenType) -> Bool {
+        switch gardenType {
+        case .indoor, .windowsill:
+            true
+
+        case .outdoor, .container, .raised, .hydroponic, .greenhouse, .balcony:
+            false
+        }
+    }
 }
 
 extension GardeningGoal {

--- a/GrowWisePackage/Sources/GrowWiseFeature/OnboardingFlow/OnboardingView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/OnboardingFlow/OnboardingView.swift
@@ -127,6 +127,7 @@ public struct UserProfile {
     var hasNotificationPermission: Bool = false
     var preferredNotificationTime: Date = Calendar.current.date(from: DateComponents(hour: 9)) ?? Date()
     var selectedFirstPlantName: String?
+    var selectedFirstPlantID: UUID?
 }
 
 public enum GardeningGoal: String, CaseIterable, Identifiable {

--- a/GrowWisePackage/Sources/GrowWiseFeature/OnboardingFlow/OnboardingView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/OnboardingFlow/OnboardingView.swift
@@ -120,6 +120,8 @@ public struct UserProfile {
     var goals: Set<GardeningGoal> = []
     var gardenType: GardenType = .outdoor
     var spaceSize: SpaceSize = .small
+    var shouldCreateFirstGarden: Bool = true
+    var firstGardenName: String = "My First Garden"
     var interests: Set<PlantType> = []
     var hasLocationPermission: Bool = false
     var hasNotificationPermission: Bool = false

--- a/GrowWisePackage/Sources/GrowWiseFeature/OnboardingFlow/Views/CompletionView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/OnboardingFlow/Views/CompletionView.swift
@@ -51,7 +51,7 @@ struct CompletionView: View {
 
             Spacer().frame(height: 32)
 
-            // Profile summary card — glass, 4 rows
+            // Profile summary card — glass, setup rows
             VStack(alignment: .leading, spacing: 0) {
                 HStack {
                     Image(systemName: "person.crop.circle.fill")
@@ -73,15 +73,13 @@ struct CompletionView: View {
                     value: userProfile.skillLevel.displayName
                 )
 
-                if let firstGoal = userProfile.goals.first {
-                    Divider().padding(.leading, 48)
-                    CompletionSummaryRow(
-                        icon: "scope",
-                        iconColor: CultivationTheme.Colors.brandLeaf.opacity(0.80),
-                        label: "Goal",
-                        value: firstGoal.displayName
-                    )
-                }
+                Divider().padding(.leading, 48)
+                CompletionSummaryRow(
+                    icon: "scope",
+                    iconColor: CultivationTheme.Colors.brandLeaf.opacity(0.80),
+                    label: "Goals",
+                    value: Self.goalsSummary(for: userProfile)
+                )
 
                 Divider().padding(.leading, 48)
                 CompletionSummaryRow(
@@ -98,6 +96,24 @@ struct CompletionView: View {
                         iconColor: CultivationTheme.Colors.textTertiary,
                         label: "Space",
                         value: userProfile.spaceSize.displayName
+                    )
+                }
+
+                Divider().padding(.leading, 48)
+                CompletionSummaryRow(
+                    icon: "sprout.fill",
+                    iconColor: CultivationTheme.Colors.brandLeaf.opacity(0.80),
+                    label: "First Plant",
+                    value: Self.firstPlantSummary(for: userProfile)
+                )
+
+                if let nextCare = Self.nextCareSummary(for: userProfile) {
+                    Divider().padding(.leading, 48)
+                    CompletionSummaryRow(
+                        icon: "drop.fill",
+                        iconColor: CultivationTheme.Colors.accentSky,
+                        label: "Next Care",
+                        value: nextCare
                     )
                 }
             }
@@ -118,6 +134,25 @@ struct CompletionView: View {
         guard profile.shouldCreateFirstGarden else { return "Skipped" }
         let trimmedName = profile.firstGardenName.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmedName.isEmpty ? "My First Garden" : trimmedName
+    }
+
+    static func firstPlantSummary(for profile: UserProfile) -> String {
+        let trimmedName = profile.selectedFirstPlantName?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return trimmedName.isEmpty ? "Skipped" : trimmedName
+    }
+
+    static func nextCareSummary(for profile: UserProfile) -> String? {
+        firstPlantSummary(for: profile) == "Skipped" ? nil : "Watering reminder"
+    }
+
+    static func goalsSummary(for profile: UserProfile) -> String {
+        let selectedGoals = GardeningGoal.allCases.filter { profile.goals.contains($0) }
+        guard !selectedGoals.isEmpty else { return "None selected" }
+
+        let visibleGoals = selectedGoals.prefix(2).map(\.displayName).joined(separator: ", ")
+        let remainingCount = selectedGoals.count - 2
+        guard remainingCount > 0 else { return visibleGoals }
+        return "\(visibleGoals) +\(remainingCount)"
     }
 }
 

--- a/GrowWisePackage/Sources/GrowWiseFeature/OnboardingFlow/Views/CompletionView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/OnboardingFlow/Views/CompletionView.swift
@@ -87,17 +87,19 @@ struct CompletionView: View {
                 CompletionSummaryRow(
                     icon: "leaf.fill",
                     iconColor: CultivationTheme.Colors.brandLeaf.opacity(0.70),
-                    label: "Garden",
-                    value: userProfile.gardenType.displayName
+                    label: "First Garden",
+                    value: Self.gardenSummary(for: userProfile)
                 )
 
-                Divider().padding(.leading, 48)
-                CompletionSummaryRow(
-                    icon: "square.grid.2x2.fill",
-                    iconColor: CultivationTheme.Colors.textTertiary,
-                    label: "Space",
-                    value: userProfile.spaceSize.displayName
-                )
+                if userProfile.shouldCreateFirstGarden {
+                    Divider().padding(.leading, 48)
+                    CompletionSummaryRow(
+                        icon: "square.grid.2x2.fill",
+                        iconColor: CultivationTheme.Colors.textTertiary,
+                        label: "Space",
+                        value: userProfile.spaceSize.displayName
+                    )
+                }
             }
             .paperCard()
             .padding(.horizontal, 24)
@@ -110,6 +112,12 @@ struct CompletionView: View {
             withAnimation(.spring(duration: 0.65, bounce: 0.2).delay(0.1)) { heroVisible = true }
             withAnimation(.spring(duration: 0.55).delay(0.55)) { summaryVisible = true }
         }
+    }
+
+    static func gardenSummary(for profile: UserProfile) -> String {
+        guard profile.shouldCreateFirstGarden else { return "Skipped" }
+        let trimmedName = profile.firstGardenName.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmedName.isEmpty ? "My First Garden" : trimmedName
     }
 }
 

--- a/GrowWisePackage/Sources/GrowWiseFeature/OnboardingFlow/Views/FirstPlantStepView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/OnboardingFlow/Views/FirstPlantStepView.swift
@@ -66,9 +66,11 @@ struct FirstPlantStepView: View {
                                 if selectedPlant?.id == plant.id {
                                     selectedPlant = nil
                                     userProfile.selectedFirstPlantName = nil
+                                    userProfile.selectedFirstPlantID = nil
                                 } else {
                                     selectedPlant = plant
                                     userProfile.selectedFirstPlantName = plant.name
+                                    userProfile.selectedFirstPlantID = plant.id
                                 }
                             }
                         }
@@ -80,6 +82,7 @@ struct FirstPlantStepView: View {
                 Button {
                     selectedPlant = nil
                     userProfile.selectedFirstPlantName = nil
+                    userProfile.selectedFirstPlantID = nil
                 } label: {
                     Text("Skip — I'll add plants later")
                         .font(.system(size: 14, design: .rounded))

--- a/GrowWisePackage/Sources/GrowWiseFeature/OnboardingFlow/Views/GardenSetupView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/OnboardingFlow/Views/GardenSetupView.swift
@@ -14,62 +14,102 @@ struct GardenSetupView: View {
             )
 
             VStack(spacing: 16) {
+                gardenCreationSection
+
                 // Garden type — horizontal chip row
-                VStack(alignment: .leading, spacing: 10) {
-                    Text("GARDEN TYPE")
-                        .font(.system(size: 11, weight: .semibold))
-                        .foregroundStyle(CultivationTheme.Colors.textTertiary)
-                        .tracking(1.0)
-                        .padding(.horizontal, 20)
+                if userProfile.shouldCreateFirstGarden {
+                    VStack(alignment: .leading, spacing: 10) {
+                        Text("GARDEN TYPE")
+                            .font(.system(size: 11, weight: .semibold))
+                            .foregroundStyle(CultivationTheme.Colors.textTertiary)
+                            .tracking(1.0)
+                            .padding(.horizontal, 20)
 
-                    ScrollView(.horizontal, showsIndicators: false) {
-                        HStack(spacing: 8) {
-                            ForEach(GardenType.allCases, id: \.self) { type in
-                                GardenTypeChip(
-                                    type: type,
-                                    isSelected: userProfile.gardenType == type
-                                ) {
-                                    withAnimation(.spring(duration: 0.25)) {
-                                        userProfile.gardenType = type
+                        ScrollView(.horizontal, showsIndicators: false) {
+                            HStack(spacing: 8) {
+                                ForEach(GardenType.allCases, id: \.self) { type in
+                                    GardenTypeChip(
+                                        type: type,
+                                        isSelected: userProfile.gardenType == type
+                                    ) {
+                                        withAnimation(.spring(duration: 0.25)) {
+                                            userProfile.gardenType = type
+                                        }
                                     }
-                                }
-                                .accessibilityIdentifier("onboarding_gardentype_\(type.rawValue)")
-                            }
-                        }
-                        .padding(.horizontal, 20)
-                    }
-                }
-
-                // Space size — vertical list, fills remaining height
-                VStack(alignment: .leading, spacing: 10) {
-                    Text("YOUR SPACE")
-                        .font(.system(size: 11, weight: .semibold))
-                        .foregroundStyle(CultivationTheme.Colors.textTertiary)
-                        .tracking(1.0)
-                        .padding(.horizontal, 20)
-
-                    VStack(spacing: 8) {
-                        ForEach(SpaceSize.allCases, id: \.self) { size in
-                            SpaceSizeRow(
-                                size: size,
-                                isSelected: userProfile.spaceSize == size
-                            ) {
-                                withAnimation(.spring(duration: 0.25)) {
-                                    userProfile.spaceSize = size
+                                    .accessibilityIdentifier("onboarding_gardentype_\(type.rawValue)")
                                 }
                             }
                             .padding(.horizontal, 20)
-                            .frame(maxHeight: .infinity)
-                            .accessibilityIdentifier("onboarding_space_\(size.rawValue)")
                         }
                     }
-                    .frame(maxHeight: .infinity)
+
+                    // Space size — vertical list, fills remaining height
+                    VStack(alignment: .leading, spacing: 10) {
+                        Text("YOUR SPACE")
+                            .font(.system(size: 11, weight: .semibold))
+                            .foregroundStyle(CultivationTheme.Colors.textTertiary)
+                            .tracking(1.0)
+                            .padding(.horizontal, 20)
+
+                        VStack(spacing: 8) {
+                            ForEach(SpaceSize.allCases, id: \.self) { size in
+                                SpaceSizeRow(
+                                    size: size,
+                                    isSelected: userProfile.spaceSize == size
+                                ) {
+                                    withAnimation(.spring(duration: 0.25)) {
+                                        userProfile.spaceSize = size
+                                    }
+                                }
+                                .padding(.horizontal, 20)
+                                .frame(maxHeight: .infinity)
+                                .accessibilityIdentifier("onboarding_space_\(size.rawValue)")
+                            }
+                        }
+                        .frame(maxHeight: .infinity)
+                    }
                 }
             }
             .frame(maxHeight: .infinity)
         }
         .padding(.top, 8)
         .padding(.bottom, 4)
+    }
+
+    private var gardenCreationSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Toggle(isOn: $userProfile.shouldCreateFirstGarden) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Create your first garden")
+                        .font(.system(size: 15, weight: .semibold))
+                        .foregroundStyle(CultivationTheme.Colors.textPrimary)
+                    Text(userProfile.shouldCreateFirstGarden ? "Ready for plants after setup" : "Skipped for now")
+                        .font(.system(size: 12))
+                        .foregroundStyle(CultivationTheme.Colors.textSecondary)
+                }
+            }
+            .tint(CultivationTheme.Colors.brandLeaf)
+            .accessibilityIdentifier("onboarding_toggle_create_garden")
+
+            if userProfile.shouldCreateFirstGarden {
+                TextField("Garden name", text: $userProfile.firstGardenName)
+                    .font(.system(size: 15, weight: .medium))
+                    .foregroundStyle(CultivationTheme.Colors.textPrimary)
+                    .padding(12)
+                    .background(
+                        RoundedRectangle(cornerRadius: 12)
+                            .fill(CultivationTheme.Colors.backgroundSecondary)
+                    )
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 12)
+                            .stroke(CultivationTheme.Colors.cardBorder, lineWidth: 1)
+                    )
+                    .accessibilityIdentifier("onboarding_textfield_garden_name")
+            }
+        }
+        .padding(CultivationTheme.Spacing.cardPadding)
+        .glassCard()
+        .padding(.horizontal, 20)
     }
 }
 

--- a/GrowWisePackage/Sources/GrowWiseFeature/OnboardingFlow/Views/OnboardingNavigationView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/OnboardingFlow/Views/OnboardingNavigationView.swift
@@ -185,8 +185,8 @@ struct OnboardingNavigationView: View {
                 )
 
                 try await saveUserPreferences(user: user)
-                try await createFirstGardenIfRequested()
-                await createFirstPlantIfSelected(user: user)
+                let firstGarden = try await createFirstGardenIfRequested()
+                try await createFirstPlantIfSelected(garden: firstGarden)
                 UserDefaults.standard.set(true, forKey: "hasCompletedOnboarding")
 
                 await MainActor.run {
@@ -207,12 +207,12 @@ struct OnboardingNavigationView: View {
     }
 
     @MainActor
-    private func createFirstGardenIfRequested() async throws {
-        guard userProfile.shouldCreateFirstGarden else { return }
+    private func createFirstGardenIfRequested() async throws -> Garden? {
+        guard userProfile.shouldCreateFirstGarden else { return nil }
         let trimmedName = userProfile.firstGardenName.trimmingCharacters(in: .whitespacesAndNewlines)
         let gardenName = trimmedName.isEmpty ? "My First Garden" : trimmedName
 
-        try dataService.createGarden(
+        return try dataService.createGarden(
             name: gardenName,
             type: userProfile.gardenType,
             isIndoor: OnboardingPersonalization.defaultIsIndoor(for: userProfile.gardenType),
@@ -221,32 +221,26 @@ struct OnboardingNavigationView: View {
     }
 
     @MainActor
-    private func createFirstPlantIfSelected(user: User) async {
+    private func createFirstPlantIfSelected(garden: Garden?) async throws {
         guard let plantName = userProfile.selectedFirstPlantName, !plantName.isEmpty else { return }
-
-        let plant = Plant(
-            name: plantName,
-            plantType: .flower,
-            difficultyLevel: .beginner
-        )
-        plant.plantingDate = Date()
-
-        do {
-            try dataService.plants.add(plant)
-
-            // Auto-create a watering reminder due tomorrow
-            let tomorrow = Calendar.current.date(byAdding: .day, value: 1, to: Date()) ?? Date()
-            _ = try dataService.createReminder(
-                title: "Water \(plantName)",
-                message: "Time to water your new \(plantName)!",
-                type: .watering,
-                frequency: .weekly,
-                dueDate: tomorrow,
-                plant: plant
-            )
-        } catch {
-            // Non-critical — plant creation failure shouldn't block onboarding
+        guard let garden else {
+            throw OnboardingSaveError.firstPlantNeedsGarden
         }
+        guard let template = selectedFirstPlantTemplate(named: plantName) else {
+            throw OnboardingSaveError.firstPlantTemplateMissing(plantName)
+        }
+
+        try dataService.createStarterPlant(from: template, in: garden)
+    }
+
+    private func selectedFirstPlantTemplate(named plantName: String) -> Plant? {
+        let templates = dataService.fetchPlantDatabase()
+        if let selectedFirstPlantID = userProfile.selectedFirstPlantID,
+           let match = templates.first(where: { $0.id == selectedFirstPlantID })
+        {
+            return match
+        }
+        return templates.first { $0.name == plantName }
     }
 
     @MainActor
@@ -280,6 +274,21 @@ struct OnboardingNavigationView: View {
 enum StepDirection {
     case next
     case previous
+}
+
+private enum OnboardingSaveError: LocalizedError {
+    case firstPlantNeedsGarden
+    case firstPlantTemplateMissing(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .firstPlantNeedsGarden:
+            "Create a first garden before adding a first plant, or skip the first plant for now."
+
+        case .firstPlantTemplateMissing(let name):
+            "Could not find \(name) in the plant database. Please pick a plant again or skip for now."
+        }
+    }
 }
 
 #Preview {

--- a/GrowWisePackage/Sources/GrowWiseFeature/OnboardingFlow/Views/OnboardingNavigationView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/OnboardingFlow/Views/OnboardingNavigationView.swift
@@ -185,6 +185,7 @@ struct OnboardingNavigationView: View {
                 )
 
                 try await saveUserPreferences(user: user)
+                try await createFirstGardenIfRequested()
                 await createFirstPlantIfSelected(user: user)
                 UserDefaults.standard.set(true, forKey: "hasCompletedOnboarding")
 
@@ -203,6 +204,20 @@ struct OnboardingNavigationView: View {
         isSaving = false
         errorMessage = message
         showingError = true
+    }
+
+    @MainActor
+    private func createFirstGardenIfRequested() async throws {
+        guard userProfile.shouldCreateFirstGarden else { return }
+        let trimmedName = userProfile.firstGardenName.trimmingCharacters(in: .whitespacesAndNewlines)
+        let gardenName = trimmedName.isEmpty ? "My First Garden" : trimmedName
+
+        try dataService.createGarden(
+            name: gardenName,
+            type: userProfile.gardenType,
+            isIndoor: OnboardingPersonalization.defaultIsIndoor(for: userProfile.gardenType),
+            spaceSize: userProfile.spaceSize
+        )
     }
 
     @MainActor

--- a/GrowWisePackage/Sources/GrowWiseFeature/OnboardingFlow/Views/OnboardingNavigationView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/OnboardingFlow/Views/OnboardingNavigationView.swift
@@ -184,7 +184,7 @@ struct OnboardingNavigationView: View {
                     skillLevel: userProfile.skillLevel
                 )
 
-                await saveUserPreferences(user: user)
+                try await saveUserPreferences(user: user)
                 await createFirstPlantIfSelected(user: user)
                 UserDefaults.standard.set(true, forKey: "hasCompletedOnboarding")
 
@@ -234,7 +234,8 @@ struct OnboardingNavigationView: View {
         }
     }
 
-    private func saveUserPreferences(user: User) async {
+    @MainActor
+    private func saveUserPreferences(user: User) async throws {
         if let goalsData = try? JSONEncoder().encode(userProfile.goals.map(\.rawValue)) {
             UserDefaults.standard.set(goalsData, forKey: "userGardeningGoals")
         }
@@ -249,6 +250,15 @@ struct OnboardingNavigationView: View {
         if userProfile.hasNotificationPermission {
             notificationService.setupNotificationCategories()
         }
+
+        try dataService.updateOnboardingProfile(
+            for: user,
+            gardeningGoals: OnboardingPersonalization.modelGoals(from: userProfile.goals),
+            preferredPlantTypes: OnboardingPersonalization.preferredPlantTypes(
+                goals: userProfile.goals,
+                interests: userProfile.interests
+            )
+        )
     }
 }
 

--- a/GrowWisePackage/Sources/GrowWiseFeature/Resources/de.lproj/Localizable.strings
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Resources/de.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-/* German - Localization for GrowWise */
+/* German - Localization for Cultivation */
 
 /* Navigation & Tabs */
 "tab.home" = "Startseite";
@@ -65,7 +65,7 @@
 "common.retry" = "Erneut versuchen";
 
 /* Onboarding */
-"onboarding.welcome" = "Willkommen bei GrowWise";
+"onboarding.welcome" = "Willkommen bei Cultivation";
 "onboarding.experienceQuestion" = "Wie ist Ihr Erfahrungsniveau?";
 "onboarding.level.beginner" = "Anfänger";
 "onboarding.level.intermediate" = "Fortgeschritten";
@@ -85,7 +85,7 @@
 "plantCare.lastFertilized" = "Zuletzt gedüngt";
 
 /* Subscription */
-"subscription.unlock" = "GrowWise Premium freischalten";
+"subscription.unlock" = "Cultivation Premium freischalten";
 "subscription.tier.free" = "Kostenlos";
 "subscription.tier.premium" = "Premium";
 "subscription.tier.pro" = "Pro";

--- a/GrowWisePackage/Sources/GrowWiseFeature/Resources/en.lproj/Localizable.strings
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Resources/en.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-/* English (US) - Base localization for GrowWise */
+/* English (US) - Base localization for Cultivation */
 
 /* Navigation & Tabs */
 "tab.home" = "Home";
@@ -65,7 +65,7 @@
 "common.retry" = "Retry";
 
 /* Onboarding */
-"onboarding.welcome" = "Welcome to GrowWise";
+"onboarding.welcome" = "Welcome to Cultivation";
 "onboarding.experienceQuestion" = "What's your experience level?";
 "onboarding.level.beginner" = "Beginner";
 "onboarding.level.intermediate" = "Intermediate";
@@ -85,7 +85,7 @@
 "plantCare.lastFertilized" = "Last Fertilized";
 
 /* Subscription */
-"subscription.unlock" = "Unlock GrowWise Premium";
+"subscription.unlock" = "Unlock Cultivation Premium";
 "subscription.tier.free" = "Free";
 "subscription.tier.premium" = "Premium";
 "subscription.tier.pro" = "Pro";

--- a/GrowWisePackage/Sources/GrowWiseFeature/Resources/es.lproj/Localizable.strings
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Resources/es.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-/* Spanish - Localization for GrowWise */
+/* Spanish - Localization for Cultivation */
 
 /* Navigation & Tabs */
 "tab.home" = "Inicio";
@@ -65,7 +65,7 @@
 "common.retry" = "Reintentar";
 
 /* Onboarding */
-"onboarding.welcome" = "Bienvenido a GrowWise";
+"onboarding.welcome" = "Bienvenido a Cultivation";
 "onboarding.experienceQuestion" = "¿Cuál es tu nivel de experiencia?";
 "onboarding.level.beginner" = "Principiante";
 "onboarding.level.intermediate" = "Intermedio";
@@ -85,7 +85,7 @@
 "plantCare.lastFertilized" = "Última fertilización";
 
 /* Subscription */
-"subscription.unlock" = "Desbloquea GrowWise Premium";
+"subscription.unlock" = "Desbloquea Cultivation Premium";
 "subscription.tier.free" = "Gratis";
 "subscription.tier.premium" = "Premium";
 "subscription.tier.pro" = "Pro";

--- a/GrowWisePackage/Sources/GrowWiseFeature/Resources/fr.lproj/Localizable.strings
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Resources/fr.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-/* French - Localization for GrowWise */
+/* French - Localization for Cultivation */
 
 /* Navigation & Tabs */
 "tab.home" = "Accueil";
@@ -65,7 +65,7 @@
 "common.retry" = "Réessayer";
 
 /* Onboarding */
-"onboarding.welcome" = "Bienvenue sur GrowWise";
+"onboarding.welcome" = "Bienvenue sur Cultivation";
 "onboarding.experienceQuestion" = "Quel est votre niveau d'expérience ?";
 "onboarding.level.beginner" = "Débutant";
 "onboarding.level.intermediate" = "Intermédiaire";
@@ -85,7 +85,7 @@
 "plantCare.lastFertilized" = "Dernière fertilisation";
 
 /* Subscription */
-"subscription.unlock" = "Débloquez GrowWise Premium";
+"subscription.unlock" = "Débloquez Cultivation Premium";
 "subscription.tier.free" = "Gratuit";
 "subscription.tier.premium" = "Premium";
 "subscription.tier.pro" = "Pro";

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/AddPlantSheet.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/AddPlantSheet.swift
@@ -563,13 +563,12 @@ public struct AddPlantSheet: View {
                     plantingDate: plantingDate
                 )
             } else {
-                newPlant = Plant(
+                newPlant = try dataService.createPlant(
                     name: plantName,
-                    plantType: selectedPlantType,
-                    difficultyLevel: selectedDifficultyLevel
+                    type: selectedPlantType,
+                    difficultyLevel: selectedDifficultyLevel,
+                    garden: selectedGarden
                 )
-                newPlant.garden = selectedGarden
-                modelContext.insert(newPlant)
             }
         } catch {
             errorMessage = "Failed to add plant: \(error.localizedDescription)"

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/AddPlantSheet.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/AddPlantSheet.swift
@@ -48,6 +48,7 @@ public struct AddPlantSheet: View {
     @State private var suggestions: [Plant] = []
     @State private var searchTask: Task<Void, Never>?
     @State private var nameFieldCommitted = false
+    @State private var selectedTemplate: Plant?
 
     // Companion planting analysis
     @State private var compatibilityAnalysis: GardenCompatibilityAnalysis?
@@ -94,8 +95,12 @@ public struct AddPlantSheet: View {
                                     // Debounced autocomplete
                                     searchTask?.cancel()
                                     nameFieldCommitted = false
+                                    if selectedTemplate?.name != newValue {
+                                        selectedTemplate = nil
+                                    }
                                     guard !newValue.isEmpty else {
                                         suggestions = []
+                                        selectedTemplate = nil
                                         return
                                     }
                                     searchTask = Task {
@@ -530,6 +535,7 @@ public struct AddPlantSheet: View {
     }
 
     private func applyTemplate(_ plant: Plant) {
+        selectedTemplate = plant
         plantName = plant.name ?? plantName
         scientificName = plant.scientificName ?? scientificName
         if let type = plant.plantType { selectedPlantType = type }
@@ -548,23 +554,51 @@ public struct AddPlantSheet: View {
 
         isSaving = true
 
-        let newPlant = Plant(
-            name: plantName,
-            plantType: selectedPlantType,
-            difficultyLevel: selectedDifficultyLevel
-        )
+        let newPlant: Plant
+        do {
+            if let selectedTemplate {
+                newPlant = try dataService.createUserPlant(
+                    from: selectedTemplate,
+                    in: selectedGarden,
+                    plantingDate: plantingDate
+                )
+            } else {
+                newPlant = Plant(
+                    name: plantName,
+                    plantType: selectedPlantType,
+                    difficultyLevel: selectedDifficultyLevel
+                )
+                newPlant.garden = selectedGarden
+                modelContext.insert(newPlant)
+            }
+        } catch {
+            errorMessage = "Failed to add plant: \(error.localizedDescription)"
+            showingError = true
+            isSaving = false
+            return
+        }
 
-        newPlant.scientificName = scientificName.isEmpty ? nil : scientificName
+        newPlant.name = plantName
+        newPlant.scientificName = scientificName.isEmpty ? newPlant.scientificName : scientificName
+        newPlant.plantType = selectedPlantType
+        newPlant.difficultyLevel = selectedDifficultyLevel
         newPlant.plantingDate = plantingDate
         newPlant.bed = selectedBed
-        newPlant.notes = notes.isEmpty ? nil : notes
+        if !notes.isEmpty {
+            newPlant.notes = notes
+        }
 
         if !photoURLs.isEmpty {
             newPlant.photoURLs = photoURLs.map(\.absoluteString)
         }
-
-        newPlant.garden = selectedGarden
-        modelContext.insert(newPlant)
+        do {
+            try dataService.plants.update(newPlant)
+        } catch {
+            errorMessage = "Failed to save plant: \(error.localizedDescription)"
+            showingError = true
+            isSaving = false
+            return
+        }
         savedPlant = newPlant
         wateringSchedule = reminderService.suggestWateringSchedule(for: newPlant, in: selectedGarden)
         showWateringSchedule = true

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/Garden/RecommendedPlantsView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/Garden/RecommendedPlantsView.swift
@@ -146,7 +146,9 @@ struct RecommendedPlantsView: View {
             skillLevel: user?.skillLevel ?? .beginner,
             availableSpace: spaceRequirementFromGarden(),
             timeCommitment: user?.timeCommitment ?? .moderate,
-            gardenType: garden.gardenType?.rawValue ?? "outdoor"
+            gardenType: garden.gardenType?.rawValue ?? "outdoor",
+            preferredPlantTypes: user?.preferredPlantTypes ?? [],
+            gardeningGoals: user?.gardeningGoals ?? []
         )
 
         recommendations = plantDatabaseService.getRecommendedPlants(for: profile, limit: 8)
@@ -396,7 +398,9 @@ struct SuggestedPlantsSection: View {
             skillLevel: user?.skillLevel ?? .beginner,
             availableSpace: spaceRequirement(),
             timeCommitment: user?.timeCommitment ?? .moderate,
-            gardenType: garden.gardenType?.rawValue ?? "outdoor"
+            gardenType: garden.gardenType?.rawValue ?? "outdoor",
+            preferredPlantTypes: user?.preferredPlantTypes ?? [],
+            gardeningGoals: user?.gardeningGoals ?? []
         )
 
         suggestions = plantDatabaseService.getRecommendedPlants(for: profile, limit: 4)

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/Garden/RecommendedPlantsView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/Garden/RecommendedPlantsView.swift
@@ -187,21 +187,7 @@ struct RecommendedPlantsView: View {
 
     private func addPlantToGarden(_ plant: Plant) {
         do {
-            let newPlant = Plant(
-                name: plant.name ?? "Unknown",
-                plantType: plant.plantType ?? .houseplant,
-                difficultyLevel: plant.difficultyLevel ?? .beginner,
-                isUserPlant: true
-            )
-            newPlant.scientificName = plant.scientificName
-            newPlant.sunlightRequirement = plant.sunlightRequirement
-            newPlant.wateringFrequency = plant.wateringFrequency
-            newPlant.spaceRequirement = plant.spaceRequirement
-            newPlant.notes = plant.notes
-            newPlant.garden = garden
-            newPlant.plantingDate = Date()
-
-            try dataService.plants.add(newPlant)
+            try dataService.createUserPlant(from: plant, in: garden)
 
             if let plantID = plant.id {
                 addedPlantIDs.insert(plantID)

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/GardenClub/ClubPostCard.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/GardenClub/ClubPostCard.swift
@@ -1,0 +1,101 @@
+import SwiftUI
+
+struct ClubPostCard: View {
+    let post: GardenClubFeedView.ClubActivityViewData
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            header
+
+            if let caption = post.caption {
+                Text(caption)
+                    .font(CultivationTheme.Fonts.body(13))
+                    .foregroundStyle(CultivationTheme.Colors.textSecondary)
+                    .lineLimit(nil)
+            }
+
+            photo
+            actionRow
+        }
+        .padding(14)
+        .paperCard()
+        .accessibilityIdentifier("club_post_\(post.id.uuidString)")
+    }
+
+    private var header: some View {
+        HStack(spacing: 10) {
+            Circle()
+                .fill(LinearGradient(
+                    colors: [CultivationTheme.Colors.brandMint, CultivationTheme.Colors.brandLeaf],
+                    startPoint: .topLeading,
+                    endPoint: .bottomTrailing
+                ))
+                .frame(width: 32, height: 32)
+                .overlay(
+                    Text(initials(of: post.authorDisplayName))
+                        .font(CultivationTheme.Fonts.display(13, weight: .semibold))
+                        .foregroundStyle(.white)
+                )
+            VStack(alignment: .leading, spacing: 1) {
+                Text(post.authorDisplayName)
+                    .font(CultivationTheme.Fonts.body(13, weight: .bold))
+                    .foregroundStyle(CultivationTheme.Colors.textPrimary)
+                subtitle
+            }
+            Spacer()
+        }
+    }
+
+    private var subtitle: some View {
+        HStack(spacing: 5) {
+            if let zone = post.zoneTag {
+                Text("Zone \(zone)")
+                    .foregroundStyle(CultivationTheme.Colors.smartTagForeground)
+                    .fontWeight(.bold)
+            }
+            if let when = post.relativeTimeLabel {
+                Text(post.zoneTag == nil ? when : "\u{00B7} \(when)")
+                    .foregroundStyle(CultivationTheme.Colors.textTertiary)
+            }
+        }
+        .font(CultivationTheme.Fonts.body(10))
+    }
+
+    @ViewBuilder private var photo: some View {
+        if let photoURL = post.photoURL {
+            #if canImport(UIKit)
+            ClubPostPhoto(photoURL: photoURL, postID: post.id)
+            #else
+            AsyncImage(url: URL(string: photoURL)) { image in
+                image
+                    .resizable()
+                    .scaledToFill()
+            } placeholder: {
+                ProgressView()
+            }
+            .frame(height: 160)
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+            .accessibilityLabel("Club post photo")
+            .accessibilityIdentifier("club_post_photo_\(post.id.uuidString)")
+            #endif
+        }
+    }
+
+    private var actionRow: some View {
+        HStack(spacing: 16) {
+            if post.likeCount > 0 {
+                Label("\(post.likeCount)", systemImage: "heart")
+            }
+            if post.commentCount > 0 {
+                Label("\(post.commentCount)", systemImage: "bubble.right")
+            }
+            Label("Share", systemImage: "arrow.up.right")
+        }
+        .font(CultivationTheme.Fonts.body(11, weight: .semibold))
+        .foregroundStyle(CultivationTheme.Colors.textTertiary)
+    }
+
+    private func initials(of name: String) -> String {
+        String(name.prefix(1)).uppercased()
+    }
+}

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/GardenClub/ClubPostPhoto.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/GardenClub/ClubPostPhoto.swift
@@ -1,0 +1,49 @@
+#if canImport(UIKit)
+import GrowWiseServices
+import SwiftUI
+import UIKit
+
+struct ClubPostPhoto: View {
+    @Environment(PhotoService.self)
+    private var photoService
+
+    let photoURL: String
+    let postID: UUID
+
+    @State private var image: UIImage?
+    @State private var didLoad = false
+
+    var body: some View {
+        Group {
+            if let image {
+                Image(uiImage: image)
+                    .resizable()
+                    .scaledToFill()
+            } else if didLoad {
+                unavailableState
+            } else {
+                ProgressView()
+                    .frame(maxWidth: .infinity)
+            }
+        }
+        .frame(height: 160)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .accessibilityLabel("Club post photo")
+        .accessibilityIdentifier("club_post_photo_\(postID.uuidString)")
+        .task(id: photoURL) {
+            image = await photoService.loadImage(from: photoURL)
+            didLoad = true
+        }
+    }
+
+    private var unavailableState: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 12)
+                .fill(CultivationTheme.Colors.backgroundSecondary)
+            Label("Photo unavailable", systemImage: "photo")
+                .font(CultivationTheme.Fonts.body(12, weight: .medium))
+                .foregroundStyle(CultivationTheme.Colors.textTertiary)
+        }
+    }
+}
+#endif

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/GardenClub/ClubShareComposerSheet.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/GardenClub/ClubShareComposerSheet.swift
@@ -1,5 +1,6 @@
 import GrowWiseModels
 import GrowWiseServices
+import PhotosUI
 import SwiftUI
 
 // SwiftLint suppressions for #284 — pre-existing structural & style violations; refactor out of scope.
@@ -9,23 +10,41 @@ import SwiftUI
 ///
 /// Accepts an optional `plant` for pre-filling context. Calls `onPost` on
 /// success so the parent can refresh its feed.
-public struct ClubShareComposerSheet: View {
+public struct ClubShareComposerSheet: View { // swiftlint:disable:this type_body_length
     @Environment(DataService.self) private var dataService
+    @Environment(PhotoService.self) private var photoService
+    @Environment(ClubCloudKitService.self) private var clubCloudKitService
     @Environment(\.dismiss) private var dismiss
 
     let plant: Plant?
+    let club: GardenClub?
     let initialCaption: String?
     var onPost: () -> Void = {}
 
     @State private var caption = ""
     @State private var includePlant = true
+    @State private var availableClubs: [GardenClub] = []
+    @State private var selectedClubID: UUID?
+    @State private var selectedPhotoItem: PhotosPickerItem?
+    @State private var selectedPhotoData: Data?
     @State private var isPosting = false
     @State private var errorMessage: String?
     @State private var showError = false
-    @State private var clubName = "Your Club"
+    @State private var offlineMessage: String?
+    @State private var showOfflineNotice = false
 
     private var captionIsEmpty: Bool {
         caption.trimmingCharacters(in: .whitespaces).isEmpty
+    }
+
+    private var selectedClub: GardenClub? {
+        if let club { return club }
+        guard let selectedClubID else { return availableClubs.first }
+        return availableClubs.first { $0.id == selectedClubID } ?? availableClubs.first
+    }
+
+    private var selectedClubName: String {
+        selectedClub?.name ?? "Garden Club"
     }
 
     private var resolvedPlantName: String? {
@@ -33,8 +52,14 @@ public struct ClubShareComposerSheet: View {
         return plant?.name
     }
 
-    public init(plant: Plant? = nil, initialCaption: String? = nil, onPost: @escaping () -> Void = {}) {
+    public init(
+        plant: Plant? = nil,
+        club: GardenClub? = nil,
+        initialCaption: String? = nil,
+        onPost: @escaping () -> Void = {}
+    ) {
         self.plant = plant
+        self.club = club
         self.initialCaption = initialCaption
         self.onPost = onPost
         if let ic = initialCaption {
@@ -48,7 +73,7 @@ public struct ClubShareComposerSheet: View {
                 CultivationTheme.Colors.background.ignoresSafeArea()
                 scrollContent
             }
-            .navigationTitle("Share with \(clubName)")
+            .navigationTitle("Share with \(selectedClubName)")
             .gwNavigationBarTitleDisplayMode(.inline)
             .toolbar { toolbarContent }
             .alert("Couldn't post", isPresented: $showError) {
@@ -57,7 +82,13 @@ public struct ClubShareComposerSheet: View {
             } message: {
                 Text(errorMessage ?? "Something went wrong.")
             }
-            .task { loadClubName() }
+            .alert("Saved locally", isPresented: $showOfflineNotice) {
+                Button("OK") { dismiss() }
+                    .accessibilityIdentifier("share_composer_alert_offline")
+            } message: {
+                Text(offlineMessage ?? "Your post is visible locally and will be ready to retry when iCloud is available.")
+            }
+            .task { loadClubs() }
         }
         .accessibilityIdentifier("screen_share_composer")
     }
@@ -67,10 +98,14 @@ public struct ClubShareComposerSheet: View {
     private var scrollContent: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: CultivationTheme.Spacing.sectionGap) {
+                if club == nil {
+                    clubSelectionSection
+                }
                 captionSection
                 if plant != nil {
                     plantContextSection
                 }
+                photoSection
                 postFooterHint
             }
             .padding(.horizontal, CultivationTheme.Spacing.screenPadding)
@@ -103,6 +138,36 @@ public struct ClubShareComposerSheet: View {
     }
 
     // MARK: - Plant context chip
+
+    private var clubSelectionSection: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Club")
+                .sectionLabelStyle()
+                .padding(.leading, 4)
+
+            if availableClubs.isEmpty {
+                Text("Join or create a club before posting.")
+                    .font(CultivationTheme.Fonts.body(13))
+                    .foregroundStyle(CultivationTheme.Colors.textSecondary)
+                    .padding(CultivationTheme.Spacing.cardPadding)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .glassCard()
+                    .accessibilityIdentifier("share_composer_text_no_club")
+            } else {
+                Picker("Club", selection: $selectedClubID) {
+                    ForEach(availableClubs, id: \.id) { club in
+                        Text(club.name ?? "Garden Club")
+                            .tag(club.id)
+                    }
+                }
+                .pickerStyle(.menu)
+                .padding(CultivationTheme.Spacing.cardPadding)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .glassCard()
+                .accessibilityIdentifier("share_composer_picker_club")
+            }
+        }
+    }
 
     private var plantContextSection: some View {
         VStack(alignment: .leading, spacing: 6) {
@@ -160,6 +225,52 @@ public struct ClubShareComposerSheet: View {
         }
     }
 
+    // MARK: - Photo section
+
+    private var photoSection: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Photo")
+                .sectionLabelStyle()
+                .padding(.leading, 4)
+
+            PhotosPicker(selection: $selectedPhotoItem, matching: .images) {
+                HStack(spacing: 10) {
+                    Image(systemName: selectedPhotoData == nil ? "photo.badge.plus" : "photo.fill")
+                        .font(.system(size: 16, weight: .semibold))
+                        .foregroundStyle(CultivationTheme.Colors.accentCoral)
+                    Text(selectedPhotoData == nil ? "Add Photo" : "Photo attached")
+                        .font(CultivationTheme.Fonts.body(13, weight: .semibold))
+                        .foregroundStyle(CultivationTheme.Colors.textPrimary)
+                    Spacer()
+                    if selectedPhotoData != nil {
+                        Button {
+                            selectedPhotoData = nil
+                            selectedPhotoItem = nil
+                        } label: {
+                            Image(systemName: "xmark.circle.fill")
+                                .foregroundStyle(CultivationTheme.Colors.textTertiary)
+                        }
+                        .accessibilityLabel("Remove attached photo")
+                        .accessibilityIdentifier("share_composer_button_remove_photo")
+                    }
+                }
+                .padding(CultivationTheme.Spacing.cardPadding)
+                .background(
+                    RoundedRectangle(cornerRadius: CultivationTheme.Radius.card)
+                        .fill(CultivationTheme.Colors.cardSurface)
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: CultivationTheme.Radius.card)
+                        .stroke(CultivationTheme.Colors.cardBorder, lineWidth: 1)
+                )
+            }
+            .accessibilityIdentifier("share_composer_button_add_photo")
+            .onChange(of: selectedPhotoItem) { _, newValue in
+                Task<Void, Never> { await loadSelectedPhoto(newValue) }
+            }
+        }
+    }
+
     // MARK: - Footer hint
 
     private var postFooterHint: some View {
@@ -198,7 +309,7 @@ public struct ClubShareComposerSheet: View {
                     ? CultivationTheme.Colors.textTertiary
                     : CultivationTheme.Colors.accentCoral
             )
-            .disabled(captionIsEmpty)
+            .disabled(captionIsEmpty || selectedClub == nil)
             .accessibilityIdentifier("share_composer_button_post")
         }
     }
@@ -209,28 +320,67 @@ public struct ClubShareComposerSheet: View {
     private func submitPost() async {
         let trimmed = caption.trimmingCharacters(in: .whitespaces)
         guard !trimmed.isEmpty else { return }
+        guard let selectedClub else {
+            errorMessage = CreateClubPostError.noClub.localizedDescription
+            showError = true
+            return
+        }
 
         isPosting = true
         defer { isPosting = false }
 
         do {
-            try dataService.createClubPost(
+            let photoURL = try await saveSelectedPhotoIfNeeded()
+            let activity = try dataService.createClubPost(
                 caption: trimmed,
                 activityType: "shared",
-                plantName: resolvedPlantName
+                plantName: resolvedPlantName,
+                club: selectedClub,
+                photoURL: photoURL
             )
             onPost()
-            dismiss()
+            do {
+                try await clubCloudKitService.publishActivity(activity)
+                dismiss()
+            } catch {
+                offlineMessage = [
+                    "Your post is visible locally.",
+                    "iCloud sync is unavailable right now, so open the club again later to retry syncing.",
+                ].joined(separator: " ")
+                showOfflineNotice = true
+            }
         } catch {
             errorMessage = error.localizedDescription
             showError = true
         }
     }
 
-    private func loadClubName() {
-        if let name = dataService.fetchPrimaryClub()?.name {
-            clubName = name
+    private func loadClubs() {
+        do {
+            availableClubs = try dataService.fetchClubs()
+            if selectedClubID == nil {
+                selectedClubID = club?.id ?? availableClubs.first?.id
+            }
+        } catch {
+            errorMessage = error.localizedDescription
+            showError = true
         }
+    }
+
+    @MainActor
+    private func loadSelectedPhoto(_ item: PhotosPickerItem?) async {
+        guard let item else { return }
+        do {
+            selectedPhotoData = try await item.loadTransferable(type: Data.self)
+        } catch {
+            errorMessage = "Couldn't load that photo. Please try another image."
+            showError = true
+        }
+    }
+
+    private func saveSelectedPhotoIfNeeded() async throws -> String? {
+        guard let selectedPhotoData else { return nil }
+        return try await photoService.saveClubPostPhotoData(selectedPhotoData)
     }
 }
 

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/GardenClub/GardenClubFeedView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/GardenClub/GardenClubFeedView.swift
@@ -59,6 +59,7 @@ public struct GardenClubFeedView: View { // swiftlint:disable:this type_body_len
         let authorDisplayName: String
         let caption: String?
         let zoneTag: String?
+        let photoURL: String?
         let relativeTimeLabel: String?
         let likeCount: Int
         let commentCount: Int
@@ -85,10 +86,11 @@ public struct GardenClubFeedView: View { // swiftlint:disable:this type_body_len
         #endif
         .task { await load() }
         .sheet(isPresented: $isPresentingComposer) {
-            ClubShareComposerSheet(plant: nil, onPost: {
+            ClubShareComposerSheet(plant: nil, club: club, onPost: {
                 Task<Void, Never> { await load() }
             })
             .environment(dataService)
+            .environment(clubCloudKitService)
         }
     }
 
@@ -234,7 +236,7 @@ public struct GardenClubFeedView: View { // swiftlint:disable:this type_body_len
                 if index == 1, let match = smartMatch {
                     smartMatchCard(match)
                 }
-                PostCard(post: post)
+                ClubPostCard(post: post)
             }
             if posts.count < 2, let match = smartMatch {
                 smartMatchCard(match)
@@ -358,7 +360,7 @@ public struct GardenClubFeedView: View { // swiftlint:disable:this type_body_len
         }
     }
 
-    private static func viewData(from activity: ClubActivity) -> ClubActivityViewData {
+    static func viewData(from activity: ClubActivity) -> ClubActivityViewData {
         let id = activity.id ?? UUID()
         let author = activity.memberName ?? "Member"
         let caption = activity.activityDescription
@@ -375,6 +377,7 @@ public struct GardenClubFeedView: View { // swiftlint:disable:this type_body_len
             authorDisplayName: author,
             caption: caption,
             zoneTag: nil, // not yet captured on ClubActivity
+            photoURL: activity.photoURL,
             relativeTimeLabel: label,
             likeCount: 0, // future feature
             commentCount: 0 // future feature
@@ -384,11 +387,13 @@ public struct GardenClubFeedView: View { // swiftlint:disable:this type_body_len
     /// Maps a raw `CKRecord` for a `ClubActivity` CloudKit record onto the
     /// presentation type. Field names must match those written by
     /// `ClubCloudKitService.publishActivity(_:)`.
-    private static func viewData(from record: CKRecord) -> ClubActivityViewData {
+    static func viewData(from record: CKRecord) -> ClubActivityViewData {
         // The record name is the activity UUID stored as a string by publishActivity.
         let id = UUID(uuidString: record.recordID.recordName) ?? UUID()
         let author = record["memberName"] as? String ?? "Member"
         let caption = record["activityDescription"] as? String
+        let photoURL = (record["photo"] as? CKAsset)?.fileURL?.absoluteString
+            ?? record["photoURL"] as? String
         let timestamp = record["timestamp"] as? Date
         let label: String?
         if let timestamp {
@@ -403,6 +408,7 @@ public struct GardenClubFeedView: View { // swiftlint:disable:this type_body_len
             authorDisplayName: author,
             caption: caption,
             zoneTag: nil, // not yet captured in CK record
+            photoURL: photoURL,
             relativeTimeLabel: label,
             likeCount: 0, // future feature
             commentCount: 0 // future feature
@@ -416,83 +422,5 @@ public struct GardenClubFeedView: View { // swiftlint:disable:this type_body_len
             return "Gardener"
         }
         return String(first)
-    }
-}
-
-// MARK: - Post card
-
-private struct PostCard: View {
-    let post: GardenClubFeedView.ClubActivityViewData
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            HStack(spacing: 10) {
-                Circle()
-                    .fill(LinearGradient(
-                        colors: [CultivationTheme.Colors.brandMint, CultivationTheme.Colors.brandLeaf],
-                        startPoint: .topLeading,
-                        endPoint: .bottomTrailing
-                    ))
-                    .frame(width: 32, height: 32)
-                    .overlay(
-                        Text(initials(of: post.authorDisplayName))
-                            .font(CultivationTheme.Fonts.display(13, weight: .semibold))
-                            .foregroundStyle(.white)
-                    )
-                VStack(alignment: .leading, spacing: 1) {
-                    Text(post.authorDisplayName)
-                        .font(CultivationTheme.Fonts.body(13, weight: .bold))
-                        .foregroundStyle(CultivationTheme.Colors.textPrimary)
-                    HStack(spacing: 5) {
-                        if let zone = post.zoneTag {
-                            Text("Zone \(zone)")
-                                .foregroundStyle(CultivationTheme.Colors.smartTagForeground)
-                                .fontWeight(.bold)
-                        }
-                        if let when = post.relativeTimeLabel {
-                            Text(post.zoneTag == nil ? when : "\u{00B7} \(when)")
-                                .foregroundStyle(CultivationTheme.Colors.textTertiary)
-                        }
-                    }
-                    .font(CultivationTheme.Fonts.body(10))
-                }
-                Spacer()
-            }
-
-            if let caption = post.caption {
-                Text(caption)
-                    .font(CultivationTheme.Fonts.body(13))
-                    .foregroundStyle(CultivationTheme.Colors.textSecondary)
-                    .lineLimit(nil)
-            }
-
-            // Photo placeholder — wire to PhotoService asset URL when available
-            RoundedRectangle(cornerRadius: 12)
-                .fill(LinearGradient(
-                    colors: [CultivationTheme.Colors.brandLeaf, CultivationTheme.Colors.brandForest],
-                    startPoint: .topLeading,
-                    endPoint: .bottomTrailing
-                ))
-                .frame(height: 120)
-
-            HStack(spacing: 16) {
-                if post.likeCount > 0 {
-                    Label("\(post.likeCount)", systemImage: "heart")
-                }
-                if post.commentCount > 0 {
-                    Label("\(post.commentCount)", systemImage: "bubble.right")
-                }
-                Label("Share", systemImage: "arrow.up.right")
-            }
-            .font(CultivationTheme.Fonts.body(11, weight: .semibold))
-            .foregroundStyle(CultivationTheme.Colors.textTertiary)
-        }
-        .padding(14)
-        .paperCard()
-        .accessibilityIdentifier("club_post_\(post.id.uuidString)")
-    }
-
-    private func initials(of name: String) -> String {
-        String(name.prefix(1)).uppercased()
     }
 }

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/Home/HomeViewModel.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/Home/HomeViewModel.swift
@@ -21,6 +21,7 @@ final class HomeViewModel {
     var totalPlantCount: Int = 0
     var isLoading = false
     var userName: String = ""
+    var starterPlan = StarterPlan()
 
     /// Seeds that are ready to start indoors based on zone and current date.
     var readyToPlantSeeds: [Seed] = []
@@ -99,6 +100,13 @@ final class HomeViewModel {
         } catch {
             totalPlantCount = 0
             errorMessage = "Failed to load plants: \(error.localizedDescription)"
+        }
+
+        do {
+            starterPlan = try dataService.buildStarterPlan()
+        } catch {
+            starterPlan = StarterPlan()
+            errorMessage = "Failed to load starter plan: \(error.localizedDescription)"
         }
 
         // Resolve ready-to-plant seeds

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/Home/StarterPlanCard.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/Home/StarterPlanCard.swift
@@ -1,0 +1,90 @@
+import GrowWiseServices
+import SwiftUI
+
+struct StarterPlanCard: View {
+    let actions: [StarterPlanAction]
+    let onSelect: (StarterPlanAction) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(alignment: .firstTextBaseline) {
+                Text("Starter plan")
+                    .sectionLabelStyle()
+                    .foregroundStyle(CultivationTheme.Colors.sectionLabel)
+
+                Spacer()
+
+                Text("\(actions.count) steps")
+                    .font(CultivationTheme.Fonts.body(11, weight: .semibold))
+                    .foregroundStyle(CultivationTheme.Colors.textTertiary)
+            }
+
+            ForEach(actions) { action in
+                Button {
+                    onSelect(action)
+                } label: {
+                    StarterPlanActionRow(action: action)
+                }
+                .buttonStyle(.plain)
+                .accessibilityIdentifier("home_starter_plan_action_\(action.kind.rawValue)")
+            }
+        }
+        .padding(CultivationTheme.Spacing.cardPadding)
+        .paperCard()
+        .accessibilityIdentifier("home_starter_plan_card")
+    }
+}
+
+private struct StarterPlanActionRow: View {
+    let action: StarterPlanAction
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Image(systemName: action.systemImage)
+                .font(.system(size: 18, weight: .semibold))
+                .foregroundStyle(tint)
+                .frame(width: 34, height: 34)
+                .background(
+                    RoundedRectangle(cornerRadius: 9)
+                        .fill(tint.opacity(0.12))
+                )
+                .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(action.title)
+                    .font(CultivationTheme.Fonts.display(14, weight: .medium))
+                    .foregroundStyle(CultivationTheme.Colors.textPrimary)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.85)
+
+                Text(action.detail)
+                    .font(CultivationTheme.Fonts.body(11))
+                    .foregroundStyle(CultivationTheme.Colors.textTertiary)
+                    .lineLimit(2)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            Image(systemName: "chevron.right")
+                .font(.system(size: 11, weight: .bold))
+                .foregroundStyle(CultivationTheme.Colors.textTertiary)
+                .accessibilityHidden(true)
+        }
+        .padding(.vertical, 4)
+    }
+
+    private var tint: Color {
+        switch action.kind {
+        case .createGarden, .addPlant:
+            CultivationTheme.Colors.brandLeaf
+
+        case .reviewWateringReminder:
+            CultivationTheme.Colors.accentSky
+
+        case .browseRecommendations:
+            CultivationTheme.Colors.accentAmber
+
+        case .startTutorial:
+            CultivationTheme.Colors.accentCoral
+        }
+    }
+}

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/HomeView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/HomeView.swift
@@ -32,6 +32,13 @@ public struct HomeView: View {
                         .padding(.horizontal, CultivationTheme.Spacing.screenPadding)
                         .padding(.top, CultivationTheme.Spacing.sectionGap)
 
+                    if !viewModel.starterPlan.actions.isEmpty {
+                        StarterPlanCard(actions: viewModel.starterPlan.actions) { action in
+                            handleStarterPlanAction(action)
+                        }
+                        .padding(.horizontal, CultivationTheme.Spacing.screenPadding)
+                    }
+
                     Button {
                         router.selectedTab = .club
                     } label: {
@@ -130,6 +137,16 @@ public struct HomeView: View {
         .padding(CultivationTheme.Spacing.cardPadding)
         .paperCard()
         .accessibilityIdentifier("home_card_today_care")
+    }
+
+    private func handleStarterPlanAction(_ action: StarterPlanAction) {
+        switch action.kind {
+        case .createGarden, .addPlant, .reviewWateringReminder, .browseRecommendations:
+            router.selectedTab = .garden
+
+        case .startTutorial:
+            router.selectedTab = .profile
+        }
     }
 
     private func careTaskRow(_ reminder: PlantReminder) -> some View {

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/HomeView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/HomeView.swift
@@ -54,6 +54,7 @@ public struct HomeView: View {
                         .padding(.bottom, CultivationTheme.Spacing.sectionGap)
                 }
             }
+            .accessibilityIdentifier("home_screen")
             .safeAreaInset(edge: .top, spacing: 0) {
                 HomeHeroHeader(
                     userName: viewModel.userName,

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/PaywallView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/PaywallView.swift
@@ -24,7 +24,7 @@ public struct PaywallView: View {
     private let premiumYearlyID = "com.growwise.premium.annual"
     internal static let freePlanName = "Free"
     internal static let premiumPlanName = "Premium"
-    internal static let comparisonPlanNames = [freePlanName, premiumPlanName]
+    /// Source-of-truth rows for the Free vs Premium plan comparison table.
     internal static let comparisonRows: [PaywallComparisonRow] = [
         PaywallComparisonRow(feature: "Plant Health Guidance", free: "3/mo", premium: true),
         PaywallComparisonRow(feature: "Plant Limit", free: "50", premium: "500"),
@@ -32,7 +32,7 @@ public struct PaywallView: View {
         PaywallComparisonRow(feature: "Weather Adjust", free: false, premium: true),
         PaywallComparisonRow(feature: "Priority Support", free: false, premium: true),
         PaywallComparisonRow(feature: "Garden Clubs", free: true, premium: true),
-        PaywallComparisonRow(feature: "Analytics", free: "Basic", premium: "Standard"),
+        PaywallComparisonRow(feature: "Analytics", free: "Basic", premium: "Standard")
     ]
 
     public init() {}
@@ -361,11 +361,11 @@ public struct PaywallView: View {
                         .font(.system(.caption, weight: .semibold))
                         .foregroundStyle(CultivationTheme.Colors.textSecondary)
                         .frame(maxWidth: .infinity, alignment: .leading)
-                    Text(Self.comparisonPlanNames[0])
+                    Text(Self.freePlanName)
                         .font(.system(.caption, weight: .semibold))
                         .foregroundStyle(CultivationTheme.Colors.textSecondary)
                         .frame(width: 50)
-                    Text(Self.comparisonPlanNames[1])
+                    Text(Self.premiumPlanName)
                         .font(.system(.caption, weight: .semibold))
                         .foregroundStyle(CultivationTheme.Colors.accentCoral)
                         .frame(width: 66)
@@ -547,6 +547,7 @@ internal enum PaywallComparisonValue: ExpressibleByBooleanLiteral, ExpressibleBy
     }
 }
 
+/// A single feature row in the Free vs Premium paywall comparison table.
 internal struct PaywallComparisonRow {
     let feature: String
     let free: PaywallComparisonValue

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/PaywallView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/PaywallView.swift
@@ -22,8 +22,10 @@ public struct PaywallView: View {
     // Product IDs (Premium only — Pro is "Coming soon" and not purchasable)
     private let premiumMonthlyID = "com.growwise.premium.monthly"
     private let premiumYearlyID = "com.growwise.premium.annual"
-    static let comparisonPlanNames = ["Free", "Premium"]
-    static let comparisonRows: [PaywallComparisonRow] = [
+    internal static let freePlanName = "Free"
+    internal static let premiumPlanName = "Premium"
+    internal static let comparisonPlanNames = [freePlanName, premiumPlanName]
+    internal static let comparisonRows: [PaywallComparisonRow] = [
         PaywallComparisonRow(feature: "Plant Health Guidance", free: "3/mo", premium: true),
         PaywallComparisonRow(feature: "Plant Limit", free: "50", premium: "500"),
         PaywallComparisonRow(feature: "Smart Reminders", free: false, premium: true),
@@ -189,7 +191,7 @@ public struct PaywallView: View {
         VStack(spacing: 12) {
             tierCard(
                 tier: .free,
-                name: "Free",
+                name: Self.freePlanName,
                 icon: "leaf",
                 price: "$0",
                 period: "forever",
@@ -201,7 +203,7 @@ public struct PaywallView: View {
 
             tierCard(
                 tier: .premium,
-                name: "Premium",
+                name: Self.premiumPlanName,
                 icon: "crown",
                 price: isYearly ? "$34.99" : "$2.99",
                 period: isYearly ? "/year" : "/month",
@@ -531,7 +533,7 @@ public struct PaywallView: View {
 
 // MARK: - Comparison Value
 
-enum PaywallComparisonValue: ExpressibleByBooleanLiteral, ExpressibleByStringLiteral {
+internal enum PaywallComparisonValue: ExpressibleByBooleanLiteral, ExpressibleByStringLiteral {
     case check
     case cross
     case text(String)
@@ -545,7 +547,7 @@ enum PaywallComparisonValue: ExpressibleByBooleanLiteral, ExpressibleByStringLit
     }
 }
 
-struct PaywallComparisonRow {
+internal struct PaywallComparisonRow {
     let feature: String
     let free: PaywallComparisonValue
     let premium: PaywallComparisonValue

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/PaywallView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/PaywallView.swift
@@ -357,10 +357,6 @@ public struct PaywallView: View {
                         .font(.system(.caption, weight: .semibold))
                         .foregroundStyle(CultivationTheme.Colors.accentCoral)
                         .frame(width: 66)
-                    Text("Pro")
-                        .font(.system(.caption, weight: .semibold))
-                        .foregroundStyle(CultivationTheme.Colors.accentAmber)
-                        .frame(width: 40)
                 }
                 .padding(.horizontal, CultivationTheme.Spacing.cardPadding)
                 .padding(.vertical, 10)
@@ -368,14 +364,13 @@ public struct PaywallView: View {
                 Divider()
                     .background(CultivationTheme.Colors.divider)
 
-                comparisonRow(feature: "Plant Health Guidance", free: "3/mo", premium: true, pro: true)
-                comparisonRow(feature: "Plant Limit", free: "50", premium: "500", pro: true)
-                comparisonRow(feature: "Smart Reminders", free: false, premium: true, pro: true)
-                comparisonRow(feature: "Weather Adjust", free: false, premium: true, pro: true)
-                comparisonRow(feature: "Priority Support", free: false, premium: true, pro: true)
-                comparisonRow(feature: "Expert Consults", free: false, premium: false, pro: true)
-                comparisonRow(feature: "Garden Clubs", free: true, premium: true, pro: true)
-                comparisonRow(feature: "Analytics", free: "Basic", premium: "Standard", pro: true, isLast: true)
+                comparisonRow(feature: "Plant Health Guidance", free: "3/mo", premium: true)
+                comparisonRow(feature: "Plant Limit", free: "50", premium: "500")
+                comparisonRow(feature: "Smart Reminders", free: false, premium: true)
+                comparisonRow(feature: "Weather Adjust", free: false, premium: true)
+                comparisonRow(feature: "Priority Support", free: false, premium: true)
+                comparisonRow(feature: "Garden Clubs", free: true, premium: true)
+                comparisonRow(feature: "Analytics", free: "Basic", premium: "Standard", isLast: true)
             }
             .glassCard()
         }
@@ -386,7 +381,6 @@ public struct PaywallView: View {
         feature: String,
         free: ComparisonValue,
         premium: ComparisonValue,
-        pro: ComparisonValue,
         isLast: Bool = false
     ) -> some View {
         VStack(spacing: 0) {
@@ -400,8 +394,6 @@ public struct PaywallView: View {
                     .frame(width: 50)
                 comparisonCell(value: premium)
                     .frame(width: 66)
-                comparisonCell(value: pro)
-                    .frame(width: 40)
             }
             .padding(.horizontal, CultivationTheme.Spacing.cardPadding)
             .padding(.vertical, 8)

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/PaywallView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/PaywallView.swift
@@ -22,6 +22,16 @@ public struct PaywallView: View {
     // Product IDs (Premium only — Pro is "Coming soon" and not purchasable)
     private let premiumMonthlyID = "com.growwise.premium.monthly"
     private let premiumYearlyID = "com.growwise.premium.annual"
+    static let comparisonPlanNames = ["Free", "Premium"]
+    static let comparisonRows: [PaywallComparisonRow] = [
+        PaywallComparisonRow(feature: "Plant Health Guidance", free: "3/mo", premium: true),
+        PaywallComparisonRow(feature: "Plant Limit", free: "50", premium: "500"),
+        PaywallComparisonRow(feature: "Smart Reminders", free: false, premium: true),
+        PaywallComparisonRow(feature: "Weather Adjust", free: false, premium: true),
+        PaywallComparisonRow(feature: "Priority Support", free: false, premium: true),
+        PaywallComparisonRow(feature: "Garden Clubs", free: true, premium: true),
+        PaywallComparisonRow(feature: "Analytics", free: "Basic", premium: "Standard"),
+    ]
 
     public init() {}
 
@@ -349,11 +359,11 @@ public struct PaywallView: View {
                         .font(.system(.caption, weight: .semibold))
                         .foregroundStyle(CultivationTheme.Colors.textSecondary)
                         .frame(maxWidth: .infinity, alignment: .leading)
-                    Text("Free")
+                    Text(Self.comparisonPlanNames[0])
                         .font(.system(.caption, weight: .semibold))
                         .foregroundStyle(CultivationTheme.Colors.textSecondary)
                         .frame(width: 50)
-                    Text("Premium")
+                    Text(Self.comparisonPlanNames[1])
                         .font(.system(.caption, weight: .semibold))
                         .foregroundStyle(CultivationTheme.Colors.accentCoral)
                         .frame(width: 66)
@@ -364,13 +374,14 @@ public struct PaywallView: View {
                 Divider()
                     .background(CultivationTheme.Colors.divider)
 
-                comparisonRow(feature: "Plant Health Guidance", free: "3/mo", premium: true)
-                comparisonRow(feature: "Plant Limit", free: "50", premium: "500")
-                comparisonRow(feature: "Smart Reminders", free: false, premium: true)
-                comparisonRow(feature: "Weather Adjust", free: false, premium: true)
-                comparisonRow(feature: "Priority Support", free: false, premium: true)
-                comparisonRow(feature: "Garden Clubs", free: true, premium: true)
-                comparisonRow(feature: "Analytics", free: "Basic", premium: "Standard", isLast: true)
+                ForEach(Array(Self.comparisonRows.enumerated()), id: \.offset) { index, row in
+                    comparisonRow(
+                        feature: row.feature,
+                        free: row.free,
+                        premium: row.premium,
+                        isLast: index == Self.comparisonRows.count - 1
+                    )
+                }
             }
             .glassCard()
         }
@@ -379,8 +390,8 @@ public struct PaywallView: View {
 
     private func comparisonRow(
         feature: String,
-        free: ComparisonValue,
-        premium: ComparisonValue,
+        free: PaywallComparisonValue,
+        premium: PaywallComparisonValue,
         isLast: Bool = false
     ) -> some View {
         VStack(spacing: 0) {
@@ -406,7 +417,7 @@ public struct PaywallView: View {
     }
 
     @ViewBuilder
-    private func comparisonCell(value: ComparisonValue) -> some View {
+    private func comparisonCell(value: PaywallComparisonValue) -> some View {
         switch value {
         case .check:
             Image(systemName: "checkmark.circle.fill")
@@ -520,7 +531,7 @@ public struct PaywallView: View {
 
 // MARK: - Comparison Value
 
-private enum ComparisonValue: ExpressibleByBooleanLiteral, ExpressibleByStringLiteral {
+enum PaywallComparisonValue: ExpressibleByBooleanLiteral, ExpressibleByStringLiteral {
     case check
     case cross
     case text(String)
@@ -532,6 +543,12 @@ private enum ComparisonValue: ExpressibleByBooleanLiteral, ExpressibleByStringLi
     init(stringLiteral value: String) {
         self = .text(value)
     }
+}
+
+struct PaywallComparisonRow {
+    let feature: String
+    let free: PaywallComparisonValue
+    let premium: PaywallComparisonValue
 }
 
 #Preview {

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/PlantDatabase/PerenualBrowseView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/PlantDatabase/PerenualBrowseView.swift
@@ -313,7 +313,7 @@ struct PerenualSpeciesCard: View {
 
 // MARK: - Detail View
 
-struct PerenualDetailView: View {
+struct PerenualDetailView: View { // swiftlint:disable:this type_body_length
     let detail: PerenualSpeciesDetail
     @Environment(\.dismiss)
     private var dismiss
@@ -322,6 +322,10 @@ struct PerenualDetailView: View {
     @Environment(PlantDatabaseService.self)
     private var plantDatabaseService
     @State private var showAddConfirmation = false
+    @State private var availableGardens: [Garden] = []
+    @State private var selectedGarden: Garden?
+    @State private var showingError = false
+    @State private var errorMessage = ""
 
     var body: some View {
         NavigationStack {
@@ -348,6 +352,8 @@ struct PerenualDetailView: View {
                         // Safety warnings
                         safetySection
 
+                        gardenSelectionSection
+
                         Spacer(minLength: 80)
                     }
                     .padding(.horizontal, CultivationTheme.Spacing.screenPadding)
@@ -369,6 +375,12 @@ struct PerenualDetailView: View {
             } message: {
                 Text("\(detail.commonName) has been added to your plant collection.")
             }
+            .alert("Couldn't add plant", isPresented: $showingError) {
+                Button("OK", role: .cancel) {}
+            } message: {
+                Text(errorMessage)
+            }
+            .task { loadGardens() }
         }
     }
 
@@ -555,7 +567,8 @@ struct PerenualDetailView: View {
         } label: {
             Text("Add to My Garden")
         }
-        .buttonStyle(GradientButtonStyle())
+        .buttonStyle(GradientButtonStyle(isDisabled: selectedGarden == nil))
+        .disabled(selectedGarden == nil)
         .padding(.horizontal, CultivationTheme.Spacing.screenPadding)
         .padding(.bottom, 16)
         .background {
@@ -570,6 +583,34 @@ struct PerenualDetailView: View {
             .frame(height: 100)
         }
         .accessibilityIdentifier("perenual_add_to_garden")
+    }
+
+    private var gardenSelectionSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Add to")
+                .sectionLabelStyle()
+                .padding(.leading, 4)
+
+            if availableGardens.isEmpty {
+                Text("Create a garden before adding this plant.")
+                    .font(.system(.subheadline, design: .rounded))
+                    .foregroundStyle(CultivationTheme.Colors.textSecondary)
+                    .padding(CultivationTheme.Spacing.cardPadding)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .glassCard()
+            } else {
+                Picker("Garden", selection: $selectedGarden) {
+                    ForEach(availableGardens) { garden in
+                        Text(garden.name ?? "Garden").tag(garden as Garden?)
+                    }
+                }
+                .pickerStyle(.menu)
+                .padding(CultivationTheme.Spacing.cardPadding)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .glassCard()
+                .accessibilityIdentifier("perenual_picker_garden")
+            }
+        }
     }
 
     // MARK: - Helpers
@@ -609,6 +650,12 @@ struct PerenualDetailView: View {
     }
 
     private func addToGarden() {
+        guard let selectedGarden else {
+            errorMessage = "Create or select a garden before adding this plant."
+            showingError = true
+            return
+        }
+
         do {
             let care = detail.mappedCareInstructions
             let careText = care.isEmpty ? "" : "\n\nCare Instructions:\n" + care.map { "• \($0)" }.joined(separator: "\n")
@@ -622,9 +669,18 @@ struct PerenualDetailView: View {
                 space: detail.mappedSpaceRequirement,
                 notes: (detail.description ?? "") + careText
             )
+            try dataService.createUserPlant(from: detail, in: selectedGarden)
             showAddConfirmation = true
         } catch {
-            // Duplicate or DB error — silently skip
+            errorMessage = error.localizedDescription
+            showingError = true
+        }
+    }
+
+    private func loadGardens() {
+        availableGardens = dataService.fetchGardens(limit: 50)
+        if selectedGarden == nil {
+            selectedGarden = availableGardens.first
         }
     }
 }

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/PlantReminderDetailView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/PlantReminderDetailView.swift
@@ -430,9 +430,14 @@ public struct PlantReminderDetailView: View {
     }
 
     private func deleteReminder(_ reminder: PlantReminder) {
-        reminderService.cancelNotification(for: reminder)
-        // In a real implementation, you would delete from the data service
-        loadReminders()
+        do {
+            reminderService.cancelNotification(for: reminder)
+            try dataService.deleteReminder(reminder)
+            loadReminders()
+        } catch {
+            errorMessage = "Failed to delete reminder: \(error.localizedDescription)"
+            showingError = true
+        }
     }
 
     private func completeWateringReminder() {

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/PlantScannerView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/PlantScannerView.swift
@@ -16,7 +16,7 @@ public struct PlantScannerView: View {
         NavigationStack {
             ScrollView {
                 VStack(spacing: 16) {
-                    Text("Plant Health Scanner")
+                    Text("Plant Health Check")
                         .font(.title2)
                         .fontWeight(.semibold)
 
@@ -27,23 +27,23 @@ public struct PlantScannerView: View {
                     .buttonStyle(.borderedProminent)
                     .accessibilityIdentifier("scannerChoosePhotoButton")
 
-                    Button("Run Sample Diagnosis") {
+                    Button("Show Sample Guidance") {
                         diagnosticService.setSampleDiagnosis()
                     }
                     .buttonStyle(.bordered)
                     .accessibilityIdentifier("scannerRunSampleButton")
 
                     if diagnosticService.isAnalyzing {
-                        ProgressView("Analyzing image...")
+                        ProgressView("Checking image...")
                     }
 
-                    if let diagnosis = diagnosticService.lastDiagnosis {
+                    if let guidance = diagnosticService.lastDiagnosis {
                         VStack(alignment: .leading, spacing: 8) {
-                            Text("Primary Finding: \(diagnosis.primaryLabel)")
+                            Text("Primary Finding: \(guidance.primaryLabel)")
                                 .font(.headline)
                                 .accessibilityIdentifier("scannerPrimaryFinding")
-                            Text("Severity: \(diagnosis.severity.rawValue.capitalized)")
-                            Text(diagnosis.recommendation)
+                            Text("Severity: \(guidance.severity.rawValue.capitalized)")
+                            Text(guidance.recommendation)
                                 .font(.subheadline)
                                 .foregroundColor(.secondary)
                         }

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/ProfileView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/ProfileView.swift
@@ -79,6 +79,7 @@ public struct ProfileView: View {
                 .padding(.horizontal, CultivationTheme.Spacing.screenPadding)
                 .padding(.vertical, CultivationTheme.Spacing.sectionGap)
             }
+            .accessibilityIdentifier("profile_screen")
             .background(CultivationTheme.Colors.background)
             .navigationTitle("Me")
             .sheet(isPresented: $showTutorials) {

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/Settings/AppSettingsView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/Settings/AppSettingsView.swift
@@ -52,6 +52,7 @@ public struct AppSettingsView: View {
             .padding(.horizontal, CultivationTheme.Spacing.screenPadding)
             .padding(.vertical, CultivationTheme.Spacing.sectionGap)
         }
+        .accessibilityIdentifier("appsettings_screen")
         .background(CultivationTheme.Colors.background)
         .navigationTitle("Settings")
         .task { loadUserPreferences() }

--- a/GrowWisePackage/Sources/GrowWiseServices/ClubCloudKitService.swift
+++ b/GrowWisePackage/Sources/GrowWiseServices/ClubCloudKitService.swift
@@ -336,6 +336,14 @@ public final class ClubCloudKitService {
         record["activityDescription"] = activity.activityDescription ?? ""
         record["gardenName"] = activity.gardenName ?? ""
         record["timestamp"] = activity.timestamp ?? Date()
+        if let photoURL = activity.photoURL {
+            record["photoURL"] = photoURL
+            if let assetURL = Self.localFileURL(from: photoURL),
+               FileManager.default.fileExists(atPath: assetURL.path)
+            {
+                record["photo"] = CKAsset(fileURL: assetURL)
+            }
+        }
 
         do {
             _ = try await privateDatabase.save(record)
@@ -344,6 +352,13 @@ public final class ClubCloudKitService {
             logger.error("Failed to publish activity: \(error.localizedDescription)")
             throw ClubCloudKitError.saveFailed(error.localizedDescription)
         }
+    }
+
+    private static func localFileURL(from urlString: String) -> URL? {
+        if let url = URL(string: urlString), url.isFileURL {
+            return url
+        }
+        return URL(fileURLWithPath: urlString)
     }
 }
 

--- a/GrowWisePackage/Sources/GrowWiseServices/DataService+GardenClub.swift
+++ b/GrowWisePackage/Sources/GrowWiseServices/DataService+GardenClub.swift
@@ -59,9 +59,11 @@ public extension DataService {
     func createClubPost(
         caption: String,
         activityType: String,
-        plantName: String? = nil
+        plantName: String? = nil,
+        club: GardenClub? = nil,
+        photoURL: String? = nil
     ) throws -> ClubActivity {
-        guard let club = fetchPrimaryClub(), let clubID = club.id else {
+        guard let club = club ?? fetchPrimaryClub(), let clubID = club.id else {
             throw CreateClubPostError.noClub
         }
         let user = getCurrentUser()
@@ -79,6 +81,7 @@ public extension DataService {
             activityType: activityType,
             description: description
         )
+        activity.photoURL = photoURL
         let repo = ClubActivityRepository(context: mainContext)
         try repo.save(activity)
         return activity

--- a/GrowWisePackage/Sources/GrowWiseServices/DataService.swift
+++ b/GrowWisePackage/Sources/GrowWiseServices/DataService.swift
@@ -212,8 +212,19 @@ public final class DataService {
     // MARK: - Garden Management
 
     @discardableResult
-    public func createGarden(name: String, type: GardenType, isIndoor: Bool) throws -> Garden {
-        let garden = try gardens.create(name: name, type: type, isIndoor: isIndoor, user: getCurrentUser())
+    public func createGarden(
+        name: String,
+        type: GardenType,
+        isIndoor: Bool,
+        spaceSize: SpaceSize = .small
+    ) throws -> Garden {
+        let garden = try gardens.create(
+            name: name,
+            type: type,
+            isIndoor: isIndoor,
+            user: getCurrentUser(),
+            spaceSize: spaceSize
+        )
 
         // Ensure garden and plant caches reflect the newly added garden
         cache.invalidateAll(withPrefix: "gardens:")

--- a/GrowWisePackage/Sources/GrowWiseServices/DataService.swift
+++ b/GrowWisePackage/Sources/GrowWiseServices/DataService.swift
@@ -198,6 +198,17 @@ public final class DataService {
         try users.update(user)
     }
 
+    public func updateOnboardingProfile(
+        for user: User,
+        gardeningGoals: [GardeningGoal],
+        preferredPlantTypes: [PlantType]
+    ) throws {
+        user.gardeningGoals = gardeningGoals
+        user.preferredPlantTypes = preferredPlantTypes
+        user.lastModified = Date()
+        try users.update(user)
+    }
+
     // MARK: - Garden Management
 
     @discardableResult

--- a/GrowWisePackage/Sources/GrowWiseServices/DataService.swift
+++ b/GrowWisePackage/Sources/GrowWiseServices/DataService.swift
@@ -586,6 +586,19 @@ public final class DataService {
         invalidateReminderCaches()
     }
 
+    public func buildStarterPlan() throws -> StarterPlan {
+        let gardenList = try gardens.fetchAll(offset: 0, limit: 50)
+        let plantList = try plants.fetchAll()
+        let reminderList = try reminders.fetchActive(limit: 50)
+
+        return StarterPlanService.build(
+            user: getCurrentUser(),
+            gardens: gardenList,
+            plants: plantList,
+            reminders: reminderList
+        )
+    }
+
     private func invalidateReminderCaches() {
         cache.invalidateAll(withPrefix: "reminders:")
         cache.invalidateAll(withPrefix: "stats:count:")

--- a/GrowWisePackage/Sources/GrowWiseServices/DataService.swift
+++ b/GrowWisePackage/Sources/GrowWiseServices/DataService.swift
@@ -7,6 +7,16 @@ import SwiftData
 // SwiftLint suppressions for #284 — pre-existing structural & style violations; refactor out of scope.
 // swiftlint:disable file_length function_parameter_count large_tuple type_body_length
 
+public struct StarterPlantCreationResult {
+    public let plant: Plant
+    public let reminder: PlantReminder
+
+    public init(plant: Plant, reminder: PlantReminder) {
+        self.plant = plant
+        self.reminder = reminder
+    }
+}
+
 /// Modern @Observable data service for SwiftData operations
 /// Injected via environment - access with @Environment(DataService.self)
 /// No longer uses ObservableObject pattern - automatic observation with @Observable
@@ -279,6 +289,111 @@ public final class DataService {
         cache.invalidateAll(withPrefix: "plants:")
         cache.invalidateAll(withPrefix: "stats:count:")
         return plant
+    }
+
+    @discardableResult
+    public func createUserPlant(
+        from template: Plant,
+        in garden: Garden?,
+        plantingDate: Date = Date()
+    ) throws -> Plant {
+        let plant = Plant(
+            name: template.name ?? "Plant",
+            plantType: template.plantType ?? .houseplant,
+            difficultyLevel: template.difficultyLevel ?? .beginner,
+            isUserPlant: true
+        )
+        plant.scientificName = template.scientificName
+        plant.sunlightRequirement = template.sunlightRequirement
+        plant.wateringFrequency = template.wateringFrequency
+        plant.spaceRequirement = template.spaceRequirement
+        plant.notes = template.notes
+        plant.photoURLs = template.photoURLs
+        plant.companionPlants = template.companionPlants
+        plant.garden = garden
+        plant.plantingDate = plantingDate
+
+        try plants.add(plant)
+        cache.invalidateAll(withPrefix: "plants:")
+        cache.invalidateAll(withPrefix: "stats:count:")
+        return plant
+    }
+
+    @discardableResult
+    public func createUserPlant(
+        from detail: PerenualSpeciesDetail,
+        in garden: Garden?,
+        plantingDate: Date = Date()
+    ) throws -> Plant {
+        let plant = Plant(
+            name: detail.commonName,
+            plantType: detail.mappedPlantType,
+            difficultyLevel: detail.mappedDifficultyLevel,
+            isUserPlant: true
+        )
+        plant.scientificName = detail.scientificName.first
+        plant.sunlightRequirement = detail.mappedSunlightLevel
+        plant.wateringFrequency = detail.mappedWateringFrequency
+        plant.spaceRequirement = detail.mappedSpaceRequirement
+        plant.notes = Self.notes(from: detail)
+        if let imageURL = detail.defaultImage?.bestURL {
+            plant.photoURLs = [imageURL]
+        }
+        plant.garden = garden
+        plant.plantingDate = plantingDate
+
+        try plants.add(plant)
+        cache.invalidateAll(withPrefix: "plants:")
+        cache.invalidateAll(withPrefix: "stats:count:")
+        return plant
+    }
+
+    public func createStarterPlant(
+        from template: Plant,
+        in garden: Garden?,
+        plantingDate: Date = Date()
+    ) throws -> StarterPlantCreationResult {
+        let plant = try createUserPlant(from: template, in: garden, plantingDate: plantingDate)
+        let frequency = Self.reminderFrequency(for: plant.wateringFrequency)
+        let dueDate = Calendar.current.date(
+            byAdding: .day,
+            value: max(frequency.days, 1),
+            to: plantingDate
+        ) ?? plantingDate
+        let plantName = plant.name ?? "your plant"
+        let reminder = try createReminder(
+            title: "Water \(plantName)",
+            message: "Time to water \(plantName).",
+            type: .watering,
+            frequency: frequency,
+            dueDate: dueDate,
+            plant: plant
+        )
+        return StarterPlantCreationResult(plant: plant, reminder: reminder)
+    }
+
+    private static func reminderFrequency(for wateringFrequency: WateringFrequency?) -> ReminderFrequency {
+        switch wateringFrequency {
+        case .daily: .daily
+        case .everyOtherDay: .everyOtherDay
+        case .twiceWeekly: .twiceWeekly
+        case .weekly: .weekly
+        case .biweekly: .biweekly
+        case .monthly: .monthly
+        case .asNeeded, .none: .weekly
+        }
+    }
+
+    private static func notes(from detail: PerenualSpeciesDetail) -> String {
+        var sections: [String] = []
+        if let description = detail.description, !description.isEmpty {
+            sections.append(description)
+        }
+        let care = detail.mappedCareInstructions
+        if !care.isEmpty {
+            sections.append("Care Instructions:\n" + care.map { "• \($0)" }.joined(separator: "\n"))
+        }
+        return sections.joined(separator: "\n\n")
     }
 
     /// Insert a fully-configured database plant (e.g. from an external API).

--- a/GrowWisePackage/Sources/GrowWiseServices/DataService.swift
+++ b/GrowWisePackage/Sources/GrowWiseServices/DataService.swift
@@ -393,7 +393,7 @@ public final class DataService {
             user: getCurrentUser()
         )
 
-        cache.invalidate("reminders:active")
+        invalidateReminderCaches()
         if let plantId = plant.id {
             cache.invalidate("plants:\(plantId.uuidString)")
         }
@@ -441,10 +441,18 @@ public final class DataService {
 
     public func completeReminder(_ reminder: PlantReminder) throws {
         try reminders.complete(reminder)
+        invalidateReminderCaches()
     }
 
     public func deleteReminder(_ reminder: PlantReminder) throws {
         try reminders.delete(reminder)
+        invalidateReminderCaches()
+    }
+
+    private func invalidateReminderCaches() {
+        cache.invalidateAll(withPrefix: "reminders:")
+        cache.invalidateAll(withPrefix: "stats:count:")
+        cache.invalidate("stats:gardening_summary")
     }
 
     // MARK: - Journal Management

--- a/GrowWisePackage/Sources/GrowWiseServices/PhotoService.swift
+++ b/GrowWisePackage/Sources/GrowWiseServices/PhotoService.swift
@@ -88,6 +88,10 @@ public final class PhotoService {
         photosPath.appendingPathComponent("plant_\(plantId.uuidString)")
     }
 
+    private var clubPhotoPath: URL {
+        photosPath.appendingPathComponent("club_posts")
+    }
+
     private func createPlantDirectoryIfNeeded(for plantId: UUID) {
         let plantPath = plantPhotoPath(for: plantId)
         do {
@@ -95,6 +99,10 @@ public final class PhotoService {
         } catch {
             logger.error("Failed to create plant photo directory: \(error.localizedDescription, privacy: .public)")
         }
+    }
+
+    private func createClubPhotoDirectoryIfNeeded() throws {
+        try FileManager.default.createDirectory(at: clubPhotoPath, withIntermediateDirectories: true)
     }
 
     // MARK: - Photo Saving
@@ -172,6 +180,32 @@ public final class PhotoService {
         notes: String = ""
     ) async throws -> PlantPhoto {
         try await savePhoto(image, for: plant, type: type, notes: notes)
+    }
+
+    /// Stores a Garden Club post photo using the same local photo directory,
+    /// compression, and cache-loading path as plant photos.
+    public func saveClubPostPhotoData(_ data: Data) async throws -> String {
+        try createClubPhotoDirectoryIfNeeded()
+
+        let outputData: Data
+        if let image = UIImage(data: data) {
+            let processedImage = await processImage(image)
+            guard let jpegData = processedImage.jpegData(compressionQuality: compressionQuality) else {
+                throw PhotoError.compressionFailed
+            }
+            outputData = jpegData
+        } else {
+            outputData = data
+        }
+
+        let filename = "club_post_\(UUID().uuidString).jpg"
+        let fileURL = clubPhotoPath.appendingPathComponent(filename)
+
+        try await Task.detached(priority: .background) {
+            try outputData.write(to: fileURL)
+        }.value
+
+        return fileURL.absoluteString
     }
 
     // MARK: - Photo Loading
@@ -524,6 +558,10 @@ public final class PhotoService {
 
     public func requestCameraPermission() async -> Bool {
         false
+    }
+
+    public func saveClubPostPhotoData(_: Data) async throws -> String {
+        throw PhotoError.saveLocationUnavailable
     }
 }
 #endif

--- a/GrowWisePackage/Sources/GrowWiseServices/PlantDatabaseService.swift
+++ b/GrowWisePackage/Sources/GrowWiseServices/PlantDatabaseService.swift
@@ -271,6 +271,15 @@ public final class PlantDatabaseService {
         let gardenCompatibility = checkGardenTypeCompatibility(plant: plant, gardenType: userProfile.gardenType)
         score += gardenCompatibility * 20
 
+        if !userProfile.preferredPlantTypes.isEmpty {
+            maxScore += 20
+            if let plantType = plant.plantType, userProfile.preferredPlantTypes.contains(plantType) {
+                score += 20
+            } else {
+                score += 5
+            }
+        }
+
         return (score / maxScore) * 100
     }
 
@@ -286,10 +295,37 @@ public final class PlantDatabaseService {
         }
         if plant.spaceRequirement == userProfile.availableSpace { reasons.append("Ideal size for your available space") }
         if estimateCareTime(for: plant) == userProfile.timeCommitment { reasons.append("Matches your time commitment level") }
-        if plant.plantType == .herb || plant.plantType == .vegetable { reasons.append("Provides fresh, homegrown food") }
+        if let goalReason = goalReason(for: plant, userProfile: userProfile) {
+            reasons.append(goalReason)
+        } else if plant.plantType == .herb || plant.plantType == .vegetable {
+            reasons.append("Provides fresh, homegrown food")
+        }
         if plant.difficultyLevel == .beginner { reasons.append("Very forgiving for new gardeners") }
         if reasons.isEmpty { reasons.append("A versatile plant suitable for many garden types") }
         return reasons
+    }
+
+    private func goalReason(for plant: Plant, userProfile: UserGardenProfile) -> String? {
+        guard let plantType = plant.plantType else { return nil }
+        let goals = Set(userProfile.gardeningGoals)
+
+        if goals.contains(.growFood), [.vegetable, .herb, .fruit].contains(plantType) {
+            return "Matches your Grow My Own Food goal"
+        }
+        if goals.contains(.beautifySpace), [.flower, .shrub, .tree].contains(plantType) {
+            return "Matches your Beautify My Space goal"
+        }
+        if goals.contains(.medicinalHerbs), plantType == .herb {
+            return "Supports your wellness garden goal"
+        }
+        if goals.contains(.airPurification), [.houseplant, .tree].contains(plantType) {
+            return "Supports your air quality goal"
+        }
+        if goals.contains(.sustainability), [.vegetable, .herb, .fruit, .tree].contains(plantType) {
+            return "Supports your Sustainable Living goal"
+        }
+
+        return nil
     }
 
     private func estimateCareTime(for plant: Plant) -> UserTimeCommitment {
@@ -410,17 +446,23 @@ public struct UserGardenProfile {
     public let availableSpace: SpaceRequirement
     public let timeCommitment: UserTimeCommitment
     public let gardenType: String
+    public let preferredPlantTypes: [PlantType]
+    public let gardeningGoals: [GardeningGoal]
 
     public init(
         skillLevel: GardeningSkillLevel,
         availableSpace: SpaceRequirement,
         timeCommitment: UserTimeCommitment,
-        gardenType: String
+        gardenType: String,
+        preferredPlantTypes: [PlantType] = [],
+        gardeningGoals: [GardeningGoal] = []
     ) {
         self.skillLevel = skillLevel
         self.availableSpace = availableSpace
         self.timeCommitment = timeCommitment
         self.gardenType = gardenType
+        self.preferredPlantTypes = preferredPlantTypes
+        self.gardeningGoals = gardeningGoals
     }
 }
 

--- a/GrowWisePackage/Sources/GrowWiseServices/PlantDiagnosticService.swift
+++ b/GrowWisePackage/Sources/GrowWiseServices/PlantDiagnosticService.swift
@@ -64,10 +64,10 @@ public enum PlantDiagnosticError: Error, LocalizedError {
     public var errorDescription: String? {
         switch self {
         case .invalidImage:
-            "The selected image is invalid for diagnosis."
+            "The selected image is invalid for a plant health check."
 
         case .noClassification:
-            "No diagnosis could be produced from the image."
+            "No plant health guidance could be produced from this image."
 
         case .diagnosisLimitReached(let remaining, let tier):
             "You have reached your monthly Plant Health check limit (\(tier.aiDiagnosesPerMonth) per month on the \(tier.displayName) plan). Upgrade for unlimited checks. Remaining: \(remaining)."
@@ -75,9 +75,9 @@ public enum PlantDiagnosticError: Error, LocalizedError {
     }
 }
 
-// MARK: - Diagnosis Limit Constants
+// MARK: - Plant Health Check Limit Constants
 
-private enum DiagnosisLimits {
+private enum PlantHealthCheckLimits {
     static let freeTierMonthlyLimit = 3
 }
 
@@ -96,12 +96,12 @@ public final class PlantDiagnosticService {
 
     // MARK: - Subscription Tier Enforcement
 
-    /// Whether the given user can perform another diagnosis this month.
+    /// Whether the given user can perform another plant health check this month.
     public func canDiagnose(user: User) -> Bool {
         remainingDiagnoses(user: user) != 0
     }
 
-    /// Number of diagnoses remaining this month. Returns -1 for unlimited (premium/pro).
+    /// Number of plant health checks remaining this month. Returns -1 for unlimited (premium/pro).
     public func remainingDiagnoses(user: User) -> Int {
         let tier = user.subscriptionTier
         let limit = tier.aiDiagnosesPerMonth
@@ -112,7 +112,7 @@ public final class PlantDiagnosticService {
         return max(limit - used, 0)
     }
 
-    /// Diagnoses used in the current calendar month, accounting for monthly reset.
+    /// Plant health checks used in the current calendar month, accounting for monthly reset.
     private func diagnosesUsedThisMonth(user: User) -> Int {
         guard let lastReset = user.lastDiagnosisReset else {
             // Never reset — all recorded uses are from the current period
@@ -135,10 +135,10 @@ public final class PlantDiagnosticService {
         ])
     }
 
-    // MARK: - Diagnosis
+    // MARK: - Plant Health Check
 
-    /// Run a full diagnosis, enforcing the user's subscription limits.
-    /// Increments `user.aiDiagnosesUsed` and updates `user.lastDiagnosisReset` on success.
+    /// Run a plant health check, enforcing the user's subscription limits.
+    /// Increments the user's monthly health-check usage counter on success.
     public func diagnose(image: PlatformImage, user: User) async {
         isAnalyzing = true
         lastError = nil
@@ -155,8 +155,8 @@ public final class PlantDiagnosticService {
 
         do {
             let candidates = try await classify(image: image)
-            let diagnosis = summarize(candidates)
-            lastDiagnosis = diagnosis
+            let guidance = summarize(candidates)
+            lastDiagnosis = guidance
 
             // Track usage
             let calendar = Calendar.current
@@ -177,7 +177,7 @@ public final class PlantDiagnosticService {
         }
     }
 
-    /// Legacy diagnose without user — no tier enforcement.
+    /// Legacy image check without user — no tier enforcement.
     public func diagnose(image: PlatformImage) async {
         isAnalyzing = true
         lastError = nil
@@ -185,8 +185,8 @@ public final class PlantDiagnosticService {
 
         do {
             let candidates = try await classify(image: image)
-            let diagnosis = summarize(candidates)
-            lastDiagnosis = diagnosis
+            let guidance = summarize(candidates)
+            lastDiagnosis = guidance
         } catch {
             lastError = error.localizedDescription
         }

--- a/GrowWisePackage/Sources/GrowWiseServices/Repositories/GardenRepository.swift
+++ b/GrowWisePackage/Sources/GrowWiseServices/Repositories/GardenRepository.swift
@@ -33,8 +33,15 @@ public final class GardenRepository {
     }
 
     @discardableResult
-    public func create(name: String, type: GardenType, isIndoor: Bool, user: User?) throws -> Garden {
+    public func create(
+        name: String,
+        type: GardenType,
+        isIndoor: Bool,
+        user: User?,
+        spaceSize: SpaceSize = .small
+    ) throws -> Garden {
         let garden = Garden(name: name, gardenType: type, isIndoor: isIndoor)
+        garden.spaceAvailable = spaceSize
 
         if let user {
             garden.user = user

--- a/GrowWisePackage/Sources/GrowWiseServices/Resources/tutorials.json
+++ b/GrowWisePackage/Sources/GrowWiseServices/Resources/tutorials.json
@@ -62,7 +62,7 @@
         "duration": 5,
         "tips": [
           "Check plants every weekend at the same time",
-          "Keep a simple plant care journal or use the GrowWise app",
+          "Keep a simple plant care journal or use the Cultivation app",
           "Take photos to track growth progress"
         ],
         "commonMistakes": [

--- a/GrowWisePackage/Sources/GrowWiseServices/Resources/tutorials.json
+++ b/GrowWisePackage/Sources/GrowWiseServices/Resources/tutorials.json
@@ -349,7 +349,7 @@
       },
       {
         "title": "When Plants Stop Growing",
-        "content": "Slow or stopped growth can indicate several issues: dormancy, pot-bound roots, insufficient light, or nutrient deficiency. Learn to diagnose the cause.",
+        "content": "Slow or stopped growth can indicate several issues: dormancy, pot-bound roots, insufficient light, or nutrient deficiency. Learn to identify the cause.",
         "imageURL": "step-slow-growth",
         "duration": 8,
         "tips": [

--- a/GrowWisePackage/Sources/GrowWiseServices/StarterPlanService.swift
+++ b/GrowWisePackage/Sources/GrowWiseServices/StarterPlanService.swift
@@ -1,0 +1,158 @@
+import Foundation
+import GrowWiseModels
+
+public struct StarterPlan: Equatable, Sendable {
+    public let actions: [StarterPlanAction]
+
+    public init(actions: [StarterPlanAction] = []) {
+        self.actions = actions
+    }
+}
+
+public struct StarterPlanAction: Equatable, Identifiable, Sendable {
+    public enum Kind: String, Codable, Sendable {
+        case createGarden
+        case addPlant
+        case reviewWateringReminder
+        case browseRecommendations
+        case startTutorial
+    }
+
+    public let kind: Kind
+    public let title: String
+    public let detail: String
+    public let systemImage: String
+
+    public var id: Kind {
+        kind
+    }
+
+    public init(kind: Kind, title: String, detail: String, systemImage: String) {
+        self.kind = kind
+        self.title = title
+        self.detail = detail
+        self.systemImage = systemImage
+    }
+}
+
+public enum StarterPlanService {
+    public static func build(
+        user: User?,
+        gardens: [Garden],
+        plants: [Plant],
+        reminders: [PlantReminder]
+    ) -> StarterPlan {
+        let userPlants = plants.filter { $0.isUserPlant != false }
+        var actions: [StarterPlanAction] = []
+
+        if gardens.isEmpty {
+            actions.append(createGardenAction)
+            appendTutorialActionIfNeeded(for: user, to: &actions)
+            return StarterPlan(actions: Array(actions.prefix(3)))
+        }
+
+        if userPlants.isEmpty {
+            actions.append(addPlantAction)
+            appendRecommendationsActionIfUseful(for: user, plantCount: userPlants.count, to: &actions)
+            appendTutorialActionIfNeeded(for: user, to: &actions)
+            return StarterPlan(actions: Array(actions.prefix(3)))
+        }
+
+        if let reminder = firstUnreviewedWateringReminder(from: reminders, for: userPlants) {
+            actions.append(reviewWateringAction(for: reminder))
+        }
+
+        appendRecommendationsActionIfUseful(for: user, plantCount: userPlants.count, to: &actions)
+        appendTutorialActionIfNeeded(for: user, to: &actions)
+
+        return StarterPlan(actions: Array(actions.prefix(3)))
+    }
+
+    private static var createGardenAction: StarterPlanAction {
+        StarterPlanAction(
+            kind: .createGarden,
+            title: "Create your first garden",
+            detail: "Add the space you are growing in so plants and care tasks have a home.",
+            systemImage: "leaf.circle.fill"
+        )
+    }
+
+    private static var addPlantAction: StarterPlanAction {
+        StarterPlanAction(
+            kind: .addPlant,
+            title: "Add your first plant",
+            detail: "Pick a plant from the guide and connect it to this garden.",
+            systemImage: "plus.circle.fill"
+        )
+    }
+
+    private static func reviewWateringAction(for reminder: PlantReminder) -> StarterPlanAction {
+        let plantName = reminder.plant?.name ?? "your first plant"
+        return StarterPlanAction(
+            kind: .reviewWateringReminder,
+            title: "Review your watering reminder",
+            detail: "Confirm the first watering cadence for \(plantName).",
+            systemImage: "drop.circle.fill"
+        )
+    }
+
+    private static func recommendationsAction(for user: User?) -> StarterPlanAction {
+        let detail = if user?.gardeningGoals?.contains(.growFood) == true {
+            "Find food-friendly plants that match your selected goal."
+        } else if let plantType = user?.preferredPlantTypes?.first {
+            "Browse plants that match your \(plantType.displayName.lowercased()) interest."
+        } else {
+            "Browse plants matched to your garden setup and goals."
+        }
+
+        return StarterPlanAction(
+            kind: .browseRecommendations,
+            title: "Browse plants for your goals",
+            detail: detail,
+            systemImage: "sparkles"
+        )
+    }
+
+    private static func tutorialAction(for user: User?) -> StarterPlanAction {
+        let title = if user?.skillLevel == .beginner {
+            "Start a beginner tutorial"
+        } else {
+            "Start a focused tutorial"
+        }
+
+        return StarterPlanAction(
+            kind: .startTutorial,
+            title: title,
+            detail: "Learn the next best skill for your profile.",
+            systemImage: "book.circle.fill"
+        )
+    }
+
+    private static func appendRecommendationsActionIfUseful(
+        for user: User?,
+        plantCount: Int,
+        to actions: inout [StarterPlanAction]
+    ) {
+        guard plantCount < 2 else { return }
+        let hasPersonalization = user?.gardeningGoals?.isEmpty == false || user?.preferredPlantTypes?.isEmpty == false
+        guard hasPersonalization else { return }
+        actions.append(recommendationsAction(for: user))
+    }
+
+    private static func appendTutorialActionIfNeeded(for user: User?, to actions: inout [StarterPlanAction]) {
+        guard user?.completedTutorials.isEmpty != false else { return }
+        actions.append(tutorialAction(for: user))
+    }
+
+    private static func firstUnreviewedWateringReminder(
+        from reminders: [PlantReminder],
+        for plants: [Plant]
+    ) -> PlantReminder? {
+        let plantIDs = Set(plants.compactMap(\.id))
+        return reminders.first { reminder in
+            reminder.reminderType == .watering &&
+                reminder.lastCompletedDate == nil &&
+                reminder.plant?.id.map { plantIDs.contains($0) } == true
+        }
+    }
+}

--- a/GrowWisePackage/Sources/GrowWiseServices/TutorialService.swift
+++ b/GrowWisePackage/Sources/GrowWiseServices/TutorialService.swift
@@ -38,14 +38,43 @@ public final class TutorialService {
 
     public func getRecommendedTutorials(for user: User) -> [TutorialTopic] {
         let skillLevel = user.skillLevel
-        let userGardenType = "container"
+        let userGardenTypes = Set((user.gardens ?? []).compactMap { $0.gardenType?.rawValue } + ["all"])
+        let goals = user.gardeningGoals ?? []
 
         return getTutorialsForSkillLevel(skillLevel)
             .filter { tutorial in
-                tutorial.relevantGardenTypes.contains(userGardenType) ||
-                    tutorial.relevantGardenTypes.contains("all")
+                !userGardenTypes.isDisjoint(with: tutorial.relevantGardenTypes)
             }
-            .sorted { $0.estimatedDuration < $1.estimatedDuration }
+            .sorted {
+                let lhsPriority = tutorialPriority($0, goals: goals)
+                let rhsPriority = tutorialPriority($1, goals: goals)
+                if lhsPriority != rhsPriority {
+                    return lhsPriority < rhsPriority
+                }
+                return $0.estimatedDuration < $1.estimatedDuration
+            }
+    }
+
+    private func tutorialPriority(_ tutorial: TutorialTopic, goals: [GardeningGoal]) -> Int {
+        let goalSet = Set(goals)
+
+        if goalSet.contains(.learnSkills), tutorial.category == .planning {
+            return 0
+        }
+        if goalSet.contains(.growFood), [.planning, .preparation].contains(tutorial.category) {
+            return 1
+        }
+        if goalSet.contains(.sustainability), [.environment, .preparation].contains(tutorial.category) {
+            return 1
+        }
+        if goalSet.contains(.relaxation), tutorial.category == .care {
+            return 1
+        }
+        if goalSet.contains(.beautifySpace), [.planning, .care].contains(tutorial.category) {
+            return 1
+        }
+
+        return 10
     }
 
     // MARK: - Progress Tracking

--- a/GrowWisePackage/Tests/GrowWiseFeatureTests/CultivationBrandingTests.swift
+++ b/GrowWisePackage/Tests/GrowWiseFeatureTests/CultivationBrandingTests.swift
@@ -1,4 +1,5 @@
 @testable import GrowWiseFeature
+import Foundation
 import GrowWiseModels
 import Testing
 
@@ -55,5 +56,30 @@ struct CultivationBrandingTests {
     func clubInviteShareMessageDefaultsClubName() {
         let message = ClubInviteSharing.shareMessage(clubName: nil, code: "XYZ")
         #expect(message == "Join our club on Cultivation with code XYZ")
+    }
+
+    // MARK: - Resource-backed branding
+
+    @Test("Resource-backed user-facing copy uses Cultivation")
+    func resourceBackedCopyUsesCultivation() throws {
+        let packageRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+
+        let resourcePaths = [
+            "Sources/GrowWiseFeature/Resources/en.lproj/Localizable.strings",
+            "Sources/GrowWiseFeature/Resources/fr.lproj/Localizable.strings",
+            "Sources/GrowWiseFeature/Resources/es.lproj/Localizable.strings",
+            "Sources/GrowWiseFeature/Resources/de.lproj/Localizable.strings",
+            "Sources/GrowWiseServices/Resources/tutorials.json",
+        ]
+
+        for resourcePath in resourcePaths {
+            let resourceURL = packageRoot.appendingPathComponent(resourcePath)
+            let contents = try String(contentsOf: resourceURL, encoding: .utf8)
+            #expect(!contents.contains("GrowWise"), "\(resourcePath) still contains GrowWise")
+            #expect(!contents.contains("Grow Wise"), "\(resourcePath) still contains Grow Wise")
+        }
     }
 }

--- a/GrowWisePackage/Tests/GrowWiseFeatureTests/GardenClubFeedRoutingTests.swift
+++ b/GrowWisePackage/Tests/GrowWiseFeatureTests/GardenClubFeedRoutingTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 @testable import GrowWiseFeature
 import GrowWiseModels
 import SwiftData
@@ -24,13 +25,29 @@ struct GardenClubFeedRoutingTests {
 
     @Test("Multiple clubs routes to list")
     func multipleClubsRoutesToList() {
-        let a = GardenClub(name: "A", ownerID: "user-1", inviteCode: "AAAAAA")
-        let b = GardenClub(name: "B", ownerID: "user-1", inviteCode: "BBBBBB")
-        let route = GardenClubTabRoute.resolve(clubs: [a, b])
+        let firstClub = GardenClub(name: "A", ownerID: "user-1", inviteCode: "AAAAAA")
+        let secondClub = GardenClub(name: "B", ownerID: "user-1", inviteCode: "BBBBBB")
+        let route = GardenClubTabRoute.resolve(clubs: [firstClub, secondClub])
         guard case .list(let clubs) = route else {
             Issue.record("expected .list route, got \(route)")
             return
         }
         #expect(clubs.count == 2)
+    }
+
+    @Test("ClubActivity view data carries optional photo URL")
+    func clubActivityViewDataCarriesPhotoURL() {
+        let activity = ClubActivity(
+            clubID: UUID(),
+            memberName: "Avery",
+            memberID: "user-1",
+            activityType: "shared",
+            description: "First tomato flower"
+        )
+        activity.photoURL = "file:///tmp/tomato.jpg"
+
+        let viewData = GardenClubFeedView.viewData(from: activity)
+
+        #expect(viewData.photoURL == "file:///tmp/tomato.jpg")
     }
 }

--- a/GrowWisePackage/Tests/GrowWiseFeatureTests/HomeViewModelTests.swift
+++ b/GrowWisePackage/Tests/GrowWiseFeatureTests/HomeViewModelTests.swift
@@ -296,7 +296,7 @@ struct HomeViewModelTests {
         #expect(vm.completedIDs.contains(reminder.id))
     }
 
-    @Test("complete() persists the completion and allTasksDone reflects it via completedIDs")
+    @Test("complete() reloads without stale completed reminders")
     func completeReloadsDataAfterDelay() async throws {
         let dataService = try DataService.makeForTesting()
         let plant = try dataService.createPlant(name: "Tomato", type: .vegetable)
@@ -320,19 +320,10 @@ struct HomeViewModelTests {
         // complete() persists completion, waits ~400 ms, then reloads
         await vm.complete(reminder: reminder, dataService: dataService)
 
-        // INTEGRATION GAP: DataService.completeReminder() does not invalidate the
-        // "reminders:active:limit:50" cache key (only exact invalidate("reminders:active")
-        // is called on create, not on complete). The reload inside complete() therefore
-        // gets a 2-minute cache hit with stale data: the now-disabled reminder is still
-        // returned by fetchActiveReminders() and lands back in dueTodayReminders.
-        // Fix: add cache.invalidateAll(withPrefix: "reminders:active") inside
-        // DataService.completeReminder(), or filter by isEnabled in HomeViewModel.load().
-        //
-        // What we CAN assert: persistence worked, and allTasksDone is true because
-        // completedIDs accounts for the visually-completed reminder.
         #expect(reminder.isEnabled == false) // markCompleted() ran
         #expect(vm.completedIDs.contains(reminder.id)) // optimistic id retained after reload
-        #expect(vm.allTasksDone) // completedIDs hides the stale row
+        #expect(vm.dueTodayReminders.isEmpty) // reload no longer reads stale active-reminder cache
+        #expect(vm.allTasksDone) // completed reminder is no longer pending
     }
 
     // MARK: - latestClubPost

--- a/GrowWisePackage/Tests/GrowWiseFeatureTests/HomeViewModelTests.swift
+++ b/GrowWisePackage/Tests/GrowWiseFeatureTests/HomeViewModelTests.swift
@@ -106,6 +106,21 @@ struct HomeViewModelTests {
         #expect(vm.userName.isEmpty)
     }
 
+    @Test("load() publishes starter plan actions")
+    func loadPublishesStarterPlanActions() async throws {
+        let dataService = try DataService.makeForTesting()
+        _ = try dataService.createUser(
+            email: "test@example.com",
+            displayName: "Alice",
+            skillLevel: .beginner
+        )
+
+        let vm = HomeViewModel()
+        await vm.load(dataService: dataService)
+
+        #expect(vm.starterPlan.actions.map(\.kind) == [.createGarden, .startTutorial])
+    }
+
     // MARK: - allTasksDone
 
     @Test("allTasksDone is true when all visible reminders are in completedIDs")

--- a/GrowWisePackage/Tests/GrowWiseFeatureTests/OnboardingGardenSetupTests.swift
+++ b/GrowWisePackage/Tests/GrowWiseFeatureTests/OnboardingGardenSetupTests.swift
@@ -1,0 +1,22 @@
+@testable import GrowWiseFeature
+import Testing
+
+@MainActor
+@Suite("Onboarding garden setup state")
+struct OnboardingGardenSetupTests {
+    @Test("user profile defaults to creating a first garden")
+    func userProfileDefaultsToCreatingFirstGarden() {
+        let profile = UserProfile()
+
+        #expect(profile.shouldCreateFirstGarden)
+        #expect(profile.firstGardenName == "My First Garden")
+    }
+
+    @Test("completion summary describes skipped first garden")
+    func completionSummaryDescribesSkippedGarden() {
+        var profile = UserProfile()
+        profile.shouldCreateFirstGarden = false
+
+        #expect(CompletionView.gardenSummary(for: profile) == "Skipped")
+    }
+}

--- a/GrowWisePackage/Tests/GrowWiseFeatureTests/OnboardingGardenSetupTests.swift
+++ b/GrowWisePackage/Tests/GrowWiseFeatureTests/OnboardingGardenSetupTests.swift
@@ -19,4 +19,29 @@ struct OnboardingGardenSetupTests {
 
         #expect(CompletionView.gardenSummary(for: profile) == "Skipped")
     }
+
+    @Test("completion summary describes selected first plant")
+    func completionSummaryDescribesSelectedFirstPlant() {
+        var profile = UserProfile()
+        profile.selectedFirstPlantName = "Basil"
+
+        #expect(CompletionView.firstPlantSummary(for: profile) == "Basil")
+        #expect(CompletionView.nextCareSummary(for: profile) == "Watering reminder")
+    }
+
+    @Test("completion summary describes skipped first plant")
+    func completionSummaryDescribesSkippedFirstPlant() {
+        let profile = UserProfile()
+
+        #expect(CompletionView.firstPlantSummary(for: profile) == "Skipped")
+        #expect(CompletionView.nextCareSummary(for: profile) == nil)
+    }
+
+    @Test("completion summary joins primary goals")
+    func completionSummaryJoinsPrimaryGoals() {
+        var profile = UserProfile()
+        profile.goals = [.growFood, .learnSkills, .sustainability]
+
+        #expect(CompletionView.goalsSummary(for: profile) == "Grow My Own Food, Learn Gardening +1")
+    }
 }

--- a/GrowWisePackage/Tests/GrowWiseFeatureTests/PaywallPresentationTests.swift
+++ b/GrowWisePackage/Tests/GrowWiseFeatureTests/PaywallPresentationTests.swift
@@ -1,0 +1,21 @@
+import Foundation
+import Testing
+
+@Suite("Paywall presentation")
+struct PaywallPresentationTests {
+    @Test("1.0 paywall comparison does not advertise Pro")
+    func onePointZeroPaywallComparisonDoesNotAdvertisePro() throws {
+        let packageRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+
+        let paywallURL = packageRoot
+            .appendingPathComponent("Sources/GrowWiseFeature/Views/PaywallView.swift")
+        let contents = try String(contentsOf: paywallURL, encoding: .utf8)
+
+        #expect(!contents.contains("Text(\"Pro\")"))
+        #expect(!contents.contains("Expert Consults"))
+        #expect(contents.contains("Garden Clubs"))
+    }
+}

--- a/GrowWisePackage/Tests/GrowWiseFeatureTests/PaywallPresentationTests.swift
+++ b/GrowWisePackage/Tests/GrowWiseFeatureTests/PaywallPresentationTests.swift
@@ -5,8 +5,10 @@ import Testing
 struct PaywallPresentationTests {
     @Test("1.0 paywall comparison does not advertise Pro")
     func onePointZeroPaywallComparisonDoesNotAdvertisePro() {
-        #expect(PaywallView.comparisonPlanNames == ["Free", "Premium"])
-        #expect(!PaywallView.comparisonPlanNames.contains { $0.localizedCaseInsensitiveContains("pro") })
+        #expect(PaywallView.freePlanName == "Free")
+        #expect(PaywallView.premiumPlanName == "Premium")
+        #expect(!PaywallView.freePlanName.localizedCaseInsensitiveContains("pro"))
+        #expect(!PaywallView.premiumPlanName.localizedCaseInsensitiveContains("pro"))
         #expect(!PaywallView.comparisonRows.contains { $0.feature == "Expert Consults" })
         #expect(PaywallView.comparisonRows.contains { $0.feature == "Garden Clubs" })
     }

--- a/GrowWisePackage/Tests/GrowWiseFeatureTests/PaywallPresentationTests.swift
+++ b/GrowWisePackage/Tests/GrowWiseFeatureTests/PaywallPresentationTests.swift
@@ -1,21 +1,13 @@
-import Foundation
+@testable import GrowWiseFeature
 import Testing
 
 @Suite("Paywall presentation")
 struct PaywallPresentationTests {
     @Test("1.0 paywall comparison does not advertise Pro")
-    func onePointZeroPaywallComparisonDoesNotAdvertisePro() throws {
-        let packageRoot = URL(fileURLWithPath: #filePath)
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-
-        let paywallURL = packageRoot
-            .appendingPathComponent("Sources/GrowWiseFeature/Views/PaywallView.swift")
-        let contents = try String(contentsOf: paywallURL, encoding: .utf8)
-
-        #expect(!contents.contains("Text(\"Pro\")"))
-        #expect(!contents.contains("Expert Consults"))
-        #expect(contents.contains("Garden Clubs"))
+    func onePointZeroPaywallComparisonDoesNotAdvertisePro() {
+        #expect(PaywallView.comparisonPlanNames == ["Free", "Premium"])
+        #expect(!PaywallView.comparisonPlanNames.contains { $0.localizedCaseInsensitiveContains("pro") })
+        #expect(!PaywallView.comparisonRows.contains { $0.feature == "Expert Consults" })
+        #expect(PaywallView.comparisonRows.contains { $0.feature == "Garden Clubs" })
     }
 }

--- a/GrowWisePackage/Tests/GrowWiseServicesTests/DataServiceEdgeCaseTests.swift
+++ b/GrowWisePackage/Tests/GrowWiseServicesTests/DataServiceEdgeCaseTests.swift
@@ -599,10 +599,6 @@ struct DataServiceEdgeCaseTests {
 
         try service.deleteReminder(reminder)
 
-        // deleteReminder does not invalidate the active-reminders cache, so we must
-        // invalidate it manually before re-fetching to see the post-delete state.
-        service.invalidateAllCaches()
-
         let afterIds = service.fetchActiveReminders().map(\.id)
         #expect(!afterIds.contains(reminder.id))
     }

--- a/GrowWisePackage/Tests/GrowWiseServicesTests/DataServiceGardenClubTests.swift
+++ b/GrowWisePackage/Tests/GrowWiseServicesTests/DataServiceGardenClubTests.swift
@@ -38,4 +38,23 @@ struct DataServiceGardenClubTests {
         )
         #expect(activity.activityDescription == "Basil: Looking healthy!")
     }
+
+    @Test("createClubPost can target an explicit club and persist a photo URL")
+    func createClubPostWithExplicitClubAndPhotoURL() async throws {
+        let service = try await DataService.makeForTesting()
+        let firstClub = try service.createClub(name: "First Club", ownerID: "u1")
+        let secondClub = try service.createClub(name: "Second Club", ownerID: "u1")
+        let photoURL = "file:///tmp/club-photo.jpg"
+
+        let activity = try service.createClubPost(
+            caption: "First tomato flower",
+            activityType: "shared",
+            club: secondClub,
+            photoURL: photoURL
+        )
+
+        #expect(activity.clubID == secondClub.id)
+        #expect(activity.clubID != firstClub.id)
+        #expect(activity.photoURL == photoURL)
+    }
 }

--- a/GrowWisePackage/Tests/GrowWiseServicesTests/DataServiceOnboardingGardenTests.swift
+++ b/GrowWisePackage/Tests/GrowWiseServicesTests/DataServiceOnboardingGardenTests.swift
@@ -1,0 +1,30 @@
+@testable import GrowWiseModels
+@testable import GrowWiseServices
+import Testing
+
+@MainActor
+@Suite("DataService onboarding garden creation")
+struct DataServiceOnboardingGardenTests {
+    @Test("createGarden stores onboarding space and associates the current user")
+    func createGardenStoresOnboardingSpaceAndUser() throws {
+        let dataService = try DataService.makeForTesting()
+        let user = try dataService.createUser(
+            email: "gardener@example.com",
+            displayName: "Gardener",
+            skillLevel: .beginner
+        )
+
+        let garden = try dataService.createGarden(
+            name: "Patio Starter",
+            type: .container,
+            isIndoor: false,
+            spaceSize: .tiny
+        )
+
+        #expect(garden.name == "Patio Starter")
+        #expect(garden.gardenType == .container)
+        #expect(garden.isIndoor == false)
+        #expect(garden.spaceAvailable == .tiny)
+        #expect(garden.user?.id == user.id)
+    }
+}

--- a/GrowWisePackage/Tests/GrowWiseServicesTests/DataServicePerenualTemplateTests.swift
+++ b/GrowWisePackage/Tests/GrowWiseServicesTests/DataServicePerenualTemplateTests.swift
@@ -1,0 +1,52 @@
+import Foundation
+@testable import GrowWiseModels
+@testable import GrowWiseServices
+import Testing
+
+@MainActor
+@Suite("DataService Perenual plant activation")
+struct DataServicePerenualTemplateTests {
+    @Test("createUserPlant maps a Perenual detail into a garden plant")
+    func createUserPlantMapsPerenualDetail() throws {
+        let dataService = try DataService.makeForTesting()
+        let garden = try dataService.createGarden(name: "Herb Bed", type: .raised, isIndoor: false)
+        let detail = try decodeDetail()
+
+        let plant = try dataService.createUserPlant(
+            from: detail,
+            in: garden,
+            plantingDate: Date(timeIntervalSince1970: 1_800_000_000)
+        )
+
+        #expect(plant.isUserPlant == true)
+        #expect(plant.name == "Basil")
+        #expect(plant.scientificName == "Ocimum basilicum")
+        #expect(plant.plantType == .herb)
+        #expect(plant.difficultyLevel == .beginner)
+        #expect(plant.sunlightRequirement == .fullSun)
+        #expect(plant.wateringFrequency == .daily)
+        #expect(plant.notes?.contains("Fast-growing culinary herb.") == true)
+        #expect(plant.notes?.contains("Watering: Frequent") == true)
+        #expect(plant.photoURLs == ["https://example.com/basil.jpg"])
+        #expect(plant.garden?.id == garden.id)
+    }
+
+    private func decodeDetail() throws -> PerenualSpeciesDetail {
+        let json = """
+        {
+          "id": 42,
+          "common_name": "Basil",
+          "scientific_name": ["Ocimum basilicum"],
+          "type": "Herb",
+          "watering": "Frequent",
+          "sunlight": ["full sun"],
+          "care_level": "Low",
+          "description": "Fast-growing culinary herb.",
+          "default_image": {
+            "medium_url": "https://example.com/basil.jpg"
+          }
+        }
+        """
+        return try JSONDecoder().decode(PerenualSpeciesDetail.self, from: Data(json.utf8))
+    }
+}

--- a/GrowWisePackage/Tests/GrowWiseServicesTests/DataServicePlantTemplateTests.swift
+++ b/GrowWisePackage/Tests/GrowWiseServicesTests/DataServicePlantTemplateTests.swift
@@ -1,0 +1,65 @@
+import Foundation
+@testable import GrowWiseModels
+@testable import GrowWiseServices
+import Testing
+
+@MainActor
+@Suite("DataService plant template activation")
+struct DataServicePlantTemplateTests {
+    @Test("createUserPlant copies database-backed care fields into a garden plant")
+    func createUserPlantCopiesTemplateFields() throws {
+        let dataService = try DataService.makeForTesting()
+        let garden = try dataService.createGarden(name: "Kitchen Garden", type: .container, isIndoor: false)
+        let template = try createTemplate(dataService: dataService)
+
+        let plant = try dataService.createUserPlant(
+            from: template,
+            in: garden,
+            plantingDate: Date(timeIntervalSince1970: 1_800_000_000)
+        )
+
+        #expect(plant.isUserPlant == true)
+        #expect(plant.name == "Basil")
+        #expect(plant.scientificName == "Ocimum basilicum")
+        #expect(plant.plantType == .herb)
+        #expect(plant.difficultyLevel == .beginner)
+        #expect(plant.sunlightRequirement == .partialSun)
+        #expect(plant.wateringFrequency == .everyOtherDay)
+        #expect(plant.spaceRequirement == .small)
+        #expect(plant.notes?.contains("Pinch flowers") == true)
+        #expect(plant.garden?.id == garden.id)
+    }
+
+    @Test("createStarterPlant creates watering reminder from template cadence")
+    func createStarterPlantCreatesWateringReminder() throws {
+        let dataService = try DataService.makeForTesting()
+        let garden = try dataService.createGarden(name: "Kitchen Garden", type: .container, isIndoor: false)
+        let template = try createTemplate(dataService: dataService)
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+
+        let result = try dataService.createStarterPlant(
+            from: template,
+            in: garden,
+            plantingDate: now
+        )
+
+        #expect(result.plant.garden?.id == garden.id)
+        #expect(result.reminder.title == "Water Basil")
+        #expect(result.reminder.frequency == .everyOtherDay)
+        #expect(result.reminder.plant?.id == result.plant.id)
+    }
+
+    private func createTemplate(dataService: DataService) throws -> Plant {
+        try dataService.insertDatabasePlant(
+            name: "Basil",
+            scientificName: "Ocimum basilicum",
+            type: .herb,
+            difficulty: .beginner,
+            sunlight: .partialSun,
+            watering: .everyOtherDay,
+            space: .small,
+            notes: "Pinch flowers to keep leaves tender."
+        )
+        return try #require(dataService.fetchPlantDatabase().first { $0.name == "Basil" })
+    }
+}

--- a/GrowWisePackage/Tests/GrowWiseServicesTests/OnboardingPersistenceTests.swift
+++ b/GrowWisePackage/Tests/GrowWiseServicesTests/OnboardingPersistenceTests.swift
@@ -1,0 +1,28 @@
+@testable import GrowWiseModels
+@testable import GrowWiseServices
+import Testing
+
+@MainActor
+@Suite("Onboarding persistence")
+struct OnboardingPersistenceTests {
+    @Test("updateOnboardingProfile persists goals and preferred plant types")
+    func updateOnboardingProfilePersistsPreferences() throws {
+        let dataService = try DataService.makeForTesting()
+        let user = try dataService.createUser(
+            email: "gardener@example.com",
+            displayName: "Gardener",
+            skillLevel: .beginner
+        )
+
+        try dataService.updateOnboardingProfile(
+            for: user,
+            gardeningGoals: [.growFood, .learnSkills],
+            preferredPlantTypes: [.vegetable, .herb, .fruit]
+        )
+
+        let savedUser = try #require(dataService.getCurrentUser())
+
+        #expect(savedUser.gardeningGoals == [.growFood, .learnSkills])
+        #expect(savedUser.preferredPlantTypes == [.vegetable, .herb, .fruit])
+    }
+}

--- a/GrowWisePackage/Tests/GrowWiseServicesTests/PlantDatabaseOnboardingPersonalizationTests.swift
+++ b/GrowWisePackage/Tests/GrowWiseServicesTests/PlantDatabaseOnboardingPersonalizationTests.swift
@@ -1,0 +1,51 @@
+@testable import GrowWiseModels
+@testable import GrowWiseServices
+import Testing
+
+@MainActor
+@Suite("Plant database onboarding personalization")
+struct PlantDatabaseOnboardingPersonalizationTests {
+    @Test("recommendations use onboarding food goals for plant type and reason")
+    func recommendationsUseOnboardingFoodGoal() throws {
+        let dataService = try DataService.makeForTesting()
+        let plantDBService = PlantDatabaseService(dataService: dataService)
+        try seedRecommendationFixtures(dataService: dataService)
+
+        let profile = UserGardenProfile(
+            skillLevel: .beginner,
+            availableSpace: .small,
+            timeCommitment: .moderate,
+            gardenType: "outdoor",
+            preferredPlantTypes: [.vegetable, .herb, .fruit],
+            gardeningGoals: [.growFood]
+        )
+
+        let recommendations = plantDBService.getRecommendedPlants(for: profile, limit: 2)
+
+        #expect(recommendations.first?.plant.name == "Tomato")
+        #expect(recommendations.first?.reasons.contains("Matches your Grow My Own Food goal") == true)
+    }
+
+    private func seedRecommendationFixtures(dataService: DataService) throws {
+        try dataService.insertDatabasePlant(
+            name: "Marigold",
+            scientificName: "Tagetes",
+            type: .flower,
+            difficulty: .beginner,
+            sunlight: .fullSun,
+            watering: .twiceWeekly,
+            space: .small,
+            notes: "A forgiving flower."
+        )
+        try dataService.insertDatabasePlant(
+            name: "Tomato",
+            scientificName: "Solanum lycopersicum",
+            type: .vegetable,
+            difficulty: .beginner,
+            sunlight: .fullSun,
+            watering: .twiceWeekly,
+            space: .small,
+            notes: "A productive food crop."
+        )
+    }
+}

--- a/GrowWisePackage/Tests/GrowWiseServicesTests/PlantDiagnosticServiceTests.swift
+++ b/GrowWisePackage/Tests/GrowWiseServicesTests/PlantDiagnosticServiceTests.swift
@@ -299,7 +299,7 @@ struct PlantDiagnosticServiceTests {
 
     // MARK: - PlantDiagnosticError
 
-    @Test("diagnosisLimitReached error includes tier name and limit")
+    @Test("health check limit error includes tier name and limit without diagnosis copy")
     func diagnosisLimitReachedErrorDescription() {
         let error = PlantDiagnosticError.diagnosisLimitReached(remaining: 0, tier: .free)
         let description = error.localizedDescription
@@ -307,18 +307,23 @@ struct PlantDiagnosticServiceTests {
         #expect(description.contains("Free"))
         #expect(description.contains("3 per month"))
         #expect(description.contains("Upgrade"))
+        #expect(description.localizedCaseInsensitiveContains("plant health check"))
+        #expect(!description.localizedCaseInsensitiveContains("diagnosis"))
+        #expect(!description.contains("AI"))
     }
 
-    @Test("invalidImage error has user-friendly description")
+    @Test("invalidImage error describes plant health check")
     func invalidImageErrorDescription() {
         let error = PlantDiagnosticError.invalidImage
-        #expect(error.localizedDescription.contains("invalid"))
+        #expect(error.localizedDescription.localizedCaseInsensitiveContains("plant health check"))
+        #expect(!error.localizedDescription.localizedCaseInsensitiveContains("diagnosis"))
     }
 
-    @Test("noClassification error has user-friendly description")
+    @Test("noClassification error describes plant health guidance")
     func noClassificationErrorDescription() {
         let error = PlantDiagnosticError.noClassification
-        #expect(error.localizedDescription.contains("No diagnosis"))
+        #expect(error.localizedDescription.contains("No plant health guidance"))
+        #expect(!error.localizedDescription.localizedCaseInsensitiveContains("diagnosis"))
     }
 
     // MARK: - Initial State

--- a/GrowWisePackage/Tests/GrowWiseServicesTests/StarterPlanServiceTests.swift
+++ b/GrowWisePackage/Tests/GrowWiseServicesTests/StarterPlanServiceTests.swift
@@ -1,0 +1,72 @@
+@testable import GrowWiseModels
+@testable import GrowWiseServices
+import Testing
+
+@MainActor
+@Suite("Starter plan service")
+struct StarterPlanServiceTests {
+    @Test("starter plan asks skipped-garden users to create a garden")
+    func starterPlanAsksSkippedGardenUsersToCreateGarden() throws {
+        let dataService = try makeDataService()
+
+        let plan = try dataService.buildStarterPlan()
+
+        #expect(plan.actions.map(\.kind) == [.createGarden, .startTutorial])
+    }
+
+    @Test("starter plan asks users with a garden but no plants to add and browse")
+    func starterPlanAsksGardenOnlyUsersToAddAndBrowse() throws {
+        let dataService = try makeDataService(goals: [.growFood])
+        _ = try dataService.createGarden(name: "Patio Garden", type: .container, isIndoor: false)
+
+        let plan = try dataService.buildStarterPlan()
+
+        #expect(plan.actions.map(\.kind) == [.addPlant, .browseRecommendations, .startTutorial])
+    }
+
+    @Test("starter plan surfaces first watering reminder from persisted state")
+    func starterPlanSurfacesFirstWateringReminder() throws {
+        let dataService = try makeDataService(goals: [.growFood])
+        let garden = try dataService.createGarden(name: "Kitchen Garden", type: .container, isIndoor: false)
+        let template = Plant(name: "Basil", plantType: .herb, difficultyLevel: .beginner, isUserPlant: false)
+        template.wateringFrequency = .weekly
+        _ = try dataService.createStarterPlant(from: template, in: garden)
+
+        let plan = try dataService.buildStarterPlan()
+
+        #expect(plan.actions.first?.kind == .reviewWateringReminder)
+        #expect(plan.actions.first?.title == "Review your watering reminder")
+    }
+
+    @Test("starter plan clears when starter work is complete")
+    func starterPlanClearsWhenStarterWorkIsComplete() throws {
+        let dataService = try makeDataService(goals: [.growFood])
+        let user = try #require(dataService.getCurrentUser())
+        let garden = try dataService.createGarden(name: "Kitchen Garden", type: .container, isIndoor: false)
+        let template = Plant(name: "Basil", plantType: .herb, difficultyLevel: .beginner, isUserPlant: false)
+        let result = try dataService.createStarterPlant(from: template, in: garden)
+        _ = try dataService.createPlant(name: "Tomato", type: .vegetable, garden: garden)
+        try dataService.completeReminder(result.reminder)
+        user.completedTutorials = ["getting-started-indoor-plants"]
+        try dataService.updateUser(user)
+
+        let plan = try dataService.buildStarterPlan()
+
+        #expect(plan.actions.isEmpty)
+    }
+
+    private func makeDataService(goals: [GardeningGoal] = []) throws -> DataService {
+        let dataService = try DataService.makeForTesting()
+        let user = try dataService.createUser(
+            email: "gardener@example.com",
+            displayName: "Gardener",
+            skillLevel: .beginner
+        )
+        try dataService.updateOnboardingProfile(
+            for: user,
+            gardeningGoals: goals,
+            preferredPlantTypes: [.vegetable, .herb]
+        )
+        return dataService
+    }
+}

--- a/GrowWisePackage/Tests/GrowWiseServicesTests/TutorialServicePersonalizationTests.swift
+++ b/GrowWisePackage/Tests/GrowWiseServicesTests/TutorialServicePersonalizationTests.swift
@@ -1,0 +1,23 @@
+@testable import GrowWiseModels
+@testable import GrowWiseServices
+import Testing
+
+@MainActor
+@Suite("TutorialService personalization")
+struct TutorialServicePersonalizationTests {
+    @Test("recommended tutorials prioritize the learning goal over shortest duration")
+    func recommendedTutorialsPrioritizeLearningGoal() throws {
+        let dataService = try DataService.makeForTesting()
+        let tutorialService = TutorialService(dataService: dataService)
+        let user = User(
+            email: "learner@example.com",
+            displayName: "Learner",
+            skillLevel: .beginner
+        )
+        user.gardeningGoals = [.learnSkills]
+
+        let tutorials = tutorialService.getRecommendedTutorials(for: user)
+
+        #expect(tutorials.first?.category == .planning)
+    }
+}

--- a/GrowWiseUITests/CompostShoppingProfileUITests.swift
+++ b/GrowWiseUITests/CompostShoppingProfileUITests.swift
@@ -1,5 +1,7 @@
 import XCTest
 
+// swiftlint:disable single_test_class
+
 // MARK: - Compost Tracker UI Tests
 
 @MainActor
@@ -55,7 +57,9 @@ final class CompostTrackerUITests: XCTestCase {
                 NSPredicate(format: "identifier CONTAINS 'compost'")
             ).firstMatch
             guard gardenDetailTab.waitForExistence(timeout: 3) else {
-                throw XCTSkip("Compost tracker not directly accessible from Garden tab root — requires garden to be created first")
+                throw XCTSkip(
+                    "Compost tracker not directly accessible from Garden tab root — requires garden to be created first"
+                )
             }
             gardenDetailTab.tap()
         }
@@ -172,10 +176,10 @@ final class ShoppingListUITests: XCTestCase {
     }
 }
 
-// MARK: - Profile / Settings UI Tests
+// MARK: - Me / Settings UI Tests
 
 @MainActor
-final class ProfileSettingsUITests: XCTestCase {
+final class MeSettingsUITests: XCTestCase {
     var app: XCUIApplication!
 
     override func setUpWithError() throws {
@@ -189,67 +193,49 @@ final class ProfileSettingsUITests: XCTestCase {
         app.terminate()
     }
 
-    private func navigateToProfile() {
-        let profileTab = app.tabBars.buttons["Profile"]
-        if !profileTab.waitForExistence(timeout: 3) {
-            // Try "Settings" tab name
-            let settingsTab = app.tabBars.buttons["Settings"]
-            if settingsTab.waitForExistence(timeout: 3) {
-                settingsTab.tap()
-            }
-            return
-        }
-        profileTab.tap()
+    private func navigateToMe() {
+        let meTab = app.tabBars.buttons["Me"]
+        XCTAssertTrue(meTab.waitForExistence(timeout: 3), "Me tab not found")
+        meTab.tap()
     }
 
     // MARK: - Tests
 
-    /// Verifies the Profile/Settings tab is reachable.
-    func testProfileTabLoads() throws {
-        navigateToProfile()
+    /// Verifies the Me/Settings tab is reachable.
+    func testMeTabLoads() throws {
+        navigateToMe()
 
-        let profileScreen = app.otherElements.matching(
-            NSPredicate(format: "identifier == 'profile_screen' OR identifier == 'settings_screen'")
-        ).firstMatch
+        let profileScreen = app.scrollViews.matching(identifier: "profile_screen").firstMatch
         guard profileScreen.waitForExistence(timeout: 5) else {
-            throw XCTSkip("Profile/Settings screen not found — tab may have a different identifier")
+            throw XCTSkip("Me screen not found")
         }
 
-        XCTAssertTrue(profileScreen.exists, "Profile or Settings screen should be visible")
+        XCTAssertTrue(profileScreen.exists, "Me screen should be visible")
     }
 
-    /// Verifies user display name is shown on the profile screen.
-    func testProfileShowsUserInfo() throws {
-        navigateToProfile()
+    /// Verifies user display name is shown on the Me screen.
+    func testMeShowsUserInfo() throws {
+        navigateToMe()
 
-        let profileScreen = app.otherElements.matching(
-            NSPredicate(format: "identifier == 'profile_screen' OR identifier == 'settings_screen'")
-        ).firstMatch
+        let profileScreen = app.scrollViews.matching(identifier: "profile_screen").firstMatch
         guard profileScreen.waitForExistence(timeout: 5) else {
-            throw XCTSkip("Profile/Settings screen not found")
+            throw XCTSkip("Me screen not found")
         }
 
-        // User info section should exist
-        let userSection = app.otherElements.matching(
-            NSPredicate(format: "identifier CONTAINS 'profile'")
-        ).firstMatch
-        XCTAssertTrue(userSection.waitForExistence(timeout: 3) || profileScreen.exists,
-                      "Profile screen should show user information")
+        XCTAssertTrue(profileScreen.exists, "Me screen should show user information")
     }
 
     /// Verifies the App Settings screen is accessible.
     func testAppSettingsNavigates() throws {
-        navigateToProfile()
+        navigateToMe()
 
-        let settingsButton = app.buttons.matching(
-            NSPredicate(format: "identifier CONTAINS 'settings'")
-        ).firstMatch
+        let settingsButton = app.buttons.matching(identifier: "profile_row_settings").firstMatch
         guard settingsButton.waitForExistence(timeout: 3) else {
-            throw XCTSkip("Settings button not found on profile screen")
+            throw XCTSkip("Settings button not found on Me screen")
         }
         settingsButton.tap()
 
-        let settingsScreen = app.otherElements.matching(identifier: "appsettings_screen").firstMatch
+        let settingsScreen = app.scrollViews.matching(identifier: "appsettings_screen").firstMatch
         XCTAssertTrue(settingsScreen.waitForExistence(timeout: 5), "App Settings screen did not open")
     }
 }
@@ -281,18 +267,18 @@ final class HomeScreenUITests: XCTestCase {
     // MARK: - Tests
 
     /// Verifies Home screen loads with its accessibility identifier.
-    func testHomeScreenLoads() throws {
+    func testHomeScreenLoads() {
         navigateToHome()
 
-        let homeScreen = app.otherElements.matching(identifier: "home_screen").firstMatch
+        let homeScreen = app.scrollViews.matching(identifier: "home_screen").firstMatch
         XCTAssertTrue(homeScreen.waitForExistence(timeout: 10), "Home screen did not load")
     }
 
     /// Verifies seasonal tip card appears on Home.
-    func testSeasonalTipCardVisible() throws {
+    func testSeasonalTipCardVisible() {
         navigateToHome()
 
-        let homeScreen = app.otherElements.matching(identifier: "home_screen").firstMatch
+        let homeScreen = app.scrollViews.matching(identifier: "home_screen").firstMatch
         XCTAssertTrue(homeScreen.waitForExistence(timeout: 10))
 
         // Scroll to seasonal tip card
@@ -305,62 +291,45 @@ final class HomeScreenUITests: XCTestCase {
         XCTAssertTrue(homeScreen.waitForExistence(timeout: 3), "Home screen should still be visible")
     }
 
-    /// Verifies the "Browse Plant Guide" button is present and tappable.
-    func testBrowsePlantGuideButton() throws {
+    /// Verifies the current Home care summary appears.
+    func testTodayCareSummaryVisible() {
         navigateToHome()
 
-        let homeScreen = app.otherElements.matching(identifier: "home_screen").firstMatch
+        let homeScreen = app.scrollViews.matching(identifier: "home_screen").firstMatch
         XCTAssertTrue(homeScreen.waitForExistence(timeout: 10))
 
-        let plantGuideButton = app.buttons.matching(identifier: "home_button_plantguide").firstMatch
-        if !plantGuideButton.waitForExistence(timeout: 3) {
-            app.scrollViews.firstMatch.swipeUp()
-        }
-        guard plantGuideButton.waitForExistence(timeout: 3) else {
-            throw XCTSkip("Browse Plant Guide button not visible — may be scrolled off screen")
-        }
-        plantGuideButton.tap()
-
-        // Plant database should open (either as modal or full screen)
-        let plantDB = app.otherElements.matching(identifier: "plantdatabase_screen").firstMatch
-        XCTAssertTrue(plantDB.waitForExistence(timeout: 5), "Plant database should open after tapping Browse Plant Guide")
+        let todayCareTitle = app.staticTexts["Today's care · 0 tasks"]
+        let emptyStateTitle = app.staticTexts["Your garden is thriving"]
+        XCTAssertTrue(
+            todayCareTitle.waitForExistence(timeout: 3) || emptyStateTitle.waitForExistence(timeout: 3),
+            "Today care summary should be visible"
+        )
     }
 
-    /// Verifies the Seasonal Planner link on Home is present.
-    func testSeasonalPlannerLinkOnHome() throws {
+    /// Verifies the Club entry point on Home is present.
+    func testClubCardOnHome() {
         navigateToHome()
 
-        let homeScreen = app.otherElements.matching(identifier: "home_screen").firstMatch
+        let homeScreen = app.scrollViews.matching(identifier: "home_screen").firstMatch
         XCTAssertTrue(homeScreen.waitForExistence(timeout: 10))
 
-        // Scroll until the button is visible
-        let plannerButton = app.buttons.matching(identifier: "home_button_seasonalplanner").firstMatch
-        var attempts = 0
-        while !plannerButton.exists && attempts < 4 {
+        let clubCard = app.buttons.matching(identifier: "home_card_club").firstMatch
+        if !clubCard.waitForExistence(timeout: 3) {
             app.scrollViews.firstMatch.swipeUp()
-            attempts += 1
         }
-
-        guard plannerButton.waitForExistence(timeout: 3) else {
-            throw XCTSkip("Seasonal Planner link not found after scrolling — may require plants in the garden")
-        }
-
-        XCTAssertTrue(plannerButton.isEnabled, "Seasonal Planner button should be enabled")
+        XCTAssertTrue(clubCard.waitForExistence(timeout: 3), "Club card should be visible on Home")
     }
 
     /// Verifies overdue tasks section header is accessible.
-    func testOverdueTasksSectionPresent() throws {
+    func testOverdueTasksSectionPresent() {
         navigateToHome()
 
-        let homeScreen = app.otherElements.matching(identifier: "home_screen").firstMatch
+        let homeScreen = app.scrollViews.matching(identifier: "home_screen").firstMatch
         XCTAssertTrue(homeScreen.waitForExistence(timeout: 10))
 
-        // With --reset-data, there are no plants/reminders, so check either empty state or overdue header
+        // With --reset-data, there are no plants/reminders, so the care card should show its empty state.
         let emptyState = app.otherElements.matching(identifier: "home_empty_state").firstMatch
-        let overdueHeader = app.staticTexts.matching(identifier: "home_label_section_overdue").firstMatch
-
-        let hasContent = emptyState.waitForExistence(timeout: 5) || overdueHeader.waitForExistence(timeout: 3)
-        XCTAssertTrue(hasContent, "Home should show either empty state or overdue section")
+        XCTAssertTrue(emptyState.waitForExistence(timeout: 5), "Home should show the care empty state")
     }
 }
 
@@ -381,70 +350,22 @@ final class SeasonalPlannerUITests: XCTestCase {
         app.terminate()
     }
 
-    private func navigateToSeasonalPlanner() {
-        // Navigate via Home tab Seasonal Planner link
-        let homeTab = app.tabBars.buttons["Home"]
-        if homeTab.waitForExistence(timeout: 5) {
-            homeTab.tap()
-        }
-
-        var attempts = 0
-        let plannerButton = app.buttons.matching(identifier: "home_button_seasonalplanner").firstMatch
-        while !plannerButton.exists && attempts < 4 {
-            app.scrollViews.firstMatch.swipeUp()
-            attempts += 1
-        }
-        if plannerButton.waitForExistence(timeout: 3) {
-            plannerButton.tap()
-        }
-    }
-
     // MARK: - Tests
 
     /// Verifies seasonal planner screen loads.
     func testSeasonalPlannerLoads() throws {
-        navigateToSeasonalPlanner()
-
-        let plannerScreen = app.otherElements.matching(identifier: "seasonalplanner_screen").firstMatch
-        guard plannerScreen.waitForExistence(timeout: 5) else {
-            throw XCTSkip("Seasonal Planner screen not found — Seasonal Planner link may not be visible without plants")
-        }
-
-        XCTAssertTrue(plannerScreen.exists, "Seasonal Planner screen should be visible")
+        throw XCTSkip("Seasonal Planner is not exposed from the current 1.0 Home surface")
     }
 
     /// Verifies month selector strip is present.
     func testMonthSelectorPresent() throws {
-        navigateToSeasonalPlanner()
-
-        let plannerScreen = app.otherElements.matching(identifier: "seasonalplanner_screen").firstMatch
-        guard plannerScreen.waitForExistence(timeout: 5) else {
-            throw XCTSkip("Seasonal Planner not accessible from Home")
-        }
-
-        let currentMonthButton = app.buttons.matching(
-            NSPredicate(format: "identifier BEGINSWITH 'seasonalplanner_button_month_'")
-        ).firstMatch
-        XCTAssertTrue(currentMonthButton.waitForExistence(timeout: 5), "Month selector buttons should be visible in Seasonal Planner")
+        throw XCTSkip("Seasonal Planner is not exposed from the current 1.0 Home surface")
     }
 
     /// Verifies tapping a different month updates the activities list.
     func testMonthSelectionUpdatesActivities() throws {
-        navigateToSeasonalPlanner()
-
-        let plannerScreen = app.otherElements.matching(identifier: "seasonalplanner_screen").firstMatch
-        guard plannerScreen.waitForExistence(timeout: 5) else {
-            throw XCTSkip("Seasonal Planner not accessible")
-        }
-
-        // Tap month 6 (June)
-        let juneButton = app.buttons.matching(identifier: "seasonalplanner_button_month_6").firstMatch
-        guard juneButton.waitForExistence(timeout: 3) else {
-            throw XCTSkip("June month button not found")
-        }
-        juneButton.tap()
-
-        // The screen should update without crashing
-        XCTAssertTrue(plannerScreen.waitForExistence(timeout: 3), "Planner screen should update after selecting a month")
+        throw XCTSkip("Seasonal Planner is not exposed from the current 1.0 Home surface")
     }
 }
+
+// swiftlint:enable single_test_class

--- a/GrowWiseUITests/GardenClubUITests.swift
+++ b/GrowWiseUITests/GardenClubUITests.swift
@@ -1,283 +1,78 @@
 import XCTest
-@testable import GrowWise
 
 final class GardenClubUITests: XCTestCase {
-    
     var app: XCUIApplication!
-    
+
     override func setUpWithError() throws {
         continueAfterFailure = false
         app = XCUIApplication()
-        app.launchArguments = ["--uitesting"]
+        app.launchArguments = ["--uitesting", "--skip-onboarding", "--reset-data"]
         app.launch()
     }
-    
+
     override func tearDownWithError() throws {
-        app = nil
+        app.terminate()
     }
-    
-    // MARK: - Club List Tests
-    
-    @MainActor
-    func testClubListEmptyState() throws {
-        // Navigate to Profile > Garden Clubs
-        let profileTab = app.tabBars.buttons["Profile"]
-        XCTAssertTrue(profileTab.waitForExistence(timeout: 2))
-        profileTab.tap()
-        
-        // Garden Clubs should show empty state initially
-        // Note: This test assumes no clubs exist in UI testing mode
-        let gardenClubsButton = app.buttons["Garden Clubs"]
-        if gardenClubsButton.waitForExistence(timeout: 2) {
-            gardenClubsButton.tap()
-            
-            // Empty state should be visible
-            let emptyTitle = app.staticTexts["No Clubs Yet"]
-            XCTAssertTrue(emptyTitle.waitForExistence(timeout: 2))
-        }
+
+    private func element(_ identifier: String) -> XCUIElement {
+        app.descendants(matching: .any).matching(identifier: identifier).firstMatch
     }
-    
-    @MainActor
-    func testCreateClubFlow() throws {
-        // Navigate to clubs
-        navigateToClubs()
-        
-        // Tap Create Club button
-        let createButton = app.buttons["Create Club"]
-        if createButton.waitForExistence(timeout: 2) {
-            createButton.tap()
-            
-            // Fill in club name
-            let nameField = app.textFields["Club Name"]
-            XCTAssertTrue(nameField.waitForExistence(timeout: 2))
-            nameField.tap()
-            nameField.typeText("Test Garden Club")
-            
-            // Submit
-            let createButton = app.buttons["Create"]
-            XCTAssertTrue(createButton.waitForExistence(timeout: 2))
-            createButton.tap()
-            
-            // Should show success with invite code
-            let successView = app.staticTexts["Club Created!"]
-            XCTAssertTrue(successView.waitForExistence(timeout: 3))
-        }
+
+    private func navigateToClubTab(file: StaticString = #file, line: UInt = #line) {
+        let clubTab = app.tabBars.buttons["Club"]
+        XCTAssertTrue(clubTab.waitForExistence(timeout: 5.0), "Club tab not found", file: file, line: line)
+        clubTab.tap()
+
+        XCTAssertTrue(
+            element("club_tab_container").waitForExistence(timeout: 5.0),
+            "Club tab did not load",
+            file: file,
+            line: line
+        )
     }
-    
-    @MainActor
-    func testJoinClubFlow() throws {
-        navigateToClubs()
-        
-        // Tap Join Club button
-        let joinButton = app.buttons["Join Club"]
-        if joinButton.waitForExistence(timeout: 2) {
-            joinButton.tap()
-            
-            // Enter invite code
-            let codeField = app.textFields["Invite Code"]
-            XCTAssertTrue(codeField.waitForExistence(timeout: 2))
-            codeField.tap()
-            codeField.typeText("TEST42")
-            
-            // Submit
-            let submitButton = app.buttons["Join"]
-            XCTAssertTrue(submitButton.waitForExistence(timeout: 2))
-            submitButton.tap()
-        }
+
+    func testClubTabEmptyStateUsesTopLevelClubNavigation() {
+        navigateToClubTab()
+
+        XCTAssertTrue(app.staticTexts["Join a club or start one"].waitForExistence(timeout: 5.0))
+        XCTAssertTrue(app.buttons["Create a club"].waitForExistence(timeout: 3.0))
+        XCTAssertTrue(app.buttons["Join a club"].waitForExistence(timeout: 3.0))
     }
-    
-    // MARK: - Club Detail Tests
-    
-    @MainActor
-    func testClubDetailNavigation() throws {
-        // Assuming a club exists
-        navigateToClubs()
-        
-        // Tap on a club row if it exists
-        let clubRow = app.buttons.firstMatch
-        if clubRow.waitForExistence(timeout: 2) {
-            clubRow.tap()
-            
-            // Club detail should show name and invite code
-            XCTAssertTrue(app.navigationBars.firstMatch.waitForExistence(timeout: 2))
-            
-            // Navigate to Chat
-            let chatButton = app.buttons["club_detail_chat_button"]
-            if chatButton.waitForExistence(timeout: 2) {
-                chatButton.tap()
-                XCTAssertTrue(app.staticTexts["Chat"].waitForExistence(timeout: 2))
-                app.navigationBars.buttons.firstMatch.tap()
-            }
-            
-            // Navigate to Events
-            let eventsButton = app.buttons["club_detail_events_button"]
-            if eventsButton.waitForExistence(timeout: 2) {
-                eventsButton.tap()
-                XCTAssertTrue(app.staticTexts["Events"].waitForExistence(timeout: 2))
-            }
-        }
+
+    func testCreateClubFlowFromTopLevelClubTab() {
+        navigateToClubTab()
+
+        let createPromptButton = app.buttons["Create a club"]
+        XCTAssertTrue(createPromptButton.waitForExistence(timeout: 3.0))
+        createPromptButton.tap()
+
+        let nameField = app.textFields.matching(identifier: "create_club_name_field").firstMatch
+        XCTAssertTrue(nameField.waitForExistence(timeout: 3.0))
+        nameField.tap()
+        nameField.typeText("Test Garden Club")
+
+        let createButton = app.buttons.matching(identifier: "create_club_button").firstMatch
+        XCTAssertTrue(createButton.waitForExistence(timeout: 3.0))
+        createButton.tap()
+
+        XCTAssertTrue(app.staticTexts["Club Created!"].waitForExistence(timeout: 5.0))
+        XCTAssertTrue(element("create_club_invite_code").waitForExistence(timeout: 3.0))
     }
-    
-    @MainActor
-    func testInviteCodeCopy() throws {
-        navigateToClubs()
-        
-        let clubRow = app.buttons.firstMatch
-        if clubRow.waitForExistence(timeout: 2) {
-            clubRow.tap()
-            
-            // Tap invite code to copy
-            let inviteCodeCard = app.staticTexts.matching(identifier: "invite_code").firstMatch
-            if inviteCodeCard.waitForExistence(timeout: 2) {
-                inviteCodeCard.tap()
-                
-                // Should show "Copied!" feedback
-                let copiedToast = app.staticTexts["Copied!"]
-                XCTAssertTrue(copiedToast.waitForExistence(timeout: 2))
-            }
-        }
-    }
-    
-    // MARK: - Chat Tests
-    
-    @MainActor
-    func testSendMessage() throws {
-        navigateToClubs()
-        
-        let clubRow = app.buttons.firstMatch
-        if clubRow.waitForExistence(timeout: 2) {
-            clubRow.tap()
-            
-            let chatButton = app.buttons["club_detail_chat_button"]
-            if chatButton.waitForExistence(timeout: 2) {
-                chatButton.tap()
-                
-                // Type message
-                let messageField = app.textFields["Message…"]
-                XCTAssertTrue(messageField.waitForExistence(timeout: 2))
-                messageField.tap()
-                messageField.typeText("Hello from UI test!")
-                
-                // Send
-                let sendButton = app.buttons["club_chat_send_button"]
-                XCTAssertTrue(sendButton.waitForExistence(timeout: 2))
-                sendButton.tap()
-                
-                // Message should appear in list
-                let sentMessage = app.staticTexts["Hello from UI test!"]
-                XCTAssertTrue(sentMessage.waitForExistence(timeout: 3))
-            }
-        }
-    }
-    
-    @MainActor
-    func testSendPhoto() throws {
-        navigateToClubs()
-        
-        let clubRow = app.buttons.firstMatch
-        if clubRow.waitForExistence(timeout: 2) {
-            clubRow.tap()
-            
-            let chatButton = app.buttons["club_detail_chat_button"]
-            if chatButton.waitForExistence(timeout: 2) {
-                chatButton.tap()
-                
-                // Tap photo picker button
-                let photoButton = app.buttons["club_chat_photo_button"]
-                XCTAssertTrue(photoButton.waitForExistence(timeout: 2))
-                photoButton.tap()
-                
-                // PhotosPicker opens - in UI testing this may not work
-                // So we just verify the button exists
-            }
-        }
-    }
-    
-    // MARK: - Events Tests
-    
-    @MainActor
-    func testCreateEvent() throws {
-        navigateToClubs()
-        
-        let clubRow = app.buttons.firstMatch
-        if clubRow.waitForExistence(timeout: 2) {
-            clubRow.tap()
-            
-            let eventsButton = app.buttons["club_detail_events_button"]
-            if eventsButton.waitForExistence(timeout: 2) {
-                eventsButton.tap()
-                
-                // Tap add button
-                let addButton = app.buttons["club_events_add_button"]
-                XCTAssertTrue(addButton.waitForExistence(timeout: 2))
-                addButton.tap()
-                
-                // Fill event form
-                let titleField = app.textFields["Event Title"]
-                XCTAssertTrue(titleField.waitForExistence(timeout: 2))
-                titleField.tap()
-                titleField.typeText("Spring Planting Party")
-                
-                // Location
-                let locationField = app.textFields["Location (optional)"]
-                if locationField.waitForExistence(timeout: 2) {
-                    locationField.tap()
-                    locationField.typeText("Community Garden")
-                }
-                
-                // Create
-                let createButton = app.buttons["Create"]
-                XCTAssertTrue(createButton.waitForExistence(timeout: 2))
-                createButton.tap()
-                
-                // Event should appear in upcoming list
-                let newEvent = app.staticTexts["Spring Planting Party"]
-                XCTAssertTrue(newEvent.waitForExistence(timeout: 3))
-            }
-        }
-    }
-    
-    @MainActor
-    func testEventRSVP() throws {
-        navigateToClubs()
-        
-        let clubRow = app.buttons.firstMatch
-        if clubRow.waitForExistence(timeout: 2) {
-            clubRow.tap()
-            
-            let eventsButton = app.buttons["club_detail_events_button"]
-            if eventsButton.waitForExistence(timeout: 2) {
-                eventsButton.tap()
-                
-                // Tap on an event
-                let eventCard = app.otherElements.matching(identifier: "event_card").firstMatch
-                if eventCard.waitForExistence(timeout: 2) {
-                    eventCard.tap()
-                    
-                    // RSVP buttons should be present
-                    let goingButton = app.buttons["rsvp_accepted"]
-                    XCTAssertTrue(goingButton.waitForExistence(timeout: 2))
-                    
-                    goingButton.tap()
-                    
-                    // Should show as going
-                    XCTAssertTrue(goingButton.waitForExistence(timeout: 2))
-                }
-            }
-        }
-    }
-    
-    // MARK: - Helper Methods
-    
-    private func navigateToClubs() {
-        let profileTab = app.tabBars.buttons["Profile"]
-        XCTAssertTrue(profileTab.waitForExistence(timeout: 2))
-        profileTab.tap()
-        
-        // Look for Garden Clubs button
-        let gardenClubsButton = app.buttons["Garden Clubs"]
-        if gardenClubsButton.waitForExistence(timeout: 2) {
-            gardenClubsButton.tap()
-        }
+
+    func testJoinClubFlowFromTopLevelClubTab() {
+        navigateToClubTab()
+
+        let joinPromptButton = app.buttons["Join a club"]
+        XCTAssertTrue(joinPromptButton.waitForExistence(timeout: 3.0))
+        joinPromptButton.tap()
+
+        let codeField = app.textFields.matching(identifier: "join_club_code_field").firstMatch
+        XCTAssertTrue(codeField.waitForExistence(timeout: 3.0))
+        codeField.tap()
+        codeField.typeText("TEST42")
+
+        let joinButton = app.buttons.matching(identifier: "join_club_button").firstMatch
+        XCTAssertTrue(joinButton.waitForExistence(timeout: 3.0))
+        XCTAssertTrue(joinButton.isEnabled)
     }
 }

--- a/GrowWiseUITests/GrowWiseUITests.swift
+++ b/GrowWiseUITests/GrowWiseUITests.swift
@@ -1,12 +1,12 @@
 import XCTest
 
-final class GrowWiseUITests: XCTestCase {
+final class CultivationUITests: XCTestCase {
     var app: XCUIApplication!
-    
+
     override func setUpWithError() throws {
         continueAfterFailure = false
         app = XCUIApplication()
-        
+
         // Configure app for UI testing
         app.launchArguments = ["--uitesting", "--skip-onboarding", "--reset-data"]
         app.launch()
@@ -17,35 +17,35 @@ final class GrowWiseUITests: XCTestCase {
     }
 
     // MARK: - App Launch Tests
-    
+
     @MainActor
-    func testAppLaunches() throws {
+    func testAppLaunches() {
         // Test that the app launches successfully
         XCTAssertTrue(app.exists)
 
         // Verify the app rendered content — either the main tab bar
         // (onboarding complete) or onboarding welcome screen text.
         let tabBar = app.tabBars.firstMatch
-        let growWiseText = app.staticTexts["GrowWise"]
+        let cultivationText = app.staticTexts["Cultivation"]
         let foundTabBar = tabBar.waitForExistence(timeout: 15.0)
-        let foundOnboarding = !foundTabBar && growWiseText.waitForExistence(timeout: 10.0)
+        let foundOnboarding = !foundTabBar && cultivationText.waitForExistence(timeout: 10.0)
         XCTAssertTrue(foundTabBar || foundOnboarding, "Expected tab bar or onboarding screen")
     }
-    
+
     @MainActor
-    func testAppLaunchPerformance() throws {
+    func testAppLaunchPerformance() {
         // Measure app launch time
         measure(metrics: [XCTApplicationLaunchMetric()]) {
             app.launch()
         }
     }
-    
+
     // MARK: - Helper Methods
-    
+
     private func skipOnboardingIfNeeded() {
         // Skip onboarding if it appears
         let onboardingView = app.otherElements["OnboardingView"]
-        
+
         if onboardingView.waitForExistence(timeout: 2.0) {
             // Look for skip button
             let skipButton = app.buttons["Skip"]
@@ -54,7 +54,7 @@ final class GrowWiseUITests: XCTestCase {
                 return
             }
         }
-        
+
         // Wait for main app to load
         let mainView = app.otherElements["MainAppView"]
         XCTAssertTrue(mainView.waitForExistence(timeout: 5.0))

--- a/GrowWiseUITests/OnboardingFlowUITests.swift
+++ b/GrowWiseUITests/OnboardingFlowUITests.swift
@@ -6,8 +6,6 @@ final class OnboardingFlowUITests: XCTestCase {
     override func setUpWithError() throws {
         continueAfterFailure = false
         app = XCUIApplication()
-
-        // Reset app state for consistent testing
         app.launchArguments = ["--uitesting", "--reset-onboarding", "--reset-data"]
         app.launch()
     }
@@ -18,271 +16,154 @@ final class OnboardingFlowUITests: XCTestCase {
 
     // MARK: - Helpers
 
-    /// Waits for the Continue button to exist and taps it.
-    private func tapContinue(file: StaticString = #file, line: UInt = #line) {
-        let continueButton = app.buttons["Continue"]
-        XCTAssertTrue(continueButton.waitForExistence(timeout: 5.0), "Continue button not found", file: file, line: line)
-        continueButton.tap()
+    private func element(_ identifier: String) -> XCUIElement {
+        app.descendants(matching: .any).matching(identifier: identifier).firstMatch
     }
 
-    /// Selects a goal by label, then taps Continue (which requires enabled state).
-    private func selectGoalAndContinue(_ goalLabel: String, file: StaticString = #file, line: UInt = #line) {
-        let goalButton = app.buttons[goalLabel]
-        XCTAssertTrue(goalButton.waitForExistence(timeout: 3.0), "\(goalLabel) goal not found", file: file, line: line)
+    private func tapNext(file: StaticString = #file, line: UInt = #line) {
+        let nextButton = app.buttons.matching(identifier: "onboarding_nav_next").firstMatch
+        XCTAssertTrue(nextButton.waitForExistence(timeout: 5.0), "Onboarding next button not found", file: file, line: line)
+        XCTAssertTrue(nextButton.isEnabled, "Onboarding next button is disabled", file: file, line: line)
+        nextButton.tap()
+    }
+
+    private func selectGoalAndContinue(_ goalIdentifier: String, file: StaticString = #file, line: UInt = #line) {
+        let goalButton = element(goalIdentifier)
+        XCTAssertTrue(goalButton.waitForExistence(timeout: 3.0), "\(goalIdentifier) not found", file: file, line: line)
         goalButton.tap()
 
-        // Wait a beat for the disabled state to update after goal selection
-        let continueButton = app.buttons["Continue"]
-        XCTAssertTrue(continueButton.waitForExistence(timeout: 3.0), file: file, line: line)
-        // Poll briefly for enabled state
+        let nextButton = app.buttons.matching(identifier: "onboarding_nav_next").firstMatch
+        XCTAssertTrue(nextButton.waitForExistence(timeout: 3.0), file: file, line: line)
         var attempts = 0
-        while !continueButton.isEnabled && attempts < 10 {
+        while !nextButton.isEnabled, attempts < 10 {
             Thread.sleep(forTimeInterval: 0.2)
             attempts += 1
         }
-        XCTAssertTrue(continueButton.isEnabled, "Continue not enabled after selecting goal", file: file, line: line)
-        continueButton.tap()
+        XCTAssertTrue(nextButton.isEnabled, "Continue not enabled after selecting a goal", file: file, line: line)
+        nextButton.tap()
+    }
+
+    private func advanceToCompletion(skipGarden: Bool = false) {
+        XCTAssertTrue(app.staticTexts["Cultivation"].waitForExistence(timeout: 5.0))
+        tapNext()
+
+        XCTAssertTrue(element("onboarding_skill_beginner").waitForExistence(timeout: 5.0))
+        tapNext()
+
+        XCTAssertTrue(element("onboarding_goal_grow_food").waitForExistence(timeout: 5.0))
+        selectGoalAndContinue("onboarding_goal_grow_food")
+
+        let gardenToggle = element("onboarding_toggle_create_garden")
+        XCTAssertTrue(gardenToggle.waitForExistence(timeout: 5.0))
+        if skipGarden {
+            gardenToggle.tap()
+        }
+        tapNext()
+
+        let locationSkip = app.buttons.matching(identifier: "onboarding_location_skip").firstMatch
+        XCTAssertTrue(locationSkip.waitForExistence(timeout: 5.0))
+        locationSkip.tap()
+        tapNext()
+
+        let notificationsSkip = app.buttons.matching(identifier: "onboarding_notifications_skip").firstMatch
+        XCTAssertTrue(notificationsSkip.waitForExistence(timeout: 5.0))
+        notificationsSkip.tap()
+        tapNext()
+
+        XCTAssertTrue(element("onboarding_firstplant_title").waitForExistence(timeout: 5.0))
+        let firstPlantSkip = app.buttons.matching(identifier: "onboarding_firstplant_skip").firstMatch
+        XCTAssertTrue(firstPlantSkip.waitForExistence(timeout: 3.0))
+        firstPlantSkip.tap()
+        tapNext()
     }
 
     // MARK: - Complete Onboarding Flow Tests
 
-    func testCompleteOnboardingFlow() throws {
-        // 1. Welcome Screen
-        let welcomeTitle = app.staticTexts["GrowWise"]
-        XCTAssertTrue(welcomeTitle.waitForExistence(timeout: 5.0))
+    func testCompleteOnboardingFlow() {
+        advanceToCompletion()
 
-        tapContinue() // welcome → skill
+        XCTAssertTrue(app.staticTexts["Your garden awaits!"].waitForExistence(timeout: 5.0))
+        XCTAssertTrue(app.staticTexts["First Plant"].waitForExistence(timeout: 3.0))
+        tapNext()
 
-        // 2. Skill Assessment Screen (Beginner is selected by default)
-        let skillTitle = app.staticTexts["What's your gardening experience?"]
-        XCTAssertTrue(skillTitle.waitForExistence(timeout: 5.0))
-
-        tapContinue() // skill → goals
-
-        // 3. Gardening Goals Screen — select a goal and continue
-        let goalsTitle = app.staticTexts["What are your gardening goals?"]
-        XCTAssertTrue(goalsTitle.waitForExistence(timeout: 5.0))
-
-        selectGoalAndContinue("Grow My Own Food") // goals → location
-
-        // 4. Location Setup Screen
-        let locationTitle = app.staticTexts["Help us know your location"]
-        XCTAssertTrue(locationTitle.waitForExistence(timeout: 5.0))
-
-        let skipLocationButton = app.buttons["Skip for Now"]
-        if skipLocationButton.exists {
-            skipLocationButton.tap()
-        }
-
-        tapContinue() // location → notifications
-
-        // 5. Notification Permission Screen
-        let notificationTitle = app.staticTexts["Stay connected to your garden"]
-        XCTAssertTrue(notificationTitle.waitForExistence(timeout: 5.0))
-
-        let maybeLaterButton = app.buttons["Maybe Later"]
-        if maybeLaterButton.exists {
-            maybeLaterButton.tap()
-        }
-
-        tapContinue() // notifications → completion
-
-        // 6. Completion Screen
-        let completionTitle = app.staticTexts["Welcome to GrowWise!"]
-        XCTAssertTrue(completionTitle.waitForExistence(timeout: 5.0))
-
-        let getStartedButton = app.buttons["Get Started"]
-        XCTAssertTrue(getStartedButton.waitForExistence(timeout: 3.0))
-        getStartedButton.tap()
-
-        // 7. Verify navigation to main app (tab bar should appear)
         let tabBar = app.tabBars.firstMatch
         XCTAssertTrue(tabBar.waitForExistence(timeout: 5.0))
     }
 
-    func testOnboardingSkipFlow() throws {
-        // Test skipping through onboarding as quickly as possible
+    func testOnboardingSkipGardenFlow() {
+        advanceToCompletion(skipGarden: true)
 
-        let welcomeTitle = app.staticTexts["GrowWise"]
-        XCTAssertTrue(welcomeTitle.waitForExistence(timeout: 5.0))
+        XCTAssertTrue(app.staticTexts["Your garden awaits!"].waitForExistence(timeout: 5.0))
+        XCTAssertTrue(app.staticTexts["First Garden"].waitForExistence(timeout: 3.0))
+        XCTAssertTrue(app.staticTexts["Skipped"].waitForExistence(timeout: 3.0))
+        tapNext()
 
-        tapContinue() // welcome → skill
-
-        // Skill Assessment: Beginner is already selected by default
-        let skillTitle = app.staticTexts["What's your gardening experience?"]
-        XCTAssertTrue(skillTitle.waitForExistence(timeout: 5.0))
-        tapContinue() // skill → goals
-
-        // Goals: select one goal to enable Continue
-        let goalsTitle = app.staticTexts["What are your gardening goals?"]
-        XCTAssertTrue(goalsTitle.waitForExistence(timeout: 5.0))
-        selectGoalAndContinue("Grow My Own Food") // goals → location
-
-        // Location: skip and continue
-        let locationTitle = app.staticTexts["Help us know your location"]
-        XCTAssertTrue(locationTitle.waitForExistence(timeout: 5.0))
-        let skipButton = app.buttons["Skip for Now"]
-        if skipButton.exists { skipButton.tap() }
-        tapContinue() // location → notifications
-
-        // Notifications: skip and continue
-        let notifTitle = app.staticTexts["Stay connected to your garden"]
-        XCTAssertTrue(notifTitle.waitForExistence(timeout: 5.0))
-        let maybeLater = app.buttons["Maybe Later"]
-        if maybeLater.exists { maybeLater.tap() }
-        tapContinue() // notifications → completion
-
-        // Completion: finish
-        let completionTitle = app.staticTexts["Welcome to GrowWise!"]
-        XCTAssertTrue(completionTitle.waitForExistence(timeout: 5.0))
-        let getStartedButton = app.buttons["Get Started"]
-        XCTAssertTrue(getStartedButton.waitForExistence(timeout: 3.0))
-        getStartedButton.tap()
-
-        // Verify main app
-        let tabBar = app.tabBars.firstMatch
-        XCTAssertTrue(tabBar.waitForExistence(timeout: 5.0))
+        XCTAssertTrue(app.tabBars.firstMatch.waitForExistence(timeout: 5.0))
     }
 
-    func testOnboardingBackNavigation() throws {
-        // Test navigating backwards through onboarding
+    func testOnboardingBackNavigation() {
+        XCTAssertTrue(app.staticTexts["Cultivation"].waitForExistence(timeout: 5.0))
+        tapNext()
 
-        let welcomeTitle = app.staticTexts["GrowWise"]
-        XCTAssertTrue(welcomeTitle.waitForExistence(timeout: 5.0))
+        XCTAssertTrue(element("onboarding_skill_beginner").waitForExistence(timeout: 5.0))
+        tapNext()
 
-        tapContinue() // welcome → skill
-
-        let skillTitle = app.staticTexts["What's your gardening experience?"]
-        XCTAssertTrue(skillTitle.waitForExistence(timeout: 5.0))
-
-        // Select a non-default skill level
-        let intermediateButton = app.buttons["Intermediate"]
-        XCTAssertTrue(intermediateButton.waitForExistence(timeout: 3.0))
-        intermediateButton.tap()
-        tapContinue() // skill → goals
-
-        let goalsTitle = app.staticTexts["What are your gardening goals?"]
-        XCTAssertTrue(goalsTitle.waitForExistence(timeout: 5.0))
-
-        // Navigate back to skill assessment
-        let backButton = app.buttons["Back"]
-        XCTAssertTrue(backButton.exists)
+        XCTAssertTrue(element("onboarding_goal_grow_food").waitForExistence(timeout: 5.0))
+        let backButton = app.buttons.matching(identifier: "onboarding_nav_back").firstMatch
+        XCTAssertTrue(backButton.waitForExistence(timeout: 3.0))
         backButton.tap()
 
-        XCTAssertTrue(skillTitle.waitForExistence(timeout: 5.0))
-
-        // Navigate back to welcome
-        let backButton2 = app.buttons["Back"]
-        if backButton2.exists {
-            backButton2.tap()
-            XCTAssertTrue(welcomeTitle.waitForExistence(timeout: 5.0))
-        }
+        XCTAssertTrue(element("onboarding_skill_beginner").waitForExistence(timeout: 5.0))
     }
 
-    func testOnboardingFormValidation() throws {
-        // Test form validation throughout onboarding
+    func testOnboardingFormValidation() {
+        XCTAssertTrue(app.staticTexts["Cultivation"].waitForExistence(timeout: 5.0))
+        tapNext()
 
-        let welcomeTitle = app.staticTexts["GrowWise"]
-        XCTAssertTrue(welcomeTitle.waitForExistence(timeout: 5.0))
+        XCTAssertTrue(element("onboarding_skill_advanced").waitForExistence(timeout: 5.0))
+        element("onboarding_skill_advanced").tap()
+        tapNext()
 
-        tapContinue() // welcome → skill
+        XCTAssertTrue(element("onboarding_goal_beautify_space").waitForExistence(timeout: 5.0))
+        let nextButton = app.buttons.matching(identifier: "onboarding_nav_next").firstMatch
+        XCTAssertTrue(nextButton.exists)
+        XCTAssertFalse(nextButton.isEnabled, "Continue should be disabled without goal selection")
 
-        let skillTitle = app.staticTexts["What's your gardening experience?"]
-        XCTAssertTrue(skillTitle.waitForExistence(timeout: 5.0))
-
-        // Select skill level and continue
-        let advancedButton = app.buttons["Advanced"]
-        XCTAssertTrue(advancedButton.waitForExistence(timeout: 3.0))
-        advancedButton.tap()
-        tapContinue() // skill → goals
-
-        // Goals screen - Continue should be disabled without goal selection
-        let goalsTitle = app.staticTexts["What are your gardening goals?"]
-        XCTAssertTrue(goalsTitle.waitForExistence(timeout: 5.0))
-
-        let continueButton = app.buttons["Continue"]
-        XCTAssertTrue(continueButton.exists)
-        XCTAssertFalse(continueButton.isEnabled, "Continue should be disabled without goal selection")
-
-        // Select a goal — Continue should become enabled
-        selectGoalAndContinue("Beautify My Space") // goals → location
-
-        // Should progress to location screen
-        let locationTitle = app.staticTexts["Help us know your location"]
-        XCTAssertTrue(locationTitle.waitForExistence(timeout: 5.0))
+        selectGoalAndContinue("onboarding_goal_beautify_space")
+        XCTAssertTrue(element("onboarding_toggle_create_garden").waitForExistence(timeout: 5.0))
     }
 
-    func testOnboardingAccessibility() throws {
-        // Test that key onboarding elements are present and navigable
+    func testOnboardingAccessibility() {
+        XCTAssertTrue(app.staticTexts["Cultivation"].waitForExistence(timeout: 5.0))
+        tapNext()
 
-        // 1. Welcome screen has title and progress indicator
-        let welcomeTitle = app.staticTexts["GrowWise"]
-        XCTAssertTrue(welcomeTitle.waitForExistence(timeout: 5.0))
+        XCTAssertTrue(element("onboarding_step_skillAssessment").waitForExistence(timeout: 3.0))
+        XCTAssertTrue(element("onboarding_skill_intermediate").waitForExistence(timeout: 3.0))
+        element("onboarding_skill_intermediate").tap()
+        tapNext()
 
-        // Wait for onboarding UI to fully load
-        let progressText = app.staticTexts["1 of 6"]
-        XCTAssertTrue(progressText.waitForExistence(timeout: 3.0))
-
-        // 2. Skill assessment has title and skill level buttons
-        tapContinue() // welcome → skill
-
-        let skillTitle = app.staticTexts["What's your gardening experience?"]
-        XCTAssertTrue(skillTitle.waitForExistence(timeout: 5.0))
-
-        let intermediateButton = app.buttons["Intermediate"]
-        XCTAssertTrue(intermediateButton.waitForExistence(timeout: 3.0))
-        intermediateButton.tap()
-
-        // 3. Goals screen has title and goal buttons
-        tapContinue() // skill → goals
-
-        let goalsTitle = app.staticTexts["What are your gardening goals?"]
-        XCTAssertTrue(goalsTitle.waitForExistence(timeout: 5.0))
-
-        let goalButton = app.buttons["Grow My Own Food"]
-        XCTAssertTrue(goalButton.waitForExistence(timeout: 3.0))
+        XCTAssertTrue(element("onboarding_step_goals").waitForExistence(timeout: 3.0))
+        XCTAssertTrue(element("onboarding_goal_grow_food").waitForExistence(timeout: 3.0))
     }
 
-    func testOnboardingProgressIndicator() throws {
-        // Test that progress updates as user navigates through onboarding
+    func testOnboardingProgressIndicator() {
+        XCTAssertTrue(app.staticTexts["Cultivation"].waitForExistence(timeout: 5.0))
+        tapNext()
 
-        let welcomeTitle = app.staticTexts["GrowWise"]
-        XCTAssertTrue(welcomeTitle.waitForExistence(timeout: 5.0))
+        XCTAssertTrue(element("onboarding_step_skillAssessment").waitForExistence(timeout: 3.0))
+        tapNext()
 
-        // Check initial progress text (step indicator)
-        let initialProgress = app.staticTexts["1 of 6"]
-        XCTAssertTrue(initialProgress.waitForExistence(timeout: 3.0))
+        XCTAssertTrue(element("onboarding_step_goals").waitForExistence(timeout: 3.0))
+        selectGoalAndContinue("onboarding_goal_grow_food")
 
-        tapContinue() // welcome → skill
-
-        // Progress should update to step 2
-        let skillTitle = app.staticTexts["What's your gardening experience?"]
-        XCTAssertTrue(skillTitle.waitForExistence(timeout: 5.0))
-
-        let updatedProgress = app.staticTexts["2 of 6"]
-        XCTAssertTrue(updatedProgress.waitForExistence(timeout: 3.0))
-
-        // Select a non-default skill and advance to goals
-        let expertButton = app.buttons["Expert"]
-        XCTAssertTrue(expertButton.waitForExistence(timeout: 3.0))
-        expertButton.tap()
-        tapContinue() // skill → goals
-
-        let goalsTitle = app.staticTexts["What are your gardening goals?"]
-        XCTAssertTrue(goalsTitle.waitForExistence(timeout: 5.0))
-
-        let thirdProgress = app.staticTexts["3 of 6"]
-        XCTAssertTrue(thirdProgress.waitForExistence(timeout: 3.0))
+        XCTAssertTrue(element("onboarding_step_gardenSetup").waitForExistence(timeout: 3.0))
     }
 
-    func testOnboardingPerformance() throws {
-        // Measure onboarding launch performance
-
+    func testOnboardingPerformance() {
         measure(metrics: [XCTApplicationLaunchMetric()]) {
             app.launch()
         }
 
-        let welcomeTitle = app.staticTexts["GrowWise"]
-        XCTAssertTrue(welcomeTitle.waitForExistence(timeout: 5.0))
+        XCTAssertTrue(app.staticTexts["Cultivation"].waitForExistence(timeout: 5.0))
     }
 }

--- a/GrowWiseUITests/Phase3And4UITests.swift
+++ b/GrowWiseUITests/Phase3And4UITests.swift
@@ -1,12 +1,13 @@
 import XCTest
 
+// swiftlint:disable single_test_class
+
 // MARK: - Phase 3 & 4 UI Tests
 
 @MainActor
 class Phase3And4UITests: XCTestCase {
-    
     var app: XCUIApplication!
-    
+
     override func setUpWithError() throws {
         continueAfterFailure = false
         app = XCUIApplication()
@@ -15,7 +16,7 @@ class Phase3And4UITests: XCTestCase {
     }
 
     // MARK: - Companion Planting Tests
-    
+
     func testCompanionPlantingWarningsInAddPlantSheet() throws {
         throw XCTSkip("Companion planting not yet integrated in My Garden add-plant flow (only available from Home)")
     }
@@ -23,9 +24,9 @@ class Phase3And4UITests: XCTestCase {
     func testCompanionPlantingRecommendations() throws {
         throw XCTSkip("Companion planting not yet integrated in My Garden add-plant flow (only available from Home)")
     }
-    
+
     // MARK: - Soil Management Tests
-    
+
     func testSoilManagementView() throws {
         // Soil management requires MyGardenView which is replaced by GardenView stub in Task 4.
         // Full plant list and soil management arrive in Phase 3 (Task 6).
@@ -37,21 +38,21 @@ class Phase3And4UITests: XCTestCase {
         // Full plant list and soil management arrive in Phase 3 (Task 6).
         throw XCTSkip("MyGardenView replaced by GardenView stub in Task 4. Soil management arrives in Phase 3.")
     }
-    
+
     // MARK: - Garden Showcase (Public CloudKit) Tests
-    
+
     func testGardenShowcaseView() throws {
-        throw XCTSkip("Garden Showcase feature not implemented — no Profile tab exists")
+        throw XCTSkip("Garden Showcase remains deferred from the 1.0 Me tab")
     }
-    
+
     // MARK: - Subscription/Paywall Tests
-    
+
     func testPaywallView() throws {
-        throw XCTSkip("Paywall/Subscription feature not implemented — no Profile tab exists")
+        throw XCTSkip("Paywall UI is covered by focused feature tests for the 1.0 Me tab")
     }
 
     func testRestorePurchases() throws {
-        throw XCTSkip("Paywall/Subscription feature not implemented — no Profile tab exists")
+        throw XCTSkip("Restore purchases is covered by focused feature tests for the 1.0 Me tab")
     }
 }
 
@@ -59,9 +60,8 @@ class Phase3And4UITests: XCTestCase {
 
 @MainActor
 class Phase3And4PerformanceTests: XCTestCase {
-    
     var app: XCUIApplication!
-    
+
     override func setUpWithError() throws {
         continueAfterFailure = false
         app = XCUIApplication()
@@ -79,3 +79,5 @@ class Phase3And4PerformanceTests: XCTestCase {
         throw XCTSkip("MyGardenView replaced by GardenView stub in Task 4. Soil management arrives in Phase 3.")
     }
 }
+
+// swiftlint:enable single_test_class

--- a/docs/plans/2026-05-09-1-0-release-readiness.md
+++ b/docs/plans/2026-05-09-1-0-release-readiness.md
@@ -167,6 +167,8 @@ git commit -m "fix: persist reminder deletes"
 - Modify: `GrowWisePackage/Sources/GrowWiseFeature/Views/PaywallView.swift`
 - Modify/add tests in `GrowWisePackage/Tests/GrowWiseServicesTests/SubscriptionContractTests.swift` or feature tests if practical.
 
+**Progress:** Completed.
+
 **Steps:**
 1. Keep Premium monthly/annual actionable.
 2. Remove the Pro comparison column or mark it clearly as unavailable without implying purchase.

--- a/docs/plans/2026-05-09-1-0-release-readiness.md
+++ b/docs/plans/2026-05-09-1-0-release-readiness.md
@@ -19,6 +19,7 @@
 - #275 Remaining user-facing GrowWise resource strings
 - #285 Stale UI tests for Cultivation/current flows
 - #286 Reminder delete action does not remove persisted reminder
+- #296 Completing a reminder can reload stale active-reminder cache
 - #288 Persist onboarding level/goals and use them in personalization
 - #289 Onboarding creates a real first garden, skippable
 - #290 First plant onboarding creates a database-backed plant in the selected garden
@@ -45,12 +46,15 @@ Deferred, not 1.0:
 
 ---
 
-### Task 1: Persist Reminder Deletes (#286)
+### Task 1: Persist Reminder Mutations (#286 + #296)
 
 **Files:**
 - Modify: `GrowWisePackage/Sources/GrowWiseFeature/Views/PlantReminderDetailView.swift:432`
 - Modify: `GrowWisePackage/Sources/GrowWiseServices/DataService.swift:446`
 - Modify: `GrowWisePackage/Tests/GrowWiseServicesTests/DataServiceEdgeCaseTests.swift:580`
+- Modify: `GrowWisePackage/Tests/GrowWiseFeatureTests/HomeViewModelTests.swift:300`
+
+**Progress:** Completed.
 
 **Step 1: Write/update the failing service test**
 
@@ -68,7 +72,7 @@ Expected before implementation: FAIL because `DataService.deleteReminder(_:)` do
 
 **Step 3: Implement service cache invalidation**
 
-Update `DataService.deleteReminder(_:)` to invalidate reminder/stat caches after repository deletion:
+Update reminder mutation methods to invalidate reminder/stat caches after repository changes:
 
 ```swift
 public func deleteReminder(_ reminder: PlantReminder) throws {
@@ -78,6 +82,8 @@ public func deleteReminder(_ reminder: PlantReminder) throws {
     cache.invalidate("stats:gardening_summary")
 }
 ```
+
+Apply the same cache policy to `completeReminder(_:)` so Home reloads do not keep stale completed reminders.
 
 **Step 4: Implement view delete persistence**
 

--- a/docs/plans/2026-05-09-1-0-release-readiness.md
+++ b/docs/plans/2026-05-09-1-0-release-readiness.md
@@ -253,6 +253,8 @@ git commit -m "fix: persist reminder deletes"
 
 ### Task 8: Final Release Verification
 
+**Progress:** Completed.
+
 **Commands:**
 
 ```bash
@@ -269,3 +271,9 @@ gh issue list --repo jbcrane13/GrowWise --state open --limit 200 --json number,t
 - Package tests run and pass.
 - App build succeeds.
 - Open 1.0 board has no remaining blockers except explicitly deferred #287.
+
+**Verification (2026-05-09):**
+- `swiftformat --lint --config .swiftformat GrowWisePackage/Sources GrowWise`: 0/175 files require formatting, 10 files skipped.
+- `swiftlint lint --strict --config .swiftlint.yml`: 0 violations, 0 serious in 175 files.
+- `ssh mac-mini "cd ~/Projects/GrowWise/.worktrees/1-0-release-readiness-final-9632f08/GrowWisePackage && swift test"`: 1477 tests in 166 suites passed.
+- `ssh mac-mini "cd ~/Projects/GrowWise/.worktrees/1-0-release-readiness-final-9632f08 && xcodebuild -workspace GrowWise.xcworkspace -scheme GrowWise -sdk iphonesimulator build CODE_SIGN_IDENTITY='' CODE_SIGNING_REQUIRED=NO"`: build succeeded.

--- a/docs/plans/2026-05-09-1-0-release-readiness.md
+++ b/docs/plans/2026-05-09-1-0-release-readiness.md
@@ -150,6 +150,8 @@ git commit -m "fix: persist reminder deletes"
 - Modify: `GrowWisePackage/Sources/GrowWiseFeature/Resources/de.lproj/Localizable.strings`
 - Modify: `GrowWisePackage/Sources/GrowWiseServices/Resources/tutorials.json`
 
+**Progress:** Completed.
+
 **Steps:**
 1. Replace user-facing `GrowWise` with `Cultivation` only in resource strings/content.
 2. Do not rename module IDs, bundle IDs, product IDs, CloudKit IDs, logger subsystems, or source imports per ADR-020.

--- a/docs/plans/2026-05-09-1-0-release-readiness.md
+++ b/docs/plans/2026-05-09-1-0-release-readiness.md
@@ -216,6 +216,8 @@ git commit -m "fix: persist reminder deletes"
 - Modify: `GrowWisePackage/Sources/GrowWiseServices/TutorialService.swift`
 - Add/modify tests under `GrowWisePackage/Tests/GrowWiseServicesTests/` and `GrowWisePackage/Tests/GrowWiseFeatureTests/`
 
+**Progress:** #288 completed.
+
 **Steps:**
 1. Persist onboarding level/goals onto `User`, including `gardeningGoals` and derived `preferredPlantTypes`.
 2. Replace passive garden type selection with skippable first garden creation.

--- a/docs/plans/2026-05-09-1-0-release-readiness.md
+++ b/docs/plans/2026-05-09-1-0-release-readiness.md
@@ -216,7 +216,7 @@ git commit -m "fix: persist reminder deletes"
 - Modify: `GrowWisePackage/Sources/GrowWiseServices/TutorialService.swift`
 - Add/modify tests under `GrowWisePackage/Tests/GrowWiseServicesTests/` and `GrowWisePackage/Tests/GrowWiseFeatureTests/`
 
-**Progress:** #288 completed.
+**Progress:** #288 and #289 completed.
 
 **Steps:**
 1. Persist onboarding level/goals onto `User`, including `gardeningGoals` and derived `preferredPlantTypes`.

--- a/docs/plans/2026-05-09-1-0-release-readiness.md
+++ b/docs/plans/2026-05-09-1-0-release-readiness.md
@@ -188,6 +188,8 @@ git commit -m "fix: persist reminder deletes"
 - Modify: `GrowWisePackage/Sources/GrowWiseServices/ClubCloudKitService.swift`
 - Reuse: `GrowWisePackage/Sources/GrowWiseServices/PhotoService.swift`
 
+**Progress:** Completed.
+
 **Steps:**
 1. Add photo attachment to composer.
 2. Add selected club handling where the composer can be launched without an explicit club.

--- a/docs/plans/2026-05-09-1-0-release-readiness.md
+++ b/docs/plans/2026-05-09-1-0-release-readiness.md
@@ -216,7 +216,7 @@ git commit -m "fix: persist reminder deletes"
 - Modify: `GrowWisePackage/Sources/GrowWiseServices/TutorialService.swift`
 - Add/modify tests under `GrowWisePackage/Tests/GrowWiseServicesTests/` and `GrowWisePackage/Tests/GrowWiseFeatureTests/`
 
-**Progress:** #288, #289, #290, and #291 completed.
+**Progress:** #288, #289, #290, #291, and #292 completed.
 
 **Steps:**
 1. Persist onboarding level/goals onto `User`, including `gardeningGoals` and derived `preferredPlantTypes`.

--- a/docs/plans/2026-05-09-1-0-release-readiness.md
+++ b/docs/plans/2026-05-09-1-0-release-readiness.md
@@ -239,6 +239,8 @@ git commit -m "fix: persist reminder deletes"
 - Modify: `GrowWiseUITests/CompostShoppingProfileUITests.swift`
 - Modify: `GrowWiseUITests/Phase3And4UITests.swift`
 
+**Progress:** Completed.
+
 **Steps:**
 1. Replace stale user-facing `GrowWise` expectations with `Cultivation` where appropriate.
 2. Replace brittle visible text assertions with accessibility identifiers where stable IDs exist.

--- a/docs/plans/2026-05-09-1-0-release-readiness.md
+++ b/docs/plans/2026-05-09-1-0-release-readiness.md
@@ -129,6 +129,8 @@ git commit -m "fix: persist reminder deletes"
 - Modify: `GrowWisePackage/Sources/GrowWiseServices/PlantDiagnosticService.swift`
 - Modify tests that assert scanner copy, likely `GrowWiseUITests/PhaseOneTwoUITests.swift`
 
+**Progress:** Completed.
+
 **Steps:**
 1. Replace user-facing `Diagnosis` / `diagnosis` copy with `Plant Health Check`, `Care Guidance`, or `Plant Health Guidance`.
 2. Keep internal type names unless a user-facing string leaks.

--- a/docs/plans/2026-05-09-1-0-release-readiness.md
+++ b/docs/plans/2026-05-09-1-0-release-readiness.md
@@ -216,7 +216,7 @@ git commit -m "fix: persist reminder deletes"
 - Modify: `GrowWisePackage/Sources/GrowWiseServices/TutorialService.swift`
 - Add/modify tests under `GrowWisePackage/Tests/GrowWiseServicesTests/` and `GrowWisePackage/Tests/GrowWiseFeatureTests/`
 
-**Progress:** #288 and #289 completed.
+**Progress:** #288, #289, #290, and #291 completed.
 
 **Steps:**
 1. Persist onboarding level/goals onto `User`, including `gardeningGoals` and derived `preferredPlantTypes`.

--- a/docs/plans/2026-05-09-1-0-release-readiness.md
+++ b/docs/plans/2026-05-09-1-0-release-readiness.md
@@ -1,0 +1,253 @@
+# 1.0 Release Readiness Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Close every known 1.0 blocker for Cultivation and leave the deferred ambitious onboarding work clearly queued for 1.1.
+
+**Architecture:** Work from `codex/1.0-release-readiness`, branched from current `origin/master`. Keep changes grouped by GitHub issue and land the safest release gates first: test/build infrastructure, small correctness fixes, copy/branding cleanup, then the larger Club and onboarding/database flows. The 1.0 onboarding scope is intentionally pragmatic; #287 captures the richer 1.1 personalization roadmap.
+
+**Tech Stack:** SwiftUI, SwiftData, Swift 6 strict concurrency, Swift Testing, XCUITest, StoreKit 2, CloudKit, Perenual API integration, SwiftLint, SwiftFormat. Package tests and app build verification run on `mac-mini` by SSH per ADR-016 and project instructions.
+
+---
+
+## Current 1.0 Board
+
+- #271 Club sharing: composer lacks photo, club selection, CloudKit publish/offline/retry
+- #272 Club feed photos still render placeholders
+- #259 Scanner still exposes diagnosis/sample-diagnosis copy
+- #273 Pro tier presentation remains confusing on the 1.0 paywall
+- #275 Remaining user-facing GrowWise resource strings
+- #285 Stale UI tests for Cultivation/current flows
+- #286 Reminder delete action does not remove persisted reminder
+- #288 Persist onboarding level/goals and use them in personalization
+- #289 Onboarding creates a real first garden, skippable
+- #290 First plant onboarding creates a database-backed plant in the selected garden
+- #291 Unified plant database integration across picker, Add Plant, suggestions, and Perenual
+- #292 Lightweight starter plan after onboarding
+
+Deferred, not 1.0:
+
+- #287 Ambitious onboarding/personalization fast follow for 1.1.
+
+## Baseline Verification
+
+- `swiftformat --lint --config .swiftformat GrowWisePackage/Sources GrowWise` is clean on the worktree.
+- `swiftlint lint --strict --config .swiftlint.yml` is clean on the worktree.
+- `ssh mac-mini "cd ~/Projects/GrowWise && xcodebuild -workspace GrowWise.xcworkspace -scheme GrowWise -sdk iphonesimulator build CODE_SIGN_IDENTITY='' CODE_SIGNING_REQUIRED=NO"` succeeds on current `origin/master`.
+- `ssh mac-mini "cd ~/Projects/GrowWise/GrowWisePackage && set -o pipefail && swift test"` passes on current `origin/master` when run serially. A previous parallel build/test run caused transient dependency-resolution noise; #295 was closed as not a codebase blocker.
+
+## Execution Order
+
+1. Close small isolated 1.0 gaps: #286, #259, #275, #273.
+2. Fix the Club share loop: #271 and #272 together.
+3. Implement onboarding/database activation: #288, #289, #291, #290, #292.
+4. Update UI tests and run release verification: #285 plus full build/test/lint/format.
+
+---
+
+### Task 1: Persist Reminder Deletes (#286)
+
+**Files:**
+- Modify: `GrowWisePackage/Sources/GrowWiseFeature/Views/PlantReminderDetailView.swift:432`
+- Modify: `GrowWisePackage/Sources/GrowWiseServices/DataService.swift:446`
+- Modify: `GrowWisePackage/Tests/GrowWiseServicesTests/DataServiceEdgeCaseTests.swift:580`
+
+**Step 1: Write/update the failing service test**
+
+Remove the manual `service.invalidateAllCaches()` from `deleteReminderRemovesFromActiveReminders()` and assert that `fetchActiveReminders()` no longer returns the deleted reminder after `deleteReminder(_:)`.
+
+**Step 2: Run focused test**
+
+Run:
+
+```bash
+ssh mac-mini "cd ~/Projects/GrowWise/GrowWisePackage && set -o pipefail && swift test --filter DataServiceEdgeCaseTests/deleteReminderRemovesFromActiveReminders 2>&1 | tail -60"
+```
+
+Expected before implementation: FAIL because `DataService.deleteReminder(_:)` does not invalidate reminder caches.
+
+**Step 3: Implement service cache invalidation**
+
+Update `DataService.deleteReminder(_:)` to invalidate reminder/stat caches after repository deletion:
+
+```swift
+public func deleteReminder(_ reminder: PlantReminder) throws {
+    try reminders.delete(reminder)
+    cache.invalidateAll(withPrefix: "reminders:")
+    cache.invalidateAll(withPrefix: "stats:count:")
+    cache.invalidate("stats:gardening_summary")
+}
+```
+
+**Step 4: Implement view delete persistence**
+
+Update `PlantReminderDetailView.deleteReminder(_:)`:
+
+```swift
+private func deleteReminder(_ reminder: PlantReminder) {
+    do {
+        reminderService.cancelNotification(for: reminder)
+        try dataService.deleteReminder(reminder)
+        loadReminders()
+    } catch {
+        errorMessage = "Failed to delete reminder: \(error.localizedDescription)"
+        showingError = true
+    }
+}
+```
+
+**Step 5: Verify**
+
+Run:
+
+```bash
+ssh mac-mini "cd ~/Projects/GrowWise/GrowWisePackage && set -o pipefail && swift test --filter DataServiceEdgeCaseTests/deleteReminderRemovesFromActiveReminders 2>&1 | tail -60"
+swiftlint lint --strict --config .swiftlint.yml --path GrowWisePackage/Sources/GrowWiseFeature/Views/PlantReminderDetailView.swift --path GrowWisePackage/Sources/GrowWiseServices/DataService.swift --path GrowWisePackage/Tests/GrowWiseServicesTests/DataServiceEdgeCaseTests.swift
+```
+
+Expected: focused test passes; touched files lint clean.
+
+**Step 6: Commit**
+
+```bash
+git add GrowWisePackage/Sources/GrowWiseFeature/Views/PlantReminderDetailView.swift GrowWisePackage/Sources/GrowWiseServices/DataService.swift GrowWisePackage/Tests/GrowWiseServicesTests/DataServiceEdgeCaseTests.swift
+git commit -m "fix: persist reminder deletes"
+```
+
+---
+
+### Task 2: Reframe Scanner Copy (#259)
+
+**Files:**
+- Modify: `GrowWisePackage/Sources/GrowWiseFeature/Views/PlantScannerView.swift`
+- Modify: `GrowWisePackage/Sources/GrowWiseServices/PlantDiagnosticService.swift`
+- Modify tests that assert scanner copy, likely `GrowWiseUITests/PhaseOneTwoUITests.swift`
+
+**Steps:**
+1. Replace user-facing `Diagnosis` / `diagnosis` copy with `Plant Health Check`, `Care Guidance`, or `Plant Health Guidance`.
+2. Keep internal type names unless a user-facing string leaks.
+3. Run `rg -n 'Diagnosis|diagnosis|diagnose|AI' GrowWisePackage/Sources/GrowWiseFeature GrowWisePackage/Sources/GrowWiseServices`.
+4. Update stale UI tests.
+5. Run focused tests and touched-file lint.
+6. Commit with `fix: reframe plant health scanner copy`.
+
+---
+
+### Task 3: Sweep Branding Resources (#275)
+
+**Files:**
+- Modify: `GrowWisePackage/Sources/GrowWiseFeature/Resources/en.lproj/Localizable.strings`
+- Modify: `GrowWisePackage/Sources/GrowWiseFeature/Resources/fr.lproj/Localizable.strings`
+- Modify: `GrowWisePackage/Sources/GrowWiseFeature/Resources/es.lproj/Localizable.strings`
+- Modify: `GrowWisePackage/Sources/GrowWiseFeature/Resources/de.lproj/Localizable.strings`
+- Modify: `GrowWisePackage/Sources/GrowWiseServices/Resources/tutorials.json`
+
+**Steps:**
+1. Replace user-facing `GrowWise` with `Cultivation` only in resource strings/content.
+2. Do not rename module IDs, bundle IDs, product IDs, CloudKit IDs, logger subsystems, or source imports per ADR-020.
+3. Run `rg -n 'Welcome to GrowWise|Unlock GrowWise|use the GrowWise app|GrowWise Premium|Grow Wise' GrowWisePackage/Sources`.
+4. Run format/lint.
+5. Commit with `fix: sweep remaining Cultivation branding resources`.
+
+---
+
+### Task 4: Clean Paywall Pro Presentation (#273)
+
+**Files:**
+- Modify: `GrowWisePackage/Sources/GrowWiseFeature/Views/PaywallView.swift`
+- Modify/add tests in `GrowWisePackage/Tests/GrowWiseServicesTests/SubscriptionContractTests.swift` or feature tests if practical.
+
+**Steps:**
+1. Keep Premium monthly/annual actionable.
+2. Remove the Pro comparison column or mark it clearly as unavailable without implying purchase.
+3. Ensure comparison table does not advertise purchasable Pro-only benefits in 1.0.
+4. Verify `SubscriptionService.purchasableProductIDs` remains Premium-only.
+5. Run subscription/paywall focused tests and lint.
+6. Commit with `fix: simplify 1.0 paywall tiers`.
+
+---
+
+### Task 5: Complete Club Share Loop (#271 + #272)
+
+**Files:**
+- Modify: `GrowWisePackage/Sources/GrowWiseFeature/Views/GardenClub/ClubShareComposerSheet.swift`
+- Modify: `GrowWisePackage/Sources/GrowWiseFeature/Views/GardenClub/GardenClubFeedView.swift`
+- Modify: `GrowWisePackage/Sources/GrowWiseServices/DataService+GardenClub.swift`
+- Modify: `GrowWisePackage/Sources/GrowWiseServices/ClubCloudKitService.swift`
+- Reuse: `GrowWisePackage/Sources/GrowWiseServices/PhotoService.swift`
+
+**Steps:**
+1. Add photo attachment to composer.
+2. Add selected club handling where the composer can be launched without an explicit club.
+3. Persist local post with optional photo reference.
+4. Publish via `ClubCloudKitService.publishActivity(_:)` with offline/retry-safe behavior.
+5. Render real feed photos and remove gradient placeholder as the default post media.
+6. Add tests for photo mapping, local create, publish handoff, and fallback behavior.
+7. Commit in small slices: composer photo, publish handoff, feed rendering.
+
+---
+
+### Task 6: Build Useful 1.0 Onboarding (#288 + #289 + #291 + #290 + #292)
+
+**Files:**
+- Modify: `GrowWisePackage/Sources/GrowWiseFeature/OnboardingFlow/OnboardingView.swift`
+- Modify: `GrowWisePackage/Sources/GrowWiseFeature/OnboardingFlow/Views/GardeningGoalsView.swift`
+- Modify: `GrowWisePackage/Sources/GrowWiseFeature/OnboardingFlow/Views/GardenSetupView.swift`
+- Modify: `GrowWisePackage/Sources/GrowWiseFeature/OnboardingFlow/Views/FirstPlantStepView.swift`
+- Modify: `GrowWisePackage/Sources/GrowWiseFeature/OnboardingFlow/Views/CompletionView.swift`
+- Modify: `GrowWisePackage/Sources/GrowWiseFeature/OnboardingFlow/Views/OnboardingNavigationView.swift`
+- Modify: `GrowWisePackage/Sources/GrowWiseFeature/Views/AddPlantSheet.swift`
+- Modify: `GrowWisePackage/Sources/GrowWiseFeature/Views/PlantDatabase/PerenualBrowseView.swift`
+- Modify: `GrowWisePackage/Sources/GrowWiseServices/PlantDatabaseService.swift`
+- Modify: `GrowWisePackage/Sources/GrowWiseServices/TutorialService.swift`
+- Add/modify tests under `GrowWisePackage/Tests/GrowWiseServicesTests/` and `GrowWisePackage/Tests/GrowWiseFeatureTests/`
+
+**Steps:**
+1. Persist onboarding level/goals onto `User`, including `gardeningGoals` and derived `preferredPlantTypes`.
+2. Replace passive garden type selection with skippable first garden creation.
+3. Build or consolidate a unified plant picker/search model over local database and Perenual results.
+4. Make first plant selection copy the selected database/Perenual template into a user-owned `Plant` attached to the onboarding garden.
+5. Confirm or create the first watering reminder from database-backed watering data.
+6. Add a lightweight starter plan card/section after onboarding.
+7. Keep the 1.1 ambitious scope out of 1.0 and linked to #287.
+8. Commit in issue-sized slices.
+
+---
+
+### Task 7: Update Critical UI Tests (#285)
+
+**Files:**
+- Modify: `GrowWiseUITests/OnboardingFlowUITests.swift`
+- Modify: `GrowWiseUITests/GardenClubUITests.swift`
+- Modify: `GrowWiseUITests/GrowWiseUITests.swift`
+- Modify: `GrowWiseUITests/CompostShoppingProfileUITests.swift`
+- Modify: `GrowWiseUITests/Phase3And4UITests.swift`
+
+**Steps:**
+1. Replace stale user-facing `GrowWise` expectations with `Cultivation` where appropriate.
+2. Replace brittle visible text assertions with accessibility identifiers where stable IDs exist.
+3. Update Club tests for top-level Club tab, not old Profile navigation.
+4. Update onboarding progress expectations after the 1.0 onboarding flow changes.
+5. Run focused UI tests on mac-mini/simulator if feasible, plus app build.
+6. Commit with `test: refresh 1.0 UI tests`.
+
+---
+
+### Task 8: Final Release Verification
+
+**Commands:**
+
+```bash
+swiftformat --lint --config .swiftformat GrowWisePackage/Sources GrowWise
+swiftlint lint --strict --config .swiftlint.yml
+ssh mac-mini "cd ~/Projects/GrowWise/GrowWisePackage && set -o pipefail && swift test 2>&1 | tail -80"
+ssh mac-mini "cd ~/Projects/GrowWise && set -o pipefail && xcodebuild -workspace GrowWise.xcworkspace -scheme GrowWise -sdk iphonesimulator build CODE_SIGN_IDENTITY='' CODE_SIGNING_REQUIRED=NO 2>&1 | tail -60"
+gh issue list --repo jbcrane13/GrowWise --state open --limit 200 --json number,title,labels,url
+```
+
+**Expected:**
+- Format clean.
+- Lint clean.
+- Package tests run and pass.
+- App build succeeds.
+- Open 1.0 board has no remaining blockers except explicitly deferred #287.


### PR DESCRIPTION
## Summary
- Finishes the known 1.0 release gaps across reminders, scanner copy, Cultivation branding, paywall presentation, Club photo sharing/feed rendering, onboarding, plant database activation, and starter plan guidance.
- Refreshes stale UI tests for the current Cultivation flows and adds stable screen accessibility identifiers where the tests needed them.
- Leaves #287 open as the explicit 1.1 fast-follow bucket for the more ambitious onboarding and personalization scope.

## Verification
- [x] `swiftformat --lint --config .swiftformat GrowWisePackage/Sources GrowWise` — 0/175 files require formatting, 10 skipped.
- [x] `swiftlint lint --strict --config .swiftlint.yml` — 0 violations, 0 serious in 175 files.
- [x] mac-mini `swift test` from fresh verification worktree — 1477 tests in 166 suites passed.
- [x] mac-mini `xcodebuild -workspace GrowWise.xcworkspace -scheme GrowWise -sdk iphonesimulator build CODE_SIGN_IDENTITY='' CODE_SIGNING_REQUIRED=NO` — build succeeded.
- [x] focused #285 XCUITest sweep on mac-mini — 5 selected tests passed.

## Issue State
Implemented and closed: #259, #271, #272, #273, #275, #285, #286, #288, #289, #290, #291, #292, #296.

Deferred by design: #287 for 1.1.
