### PR TITLE
Implement onboarding features and address 1.0 release blockers

### DIFF
--- a/GrowWisePackage/Sources/GrowWiseFeature/Components/PerenualEnrichmentCard.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Components/PerenualEnrichmentCard.swift
@@ -237,29 +237,8 @@ public struct PerenualEnrichmentCard: View {
     // MARK: - Data Loading
 
     private func loadEnrichment() async {
-        // First check synchronous cache
-        if let cached = enrichment.enrichment(for: plant) {
-            detail = cached
-            isLoading = false
-            hasChecked = true
-            return
-        }
-
-        // Wait a moment for the async fetch the enrichment(for:) call triggered
         isLoading = true
-        try? await Task.sleep(for: .milliseconds(200))
-
-        // Poll for result (the service fires a background task on first call)
-        for _ in 0 ..< 30 { // Up to ~6 seconds
-            if let cached = enrichment.enrichment(for: plant) {
-                detail = cached
-                isLoading = false
-                hasChecked = true
-                return
-            }
-            try? await Task.sleep(for: .milliseconds(200))
-        }
-
+        detail = await enrichment.loadEnrichment(for: plant)
         isLoading = false
         hasChecked = true
     }
@@ -316,7 +295,7 @@ public struct PerenualEnrichmentThumbnail: View {
             }
         }
         .task(id: plant.scientificName) {
-            loadFromCache()
+            await loadEnrichment()
         }
     }
 
@@ -329,8 +308,8 @@ public struct PerenualEnrichmentThumbnail: View {
         }
     }
 
-    private func loadFromCache() {
-        guard let detail = enrichment.enrichment(for: plant) else { return }
+    private func loadEnrichment() async {
+        guard let detail = await enrichment.loadEnrichment(for: plant) else { return }
         imageURL = detail.defaultImage?.thumbnail ?? detail.defaultImage?.smallUrl
         if let min = detail.hardiness?.min {
             hardinessZone = "Z\(min)"

--- a/GrowWisePackage/Sources/GrowWiseFeature/Design/GardenComponents.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Design/GardenComponents.swift
@@ -53,6 +53,7 @@ struct PlantRow: View {
     let plant: Plant
     var isUrgent: Bool = false
     var onComplete: (() -> Void)?
+    var onOpen: (() -> Void)?
 
     private var plantID: String {
         plant.id?.uuidString ?? "unknown"
@@ -74,6 +75,10 @@ struct PlantRow: View {
             return "\(watering) · \(stage)"
         }
         return watering
+    }
+
+    private var accessibilitySummary: String {
+        "\(plant.name ?? "Unnamed Plant"), \(careSubtitle), \(healthStatus.displayName)"
     }
 
     var body: some View {
@@ -132,6 +137,10 @@ struct PlantRow: View {
             }
         }
         .padding(CultivationTheme.Spacing.cardPadding)
+        .contentShape(RoundedRectangle(cornerRadius: CultivationTheme.Radius.card))
+        .onTapGesture {
+            onOpen?()
+        }
         .background {
             if isUrgent {
                 RoundedRectangle(cornerRadius: CultivationTheme.Radius.card)
@@ -139,6 +148,9 @@ struct PlantRow: View {
             }
         }
         .paperCard()
+        .accessibilityElement(children: isUrgent ? .contain : .ignore)
+        .accessibilityLabel(accessibilitySummary)
+        .accessibilityAddTraits(.isButton)
         .accessibilityIdentifier("garden_row_plant_\(plantID)")
     }
 }

--- a/GrowWisePackage/Sources/GrowWiseFeature/Main/MainAppView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Main/MainAppView.swift
@@ -268,7 +268,9 @@ private struct GardenClubTabContainer: View {
         Group {
             switch GardenClubTabRoute.resolve(clubs: clubs) {
             case .joinOrCreate:
-                GardenClubJoinOrCreatePrompt()
+                GardenClubJoinOrCreatePrompt { club in
+                    clubs = [club]
+                }
 
             case .feed(let club):
                 GardenClubFeedView(club: club)
@@ -294,6 +296,9 @@ private struct GardenClubTabContainer: View {
 private struct GardenClubJoinOrCreatePrompt: View {
     @State private var isJoining = false
     @State private var isCreating = false
+    @State private var createdClub: GardenClub?
+
+    let onCreated: (GardenClub) -> Void
 
     var body: some View {
         VStack(spacing: 16) {
@@ -316,7 +321,17 @@ private struct GardenClubJoinOrCreatePrompt: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(CultivationTheme.Colors.background.ignoresSafeArea())
         .sheet(isPresented: $isJoining) { JoinClubSheet() }
-        .sheet(isPresented: $isCreating) { CreateClubSheet() }
+        .sheet(isPresented: $isCreating, onDismiss: publishCreatedClubIfNeeded) {
+            CreateClubSheet { club in
+                createdClub = club
+            }
+        }
+    }
+
+    private func publishCreatedClubIfNeeded() {
+        guard let createdClub else { return }
+        onCreated(createdClub)
+        self.createdClub = nil
     }
 }
 

--- a/GrowWisePackage/Sources/GrowWiseFeature/OnboardingFlow/OnboardingView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/OnboardingFlow/OnboardingView.swift
@@ -122,6 +122,9 @@ public struct UserProfile {
     var spaceSize: SpaceSize = .small
     var shouldCreateFirstGarden: Bool = true
     var firstGardenName: String = "My First Garden"
+    var shouldCreateFirstContainer: Bool = true
+    var firstContainerName: String = "Starter Container"
+    var firstContainerType: BedType = .pot
     var interests: Set<PlantType> = []
     var hasLocationPermission: Bool = false
     var hasNotificationPermission: Bool = false

--- a/GrowWisePackage/Sources/GrowWiseFeature/OnboardingFlow/Views/CompletionView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/OnboardingFlow/Views/CompletionView.swift
@@ -92,6 +92,14 @@ struct CompletionView: View {
                 if userProfile.shouldCreateFirstGarden {
                     Divider().padding(.leading, 48)
                     CompletionSummaryRow(
+                        icon: userProfile.firstContainerType.iconName,
+                        iconColor: CultivationTheme.Colors.accentCoral,
+                        label: "First Container",
+                        value: Self.containerSummary(for: userProfile)
+                    )
+
+                    Divider().padding(.leading, 48)
+                    CompletionSummaryRow(
                         icon: "square.grid.2x2.fill",
                         iconColor: CultivationTheme.Colors.textTertiary,
                         label: "Space",
@@ -134,6 +142,12 @@ struct CompletionView: View {
         guard profile.shouldCreateFirstGarden else { return "Skipped" }
         let trimmedName = profile.firstGardenName.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmedName.isEmpty ? "My First Garden" : trimmedName
+    }
+
+    static func containerSummary(for profile: UserProfile) -> String {
+        guard profile.shouldCreateFirstGarden, profile.shouldCreateFirstContainer else { return "Skipped" }
+        let trimmedName = profile.firstContainerName.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmedName.isEmpty ? "Starter Container" : trimmedName
     }
 
     static func firstPlantSummary(for profile: UserProfile) -> String {

--- a/GrowWisePackage/Sources/GrowWiseFeature/OnboardingFlow/Views/FirstPlantStepView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/OnboardingFlow/Views/FirstPlantStepView.swift
@@ -20,10 +20,8 @@ struct FirstPlantStepView: View {
     ]
 
     var body: some View {
-        VStack(spacing: 0) {
-            Spacer()
-
-            VStack(spacing: 28) {
+        ScrollView {
+            VStack(spacing: 22) {
                 // Hero icon
                 ZStack {
                     Circle()
@@ -98,12 +96,15 @@ struct FirstPlantStepView: View {
                         .font(.system(size: 14, design: .rounded))
                         .foregroundStyle(CultivationTheme.Colors.textTertiary)
                 }
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 10)
                 .accessibilityIdentifier("onboarding_firstplant_skip")
             }
             .padding(.horizontal, 4)
-
-            Spacer()
+            .padding(.top, 16)
+            .padding(.bottom, 28)
         }
+        .scrollIndicators(.hidden)
         .task {
             await loadPlants()
         }
@@ -140,6 +141,15 @@ private struct PlantPickerCard: View {
     let plant: Plant
     let isSelected: Bool
     let onTap: () -> Void
+
+    private var accessibilityID: String {
+        let rawName = plant.name ?? "unknown"
+        let sanitized = rawName
+            .lowercased()
+            .replacingOccurrences(of: " ", with: "_")
+            .filter { $0.isLetter || $0.isNumber || $0 == "_" }
+        return "onboarding_firstplant_card_\(sanitized)"
+    }
 
     private var plantIcon: String {
         plant.plantType?.iconName ?? "leaf.fill"
@@ -197,7 +207,7 @@ private struct PlantPickerCard: View {
             )
         }
         .buttonStyle(.plain)
-        .accessibilityIdentifier("onboarding_firstplant_card_\(plant.name ?? "unknown")")
+        .accessibilityIdentifier(accessibilityID)
     }
 }
 

--- a/GrowWisePackage/Sources/GrowWiseFeature/OnboardingFlow/Views/FirstPlantStepView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/OnboardingFlow/Views/FirstPlantStepView.swift
@@ -11,6 +11,7 @@ struct FirstPlantStepView: View {
 
     @State private var beginnerPlants: [Plant] = []
     @State private var selectedPlant: Plant?
+    @State private var loadErrorMessage: String?
 
     /// Curated plant names for onboarding — diverse, beginner-friendly, common.
     private static let curatedNames: Set<String> = [
@@ -53,30 +54,39 @@ struct FirstPlantStepView: View {
                 }
 
                 // Plant grid
-                LazyVGrid(columns: [
-                    GridItem(.flexible()),
-                    GridItem(.flexible()),
-                ], spacing: 12) {
-                    ForEach(beginnerPlants.prefix(8)) { plant in
-                        PlantPickerCard(
-                            plant: plant,
-                            isSelected: selectedPlant?.id == plant.id
-                        ) {
-                            withAnimation(.spring(duration: 0.3, bounce: 0.2)) {
-                                if selectedPlant?.id == plant.id {
-                                    selectedPlant = nil
-                                    userProfile.selectedFirstPlantName = nil
-                                    userProfile.selectedFirstPlantID = nil
-                                } else {
-                                    selectedPlant = plant
-                                    userProfile.selectedFirstPlantName = plant.name
-                                    userProfile.selectedFirstPlantID = plant.id
+                if let loadErrorMessage, beginnerPlants.isEmpty {
+                    Text(loadErrorMessage)
+                        .font(.system(size: 14, design: .rounded))
+                        .foregroundStyle(CultivationTheme.Colors.textTertiary)
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal, 24)
+                        .accessibilityIdentifier("onboarding_firstplant_error")
+                } else {
+                    LazyVGrid(columns: [
+                        GridItem(.flexible()),
+                        GridItem(.flexible()),
+                    ], spacing: 12) {
+                        ForEach(beginnerPlants.prefix(8)) { plant in
+                            PlantPickerCard(
+                                plant: plant,
+                                isSelected: selectedPlant?.id == plant.id
+                            ) {
+                                withAnimation(.spring(duration: 0.3, bounce: 0.2)) {
+                                    if selectedPlant?.id == plant.id {
+                                        selectedPlant = nil
+                                        userProfile.selectedFirstPlantName = nil
+                                        userProfile.selectedFirstPlantID = nil
+                                    } else {
+                                        selectedPlant = plant
+                                        userProfile.selectedFirstPlantName = plant.name
+                                        userProfile.selectedFirstPlantID = plant.id
+                                    }
                                 }
                             }
                         }
                     }
+                    .padding(.horizontal, 20)
                 }
-                .padding(.horizontal, 20)
 
                 // Skip option
                 Button {
@@ -95,12 +105,19 @@ struct FirstPlantStepView: View {
             Spacer()
         }
         .task {
-            loadPlants()
+            await loadPlants()
         }
     }
 
-    private func loadPlants() {
-        let allBeginner = plantDatabaseService.getBeginnerFriendlyPlants()
+    private func loadPlants() async {
+        let allBeginner: [Plant]
+        do {
+            allBeginner = try await plantDatabaseService.getSeededBeginnerFriendlyPlants()
+            loadErrorMessage = nil
+        } catch {
+            allBeginner = plantDatabaseService.getBeginnerFriendlyPlants()
+            loadErrorMessage = "Starter plants are unavailable right now. You can skip and add plants later."
+        }
 
         // Prefer curated list for consistent onboarding experience
         let curated = allBeginner.filter { plant in

--- a/GrowWisePackage/Sources/GrowWiseFeature/OnboardingFlow/Views/GardenSetupView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/OnboardingFlow/Views/GardenSetupView.swift
@@ -5,75 +5,79 @@ struct GardenSetupView: View {
     @Binding var userProfile: UserProfile
 
     var body: some View {
-        VStack(spacing: 20) {
-            OnboardingStepHeader(
-                icon: "square.split.2x1.fill",
-                iconColor: CultivationTheme.Colors.brandLeaf,
-                title: "Tell us about\nyour garden",
-                subtitle: "Helps us give you the right plant advice."
-            )
+        ScrollView(showsIndicators: false) {
+            VStack(spacing: 20) {
+                OnboardingStepHeader(
+                    icon: "square.split.2x1.fill",
+                    iconColor: CultivationTheme.Colors.brandLeaf,
+                    title: "Tell us about\nyour garden",
+                    subtitle: "Helps us give you the right plant advice."
+                )
 
-            VStack(spacing: 16) {
-                gardenCreationSection
+                VStack(spacing: 16) {
+                    gardenCreationSection
 
-                // Garden type — horizontal chip row
-                if userProfile.shouldCreateFirstGarden {
-                    VStack(alignment: .leading, spacing: 10) {
-                        Text("GARDEN TYPE")
-                            .font(.system(size: 11, weight: .semibold))
-                            .foregroundStyle(CultivationTheme.Colors.textTertiary)
-                            .tracking(1.0)
-                            .padding(.horizontal, 20)
+                    // Garden type — horizontal chip row
+                    if userProfile.shouldCreateFirstGarden {
+                        containerCreationSection
 
-                        ScrollView(.horizontal, showsIndicators: false) {
-                            HStack(spacing: 8) {
-                                ForEach(GardenType.allCases, id: \.self) { type in
-                                    GardenTypeChip(
-                                        type: type,
-                                        isSelected: userProfile.gardenType == type
-                                    ) {
-                                        withAnimation(.spring(duration: 0.25)) {
-                                            userProfile.gardenType = type
+                        VStack(alignment: .leading, spacing: 10) {
+                            Text("GARDEN TYPE")
+                                .font(.system(size: 11, weight: .semibold))
+                                .foregroundStyle(CultivationTheme.Colors.textTertiary)
+                                .tracking(1.0)
+                                .padding(.horizontal, 20)
+
+                            ScrollView(.horizontal, showsIndicators: false) {
+                                HStack(spacing: 8) {
+                                    ForEach(GardenType.allCases, id: \.self) { type in
+                                        GardenTypeChip(
+                                            type: type,
+                                            isSelected: userProfile.gardenType == type
+                                        ) {
+                                            withAnimation(.spring(duration: 0.25)) {
+                                                userProfile.gardenType = type
+                                            }
                                         }
-                                    }
-                                    .accessibilityIdentifier("onboarding_gardentype_\(type.rawValue)")
-                                }
-                            }
-                            .padding(.horizontal, 20)
-                        }
-                    }
-
-                    // Space size — vertical list, fills remaining height
-                    VStack(alignment: .leading, spacing: 10) {
-                        Text("YOUR SPACE")
-                            .font(.system(size: 11, weight: .semibold))
-                            .foregroundStyle(CultivationTheme.Colors.textTertiary)
-                            .tracking(1.0)
-                            .padding(.horizontal, 20)
-
-                        VStack(spacing: 8) {
-                            ForEach(SpaceSize.allCases, id: \.self) { size in
-                                SpaceSizeRow(
-                                    size: size,
-                                    isSelected: userProfile.spaceSize == size
-                                ) {
-                                    withAnimation(.spring(duration: 0.25)) {
-                                        userProfile.spaceSize = size
+                                        .accessibilityIdentifier("onboarding_gardentype_\(type.rawValue)")
                                     }
                                 }
                                 .padding(.horizontal, 20)
-                                .frame(maxHeight: .infinity)
-                                .accessibilityIdentifier("onboarding_space_\(size.rawValue)")
                             }
                         }
-                        .frame(maxHeight: .infinity)
+
+                        // Space size — vertical list, fills remaining height
+                        VStack(alignment: .leading, spacing: 10) {
+                            Text("YOUR SPACE")
+                                .font(.system(size: 11, weight: .semibold))
+                                .foregroundStyle(CultivationTheme.Colors.textTertiary)
+                                .tracking(1.0)
+                                .padding(.horizontal, 20)
+
+                            VStack(spacing: 8) {
+                                ForEach(SpaceSize.allCases, id: \.self) { size in
+                                    SpaceSizeRow(
+                                        size: size,
+                                        isSelected: userProfile.spaceSize == size
+                                    ) {
+                                        withAnimation(.spring(duration: 0.25)) {
+                                            userProfile.spaceSize = size
+                                        }
+                                    }
+                                    .padding(.horizontal, 20)
+                                    .frame(maxHeight: .infinity)
+                                    .accessibilityIdentifier("onboarding_space_\(size.rawValue)")
+                                }
+                            }
+                            .frame(maxHeight: .infinity)
+                        }
                     }
                 }
+                .frame(maxHeight: .infinity)
             }
-            .frame(maxHeight: .infinity)
+            .padding(.top, 8)
+            .padding(.bottom, 4)
         }
-        .padding(.top, 8)
-        .padding(.bottom, 4)
     }
 
     private var gardenCreationSection: some View {
@@ -111,6 +115,62 @@ struct GardenSetupView: View {
         .glassCard()
         .padding(.horizontal, 20)
     }
+
+    private var containerCreationSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Toggle(isOn: $userProfile.shouldCreateFirstContainer) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Create a starter container")
+                        .font(.system(size: 15, weight: .semibold))
+                        .foregroundStyle(CultivationTheme.Colors.textPrimary)
+                    Text(userProfile.shouldCreateFirstContainer ? "Your first plant has a home" : "Plants can be assigned later")
+                        .font(.system(size: 12))
+                        .foregroundStyle(CultivationTheme.Colors.textSecondary)
+                }
+            }
+            .tint(CultivationTheme.Colors.brandLeaf)
+            .accessibilityIdentifier("onboarding_toggle_create_container")
+
+            if userProfile.shouldCreateFirstContainer {
+                TextField("Container name", text: $userProfile.firstContainerName)
+                    .font(.system(size: 15, weight: .medium))
+                    .foregroundStyle(CultivationTheme.Colors.textPrimary)
+                    .padding(12)
+                    .background(
+                        RoundedRectangle(cornerRadius: 12)
+                            .fill(CultivationTheme.Colors.backgroundSecondary)
+                    )
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 12)
+                            .stroke(CultivationTheme.Colors.cardBorder, lineWidth: 1)
+                    )
+                    .accessibilityIdentifier("onboarding_textfield_container_name")
+
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 8) {
+                        ForEach(BedType.allCases, id: \.self) { type in
+                            ContainerTypeChip(
+                                type: type,
+                                isSelected: userProfile.firstContainerType == type
+                            ) {
+                                withAnimation(.spring(duration: 0.25)) {
+                                    userProfile.firstContainerType = type
+                                    if userProfile.firstContainerName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                                        userProfile.firstContainerName = type.displayName
+                                    }
+                                }
+                            }
+                            .accessibilityIdentifier("onboarding_containertype_\(type.rawValue)")
+                        }
+                    }
+                    .padding(.vertical, 2)
+                }
+            }
+        }
+        .padding(CultivationTheme.Spacing.cardPadding)
+        .glassCard()
+        .padding(.horizontal, 20)
+    }
 }
 
 // MARK: - Garden Type Chip (Dark)
@@ -132,6 +192,53 @@ private struct GardenTypeChip: View {
             }
             .padding(.horizontal, 14)
             .padding(.vertical, 10)
+            .background(
+                Capsule()
+                    .fill(
+                        isSelected
+                            ? LinearGradient(
+                                colors: [CultivationTheme.Colors.brandForest, CultivationTheme.Colors.brandLeaf],
+                                startPoint: .leading,
+                                endPoint: .trailing
+                            )
+                            : LinearGradient(
+                                colors: [CultivationTheme.Colors.cardSurface, CultivationTheme.Colors.cardSurface],
+                                startPoint: .leading,
+                                endPoint: .trailing
+                            )
+                    )
+                    .overlay(
+                        Capsule().stroke(
+                            isSelected ? Color.clear : CultivationTheme.Colors.cardBorder,
+                            lineWidth: 1
+                        )
+                    )
+            )
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(type.displayName)
+    }
+}
+
+// MARK: - Container Type Chip
+
+private struct ContainerTypeChip: View {
+    let type: BedType
+    let isSelected: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 6) {
+                Image(systemName: type.iconName)
+                    .font(.system(size: 13, weight: .medium))
+                Text(type.displayName)
+                    .font(.system(size: 13, weight: .medium))
+                    .lineLimit(1)
+            }
+            .foregroundStyle(isSelected ? .white : CultivationTheme.Colors.textPrimary)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 9)
             .background(
                 Capsule()
                     .fill(

--- a/GrowWisePackage/Sources/GrowWiseFeature/OnboardingFlow/Views/OnboardingNavigationView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/OnboardingFlow/Views/OnboardingNavigationView.swift
@@ -186,7 +186,8 @@ struct OnboardingNavigationView: View {
 
                 try await saveUserPreferences(user: user)
                 let firstGarden = try await createFirstGardenIfRequested()
-                try await createFirstPlantIfSelected(garden: firstGarden)
+                let firstContainer = try await createFirstContainerIfRequested(garden: firstGarden)
+                try await createFirstPlantIfSelected(garden: firstGarden, gardenBed: firstContainer)
                 UserDefaults.standard.set(true, forKey: "hasCompletedOnboarding")
 
                 await MainActor.run {
@@ -221,7 +222,21 @@ struct OnboardingNavigationView: View {
     }
 
     @MainActor
-    private func createFirstPlantIfSelected(garden: Garden?) async throws {
+    private func createFirstContainerIfRequested(garden: Garden?) async throws -> GardenBed? {
+        guard userProfile.shouldCreateFirstGarden, userProfile.shouldCreateFirstContainer else { return nil }
+        guard let garden else { return nil }
+        let trimmedName = userProfile.firstContainerName.trimmingCharacters(in: .whitespacesAndNewlines)
+        let containerName = trimmedName.isEmpty ? "Starter Container" : trimmedName
+
+        return try dataService.createGardenBed(
+            name: containerName,
+            bedType: userProfile.firstContainerType,
+            in: garden
+        )
+    }
+
+    @MainActor
+    private func createFirstPlantIfSelected(garden: Garden?, gardenBed: GardenBed?) async throws {
         guard let plantName = userProfile.selectedFirstPlantName, !plantName.isEmpty else { return }
         guard let garden else {
             throw OnboardingSaveError.firstPlantNeedsGarden
@@ -230,7 +245,7 @@ struct OnboardingNavigationView: View {
             throw OnboardingSaveError.firstPlantTemplateMissing(plantName)
         }
 
-        try dataService.createStarterPlant(from: template, in: garden)
+        _ = try dataService.createStarterPlant(from: template, in: garden, gardenBed: gardenBed)
     }
 
     private func selectedFirstPlantTemplate(named plantName: String) -> Plant? {

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/AddPlantSheet.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/AddPlantSheet.swift
@@ -16,6 +16,8 @@ public struct AddPlantSheet: View {
     private var companionService
     @Environment(PlantDatabaseService.self)
     private var plantDatabaseService
+    @Environment(PerenualAPIService.self)
+    private var perenualAPIService
     @Environment(ReminderService.self)
     private var reminderService
 
@@ -42,10 +44,12 @@ public struct AddPlantSheet: View {
     @State private var saveTask: Task<Void, Never>?
 
     // Autocomplete state
-    @State private var suggestions: [Plant] = []
+    @State private var suggestions: [PlantSearchResult] = []
     @State private var searchTask: Task<Void, Never>?
     @State private var nameFieldCommitted = false
     @State private var selectedTemplate: Plant?
+    @State private var selectedPerenualDetail: PerenualSpeciesDetail?
+    @State private var loadingPerenualSuggestionID: Int?
 
     // Companion planting analysis
     @State private var compatibilityAnalysis: GardenCompatibilityAnalysis?
@@ -95,44 +99,35 @@ public struct AddPlantSheet: View {
                                     if selectedTemplate?.name != newValue {
                                         selectedTemplate = nil
                                     }
+                                    if selectedPerenualDetail?.commonName != newValue {
+                                        selectedPerenualDetail = nil
+                                    }
                                     guard !newValue.isEmpty else {
                                         suggestions = []
                                         selectedTemplate = nil
+                                        selectedPerenualDetail = nil
                                         return
                                     }
                                     searchTask = Task {
                                         try? await Task.sleep(for: .milliseconds(300))
                                         guard !Task.isCancelled else { return }
-                                        suggestions = plantDatabaseService.searchPlants(query: newValue)
+                                        let localResults = plantDatabaseService.searchPlants(query: newValue)
+                                        let onlineResults = await searchOnlinePlants(query: newValue)
+                                        suggestions = PlantSearchResult.combine(local: localResults, perenual: onlineResults)
                                     }
                                 }
 
                                 if !suggestions.isEmpty, !nameFieldCommitted {
                                     ScrollView(.horizontal, showsIndicators: false) {
                                         HStack(spacing: 8) {
-                                            ForEach(suggestions, id: \.id) { suggestion in
+                                            ForEach(suggestions) { suggestion in
                                                 Button {
-                                                    applyTemplate(suggestion)
+                                                    applySuggestion(suggestion)
                                                 } label: {
-                                                    Text(suggestion.name ?? "")
-                                                        .font(.system(.caption, weight: .medium))
-                                                        .foregroundStyle(CultivationTheme.Colors.accentCoral)
-                                                        .padding(.horizontal, 12)
-                                                        .padding(.vertical, 6)
-                                                        .background {
-                                                            Capsule()
-                                                                .fill(CultivationTheme.Colors.accentCoral.opacity(0.12))
-                                                                .overlay {
-                                                                    Capsule()
-                                                                        .stroke(
-                                                                            CultivationTheme.Colors.accentCoral.opacity(0.3),
-                                                                            lineWidth: 1
-                                                                        )
-                                                                }
-                                                        }
+                                                    suggestionPill(suggestion)
                                                 }
                                                 .buttonStyle(.plain)
-                                                .accessibilityIdentifier("addplant_suggestion_\(suggestion.name ?? "")")
+                                                .accessibilityIdentifier("addplant_suggestion_\(suggestion.displayName)")
                                             }
                                         }
                                     }
@@ -478,6 +473,33 @@ public struct AddPlantSheet: View {
         }
     }
 
+    private func suggestionPill(_ suggestion: PlantSearchResult) -> some View {
+        HStack(spacing: 6) {
+            if suggestion.source == .perenual, loadingPerenualSuggestionID == suggestion.perenualSpecies?.id {
+                ProgressView()
+                    .controlSize(.small)
+            }
+
+            Text(suggestion.displayName)
+                .font(.system(.caption, weight: .medium))
+
+            Text(suggestion.source == .perenual ? "Online" : "Local")
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundStyle(CultivationTheme.Colors.textTertiary)
+        }
+        .foregroundStyle(CultivationTheme.Colors.accentCoral)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 6)
+        .background {
+            Capsule()
+                .fill(CultivationTheme.Colors.accentCoral.opacity(0.12))
+                .overlay {
+                    Capsule()
+                        .stroke(CultivationTheme.Colors.accentCoral.opacity(0.3), lineWidth: 1)
+                }
+        }
+    }
+
     // MARK: - Data Methods
 
     private func loadGardens() {
@@ -539,12 +561,56 @@ public struct AddPlantSheet: View {
 
     private func applyTemplate(_ plant: Plant) {
         selectedTemplate = plant
+        selectedPerenualDetail = nil
         plantName = plant.name ?? plantName
         scientificName = plant.scientificName ?? scientificName
         if let type = plant.plantType { selectedPlantType = type }
         if let diff = plant.difficultyLevel { selectedDifficultyLevel = diff }
         suggestions = []
         nameFieldCommitted = true
+    }
+
+    private func applySuggestion(_ suggestion: PlantSearchResult) {
+        switch suggestion.source {
+        case .local:
+            guard let plant = suggestion.localPlant else { return }
+            applyTemplate(plant)
+
+        case .perenual:
+            guard let species = suggestion.perenualSpecies else { return }
+            Task { await applyPerenualSuggestion(species) }
+        }
+    }
+
+    private func searchOnlinePlants(query: String) async -> [PerenualSpeciesSummary] {
+        guard PerenualAPIService.hasAPIKey else { return [] }
+        do {
+            let response = try await perenualAPIService.fetchSpeciesList(query: query, page: 1)
+            return response.data
+        } catch {
+            return []
+        }
+    }
+
+    @MainActor
+    private func applyPerenualSuggestion(_ species: PerenualSpeciesSummary) async {
+        loadingPerenualSuggestionID = species.id
+        defer { loadingPerenualSuggestionID = nil }
+
+        do {
+            let detail = try await perenualAPIService.fetchSpeciesDetail(id: species.id)
+            selectedTemplate = nil
+            selectedPerenualDetail = detail
+            plantName = detail.commonName
+            scientificName = detail.scientificName.first ?? scientificName
+            selectedPlantType = detail.mappedPlantType
+            selectedDifficultyLevel = detail.mappedDifficultyLevel
+            suggestions = []
+            nameFieldCommitted = true
+        } catch {
+            errorMessage = "Could not load online plant details: \(error.localizedDescription)"
+            showingError = true
+        }
     }
 
     @MainActor
@@ -559,7 +625,14 @@ public struct AddPlantSheet: View {
 
         let newPlant: Plant
         do {
-            if let selectedTemplate {
+            if let selectedPerenualDetail {
+                newPlant = try dataService.createUserPlant(
+                    from: selectedPerenualDetail,
+                    in: selectedGarden,
+                    gardenBed: selectedBed,
+                    plantingDate: plantingDate
+                )
+            } else if let selectedTemplate {
                 newPlant = try dataService.createUserPlant(
                     from: selectedTemplate,
                     in: selectedGarden,

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/AddPlantSheet.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/AddPlantSheet.swift
@@ -1,7 +1,6 @@
 import GrowWiseModels
 import GrowWiseServices
 import PhotosUI
-import SwiftData
 import SwiftUI
 
 // Sheet view for adding a new plant to the user's garden.
@@ -19,8 +18,6 @@ public struct AddPlantSheet: View {
     private var plantDatabaseService
     @Environment(ReminderService.self)
     private var reminderService
-    @Environment(\.modelContext)
-    private var modelContext
 
     // Form fields
     @State private var plantName: String = ""
@@ -501,12 +498,18 @@ public struct AddPlantSheet: View {
     private func createGarden() {
         let name = newGardenName.trimmingCharacters(in: .whitespaces)
         guard !name.isEmpty else { return }
-        let garden = Garden(name: name)
-        modelContext.insert(garden)
-        newGardenName = ""
-        // Reload and select the new garden
-        loadGardens()
-        selectedGarden = availableGardens.last(where: { $0.name == name })
+
+        do {
+            let garden = try dataService.createGarden(name: name, type: .outdoor, isIndoor: false)
+            newGardenName = ""
+            showCreateGarden = false
+            loadGardens()
+            selectedGarden = garden
+            loadBeds(for: garden)
+        } catch {
+            errorMessage = "Could not create garden: \(error.localizedDescription)"
+            showingError = true
+        }
     }
 
     private func loadBeds(for garden: Garden?) {
@@ -560,6 +563,7 @@ public struct AddPlantSheet: View {
                 newPlant = try dataService.createUserPlant(
                     from: selectedTemplate,
                     in: selectedGarden,
+                    gardenBed: selectedBed,
                     plantingDate: plantingDate
                 )
             } else {

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/AddPlantSheet.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/AddPlantSheet.swift
@@ -622,20 +622,21 @@ public struct AddPlantSheet: View {
         }
 
         isSaving = true
+        let resolvedGarden = resolvedGardenForSave()
 
         let newPlant: Plant
         do {
             if let selectedPerenualDetail {
                 newPlant = try dataService.createUserPlant(
                     from: selectedPerenualDetail,
-                    in: selectedGarden,
+                    in: resolvedGarden,
                     gardenBed: selectedBed,
                     plantingDate: plantingDate
                 )
             } else if let selectedTemplate {
                 newPlant = try dataService.createUserPlant(
                     from: selectedTemplate,
-                    in: selectedGarden,
+                    in: resolvedGarden,
                     gardenBed: selectedBed,
                     plantingDate: plantingDate
                 )
@@ -644,7 +645,7 @@ public struct AddPlantSheet: View {
                     name: plantName,
                     type: selectedPlantType,
                     difficultyLevel: selectedDifficultyLevel,
-                    garden: selectedGarden
+                    garden: resolvedGarden
                 )
             }
         } catch {
@@ -676,8 +677,18 @@ public struct AddPlantSheet: View {
             return
         }
         savedPlant = newPlant
-        wateringSchedule = reminderService.suggestWateringSchedule(for: newPlant, in: selectedGarden)
+        wateringSchedule = reminderService.suggestWateringSchedule(for: newPlant, in: resolvedGarden)
         showWateringSchedule = true
+    }
+
+    @MainActor
+    private func resolvedGardenForSave() -> Garden? {
+        let resolvedGarden = selectedGarden ?? availableGardens.first
+        if selectedGarden == nil, let resolvedGarden {
+            selectedGarden = resolvedGarden
+            loadBeds(for: resolvedGarden)
+        }
+        return resolvedGarden
     }
 }
 

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/Garden/CreateBedSheet.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/Garden/CreateBedSheet.swift
@@ -1,6 +1,5 @@
 import GrowWiseModels
 import GrowWiseServices
-import SwiftData
 import SwiftUI
 
 /// Sheet for creating a new GardenBed in a given garden.
@@ -10,11 +9,13 @@ struct CreateBedSheet: View {
 
     @Environment(\.dismiss)
     private var dismiss
-    @Environment(\.modelContext)
-    private var modelContext
+    @Environment(DataService.self)
+    private var dataService
 
     @State private var selectedType: BedType = .raisedBed
     @State private var bedName: String = ""
+    @State private var errorMessage: String?
+    @State private var isSaving = false
 
     var body: some View {
         NavigationStack {
@@ -80,10 +81,15 @@ struct CreateBedSheet: View {
                     Button {
                         saveBed()
                     } label: {
-                        Text("Add Container")
+                        if isSaving {
+                            ProgressView()
+                                .tint(.white)
+                        } else {
+                            Text("Add Container")
+                        }
                     }
-                    .buttonStyle(GradientButtonStyle(isDisabled: bedName.trimmingCharacters(in: .whitespaces).isEmpty))
-                    .disabled(bedName.trimmingCharacters(in: .whitespaces).isEmpty)
+                    .buttonStyle(GradientButtonStyle(isDisabled: isSaveDisabled))
+                    .disabled(isSaveDisabled)
                     .padding(.horizontal, CultivationTheme.Spacing.screenPadding)
                     .accessibilityIdentifier("createbed_button_save")
                     .padding(.bottom, 24)
@@ -98,15 +104,33 @@ struct CreateBedSheet: View {
                 }
             }
         }
+        .alert("Container Error", isPresented: Binding(
+            get: { errorMessage != nil },
+            set: { if !$0 { errorMessage = nil } }
+        )) {
+            Button("OK") { errorMessage = nil }
+        } message: {
+            Text(errorMessage ?? "")
+        }
+    }
+
+    private var isSaveDisabled: Bool {
+        isSaving || bedName.trimmingCharacters(in: .whitespaces).isEmpty
     }
 
     private func saveBed() {
         let trimmed = bedName.trimmingCharacters(in: .whitespaces)
         guard !trimmed.isEmpty else { return }
-        let bed = GardenBed(name: trimmed, bedType: selectedType, garden: garden)
-        modelContext.insert(bed)
-        onCreated(bed)
-        dismiss()
+        isSaving = true
+        do {
+            let bed = try dataService.createGardenBed(name: trimmed, bedType: selectedType, in: garden)
+            isSaving = false
+            onCreated(bed)
+            dismiss()
+        } catch {
+            isSaving = false
+            errorMessage = "Could not create container: \(error.localizedDescription)"
+        }
     }
 }
 

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/Garden/GardenBedSection.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/Garden/GardenBedSection.swift
@@ -27,9 +27,9 @@ struct GardenBedSection: View {
                 PlantRow(
                     plant: plant,
                     isUrgent: isOverdue(plant),
-                    onComplete: { onQuickAction(plant) }
+                    onComplete: { onQuickAction(plant) },
+                    onOpen: { onPlantTap(plant) }
                 )
-                .onTapGesture { onPlantTap(plant) }
                 .contextMenu {
                     Button(role: .destructive) {
                         onDelete(plant)

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/GardenClub/ClubShareComposerSheet.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/GardenClub/ClubShareComposerSheet.swift
@@ -52,6 +52,11 @@ public struct ClubShareComposerSheet: View { // swiftlint:disable:this type_body
         return plant?.name
     }
 
+    private var resolvedGardenName: String? {
+        guard includePlant else { return nil }
+        return plant?.garden?.name ?? plant?.bed?.garden?.name
+    }
+
     public init(
         plant: Plant? = nil,
         club: GardenClub? = nil,
@@ -183,6 +188,14 @@ public struct ClubShareComposerSheet: View { // swiftlint:disable:this type_body
                 Text(plant?.name ?? "")
                     .font(CultivationTheme.Fonts.body(13, weight: .semibold))
                     .foregroundStyle(CultivationTheme.Colors.brandSage)
+
+                if let resolvedGardenName {
+                    Text("· \(resolvedGardenName)")
+                        .font(CultivationTheme.Fonts.body(12))
+                        .foregroundStyle(CultivationTheme.Colors.textSecondary)
+                        .lineLimit(1)
+                        .accessibilityIdentifier("share_composer_text_garden_context")
+                }
 
                 Spacer()
 
@@ -335,12 +348,13 @@ public struct ClubShareComposerSheet: View { // swiftlint:disable:this type_body
                 caption: trimmed,
                 activityType: "shared",
                 plantName: resolvedPlantName,
+                gardenName: resolvedGardenName,
                 club: selectedClub,
                 photoURL: photoURL
             )
             onPost()
             do {
-                try await clubCloudKitService.publishActivity(activity)
+                try await clubCloudKitService.publishActivity(activity, club: selectedClub)
                 dismiss()
             } catch {
                 offlineMessage = [

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/GardenClub/GardenClubFeedView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/GardenClub/GardenClubFeedView.swift
@@ -331,7 +331,8 @@ public struct GardenClubFeedView: View { // swiftlint:disable:this type_body_len
             var merged: [ClubActivityViewData] = localActivities.map(Self.viewData(from:))
             do {
                 let ckRecords = try await clubCloudKitService.fetchRecentActivities(
-                    for: clubID.uuidString,
+                    for: activeClub,
+                    memberID: dataService.getCurrentUser()?.id.uuidString,
                     limit: 50
                 )
                 let ckViewData = ckRecords.map(Self.viewData(from:))
@@ -376,7 +377,7 @@ public struct GardenClubFeedView: View { // swiftlint:disable:this type_body_len
             id: id,
             authorDisplayName: author,
             caption: caption,
-            zoneTag: nil, // not yet captured on ClubActivity
+            zoneTag: activity.gardenName,
             photoURL: activity.photoURL,
             relativeTimeLabel: label,
             likeCount: 0, // future feature
@@ -392,6 +393,7 @@ public struct GardenClubFeedView: View { // swiftlint:disable:this type_body_len
         let id = UUID(uuidString: record.recordID.recordName) ?? UUID()
         let author = record["memberName"] as? String ?? "Member"
         let caption = record["activityDescription"] as? String
+        let gardenName = record["gardenName"] as? String
         let photoURL = (record["photo"] as? CKAsset)?.fileURL?.absoluteString
             ?? record["photoURL"] as? String
         let timestamp = record["timestamp"] as? Date
@@ -407,7 +409,7 @@ public struct GardenClubFeedView: View { // swiftlint:disable:this type_body_len
             id: id,
             authorDisplayName: author,
             caption: caption,
-            zoneTag: nil, // not yet captured in CK record
+            zoneTag: gardenName,
             photoURL: photoURL,
             relativeTimeLabel: label,
             likeCount: 0, // future feature

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/GardenClub/JoinClubSheet.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/GardenClub/JoinClubSheet.swift
@@ -14,6 +14,7 @@ public struct JoinClubSheet: View {
     @State private var inviteCode: String = ""
     @State private var isJoining = false
     @State private var errorMessage: String?
+    @FocusState private var isCodeFieldFocused: Bool
 
     private let maxCodeLength = 6
     private var isValid: Bool {
@@ -101,6 +102,10 @@ public struct JoinClubSheet: View {
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, 20)
                     .glassCard()
+                    .contentShape(Rectangle())
+                    .onTapGesture {
+                        isCodeFieldFocused = true
+                    }
 
                     // Invisible text field over the top for input
                     TextField("", text: Binding(
@@ -114,7 +119,11 @@ public struct JoinClubSheet: View {
                         .textInputAutocapitalization(.characters)
                     #endif
                         .autocorrectionDisabled()
+                        .focused($isCodeFieldFocused)
                         .accessibilityIdentifier("join_club_code_field")
+                }
+                .task {
+                    isCodeFieldFocused = true
                 }
             }
             .padding(.horizontal, CultivationTheme.Spacing.screenPadding)

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/GardenView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/GardenView.swift
@@ -3,7 +3,7 @@ import GrowWiseServices
 import SwiftUI
 
 // SwiftLint suppressions for #284 — pre-existing structural & style violations; refactor out of scope.
-// swiftlint:disable file_length line_length
+// swiftlint:disable file_length
 
 // MARK: - GardenFilter
 
@@ -88,9 +88,6 @@ public struct GardenView: View { // swiftlint:disable:this type_body_length
                                                     await viewModel.load(dataService: dataService)
                                                 }
                                             }
-                                        )
-                                        .accessibilityIdentifier(
-                                            "garden_bed_\(group.displayName.lowercased().replacingOccurrences(of: " ", with: "_"))"
                                         )
                                     }
                                 }
@@ -546,4 +543,4 @@ public struct GardenView: View { // swiftlint:disable:this type_body_length
     }
 }
 
-// swiftlint:enable file_length line_length
+// swiftlint:enable file_length

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/MyGardenPlantDetailView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/MyGardenPlantDetailView.swift
@@ -15,8 +15,6 @@ struct PlantDetailView: View {
     private var reminderService
     @Environment(PlantCareAdviceService.self)
     private var careAdviceService
-    @Environment(PerenualEnrichmentService.self)
-    private var perenualEnrichment
 
     // MARK: - State
 
@@ -41,6 +39,7 @@ struct PlantDetailView: View {
                     heroPhoto
                     titleBlock
                     statRow
+                    PerenualEnrichmentCard(plant: plant)
                     actionButtons
                     adviceCard
                     photoJournalStrip

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/PaywallView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/PaywallView.swift
@@ -22,17 +22,21 @@ public struct PaywallView: View {
     // Product IDs (Premium only — Pro is "Coming soon" and not purchasable)
     private let premiumMonthlyID = "com.growwise.premium.monthly"
     private let premiumYearlyID = "com.growwise.premium.annual"
-    internal static let freePlanName = "Free"
-    internal static let premiumPlanName = "Premium"
+    static let freePlanName = "Free"
+    static let premiumPlanName = "Premium"
+    static let premiumMonthlyPriceText = "$2.99"
+    static let premiumAnnualPriceText = "$34.99"
+    static let premiumMonthlyPurchaseLabel = "Subscribe to Premium — $2.99/mo"
+    static let premiumAnnualPurchaseLabel = "Subscribe to Premium — $34.99/yr"
     /// Source-of-truth rows for the Free vs Premium plan comparison table.
-    internal static let comparisonRows: [PaywallComparisonRow] = [
+    static let comparisonRows: [PaywallComparisonRow] = [
         PaywallComparisonRow(feature: "Plant Health Guidance", free: "3/mo", premium: true),
         PaywallComparisonRow(feature: "Plant Limit", free: "50", premium: "500"),
         PaywallComparisonRow(feature: "Smart Reminders", free: false, premium: true),
         PaywallComparisonRow(feature: "Weather Adjust", free: false, premium: true),
         PaywallComparisonRow(feature: "Priority Support", free: false, premium: true),
         PaywallComparisonRow(feature: "Garden Clubs", free: true, premium: true),
-        PaywallComparisonRow(feature: "Analytics", free: "Basic", premium: "Standard")
+        PaywallComparisonRow(feature: "Analytics", free: "Basic", premium: "Standard"),
     ]
 
     public init() {}
@@ -205,7 +209,7 @@ public struct PaywallView: View {
                 tier: .premium,
                 name: Self.premiumPlanName,
                 icon: "crown",
-                price: isYearly ? "$34.99" : "$2.99",
+                price: isYearly ? Self.premiumAnnualPriceText : Self.premiumMonthlyPriceText,
                 period: isYearly ? "/year" : "/month",
                 highlights: [
                     "Unlimited Plant Health checks",
@@ -474,8 +478,7 @@ public struct PaywallView: View {
 
     private var purchaseButtonLabel: String {
         guard selectedTier == .premium else { return "Select a Plan" }
-        let price = isYearly ? "$34.99/yr" : "$2.99/mo"
-        return "Subscribe to Premium — \(price)"
+        return isYearly ? Self.premiumAnnualPurchaseLabel : Self.premiumMonthlyPurchaseLabel
     }
 
     // MARK: - Legal Footer
@@ -533,7 +536,7 @@ public struct PaywallView: View {
 
 // MARK: - Comparison Value
 
-internal enum PaywallComparisonValue: ExpressibleByBooleanLiteral, ExpressibleByStringLiteral {
+enum PaywallComparisonValue: ExpressibleByBooleanLiteral, ExpressibleByStringLiteral {
     case check
     case cross
     case text(String)
@@ -548,7 +551,7 @@ internal enum PaywallComparisonValue: ExpressibleByBooleanLiteral, ExpressibleBy
 }
 
 /// A single feature row in the Free vs Premium paywall comparison table.
-internal struct PaywallComparisonRow {
+struct PaywallComparisonRow {
     let feature: String
     let free: PaywallComparisonValue
     let premium: PaywallComparisonValue

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/PlantDatabase/PerenualBrowseView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/PlantDatabase/PerenualBrowseView.swift
@@ -69,10 +69,12 @@ public struct PerenualBrowseView: View {
 
     private var emptyState: some View {
         ContentUnavailableView {
-            Label("No Plants Found", systemImage: "leaf.fill")
+            Label(emptyStateTitle, systemImage: "leaf.fill")
         } description: {
             if !searchText.isEmpty {
                 Text("Try a different search term")
+            } else if isOnlineDatabaseUnavailable {
+                Text(PerenualError.noAPIKey.errorDescription ?? "Online plant database unavailable")
             } else if let error = api.lastError {
                 Text(error)
             } else {
@@ -84,6 +86,14 @@ public struct PerenualBrowseView: View {
             }
             .buttonStyle(.bordered)
         }
+    }
+
+    private var isOnlineDatabaseUnavailable: Bool {
+        api.lastError == PerenualError.noAPIKey.errorDescription
+    }
+
+    private var emptyStateTitle: String {
+        isOnlineDatabaseUnavailable ? "Online Database Unavailable" : "No Plants Found"
     }
 
     private var resultsList: some View {

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/PlantScannerView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/PlantScannerView.swift
@@ -7,6 +7,9 @@ import UIKit
 #endif
 
 public struct PlantScannerView: View {
+    @Environment(DataService.self)
+    private var dataService
+
     @State private var diagnosticService = PlantDiagnosticService()
 
     @State private var selectedPhotoItem: PhotosPickerItem?
@@ -26,12 +29,6 @@ public struct PlantScannerView: View {
                     }
                     .buttonStyle(.borderedProminent)
                     .accessibilityIdentifier("scannerChoosePhotoButton")
-
-                    Button("Show Sample Guidance") {
-                        diagnosticService.setSampleDiagnosis()
-                    }
-                    .buttonStyle(.bordered)
-                    .accessibilityIdentifier("scannerRunSampleButton")
 
                     if diagnosticService.isAnalyzing {
                         ProgressView("Checking image...")
@@ -69,7 +66,7 @@ public struct PlantScannerView: View {
                 if let data = try? await newValue.loadTransferable(type: Data.self),
                    let image = UIImage(data: data)
                 {
-                    await diagnosticService.diagnose(image: image)
+                    await diagnosticService.diagnose(image: image, currentUser: dataService.getCurrentUser())
                 }
                 #endif
             }
@@ -79,4 +76,5 @@ public struct PlantScannerView: View {
 
 #Preview {
     PlantScannerView()
+        .environment(DataService.createFallback())
 }

--- a/GrowWisePackage/Sources/GrowWiseModels/User.swift
+++ b/GrowWisePackage/Sources/GrowWiseModels/User.swift
@@ -196,7 +196,7 @@ public enum SubscriptionTier: String, CaseIterable, Codable, Sendable {
     public var monthlyPrice: Double {
         switch self {
         case .free: 0.0
-        case .premium: 4.99
+        case .premium: 2.99
         case .pro: 9.99
         }
     }

--- a/GrowWisePackage/Sources/GrowWiseServices/ClubCloudKitService.swift
+++ b/GrowWisePackage/Sources/GrowWiseServices/ClubCloudKitService.swift
@@ -33,6 +33,32 @@ public final class ClubCloudKitService {
 
     private let logger = Logger(subsystem: "com.growwise.cloudkit", category: "ClubCloudKitService")
 
+    // MARK: - Pure mapping helpers
+
+    public static func recordFields(from activity: ClubActivity) throws -> ClubActivityCloudRecordFields {
+        guard let clubID = activity.clubID else { throw ClubCloudKitError.missingIdentifier }
+        guard let activityID = activity.id else { throw ClubCloudKitError.missingIdentifier }
+
+        return ClubActivityCloudRecordFields(
+            recordName: activityID.uuidString,
+            clubID: clubID.uuidString,
+            memberName: activity.memberName ?? "",
+            memberID: activity.memberID ?? "",
+            activityType: activity.activityType ?? "",
+            activityDescription: activity.activityDescription ?? "",
+            gardenName: activity.gardenName ?? "",
+            photoURL: activity.photoURL,
+            timestamp: activity.timestamp ?? Date()
+        )
+    }
+
+    public static func databaseScope(for club: GardenClub?, memberID: String?) -> ClubCloudDatabaseScope {
+        guard let club, let ownerID = club.ownerID, let memberID else {
+            return .ownerPrivate
+        }
+        return ownerID == memberID ? .ownerPrivate : .sharedParticipant
+    }
+
     // MARK: - Init
 
     public init() {
@@ -288,6 +314,24 @@ public final class ClubCloudKitService {
     ///   `clubID`, `memberName`, `memberID`, `activityType`,
     ///   `activityDescription`, `gardenName`, `timestamp`.
     public func fetchRecentActivities(for clubID: String, limit: Int = 50) async throws -> [CKRecord] {
+        try await fetchRecentActivities(for: clubID, scope: .ownerPrivate, limit: limit)
+    }
+
+    public func fetchRecentActivities(
+        for club: GardenClub,
+        memberID: String? = nil,
+        limit: Int = 50
+    ) async throws -> [CKRecord] {
+        guard let clubID = club.id else { throw ClubCloudKitError.missingIdentifier }
+        let scope = Self.databaseScope(for: club, memberID: memberID)
+        return try await fetchRecentActivities(for: clubID.uuidString, scope: scope, limit: limit)
+    }
+
+    private func fetchRecentActivities(
+        for clubID: String,
+        scope: ClubCloudDatabaseScope,
+        limit: Int
+    ) async throws -> [CKRecord] {
         try await requireAvailableAccount()
 
         let predicate = NSPredicate(format: "clubID == %@", clubID)
@@ -299,10 +343,12 @@ public final class ClubCloudKitService {
 
         let zoneName = CloudKitSchema.Zone.gardenClub
         let zoneID = CKRecordZone.ID(zoneName: zoneName, ownerName: CKCurrentUserDefaultName)
+        let database = database(for: scope)
+        let queryZone: CKRecordZone.ID? = scope == .ownerPrivate ? zoneID : nil
 
-        let (results, _) = try await privateDatabase.records(
+        let (results, _) = try await database.records(
             matching: query,
-            inZoneWith: zoneID,
+            inZoneWith: queryZone,
             resultsLimit: limit
         )
 
@@ -318,25 +364,30 @@ public final class ClubCloudKitService {
     // MARK: - Save a club record to shared zone
 
     /// Saves an activity record into the club's shared zone so all members can see it.
-    public func publishActivity(_ activity: ClubActivity) async throws {
+    public func publishActivity(_ activity: ClubActivity, club: GardenClub? = nil) async throws {
         try await requireAvailableAccount()
 
-        guard let clubID = activity.clubID else { throw ClubCloudKitError.missingIdentifier }
-        guard let activityID = activity.id else { throw ClubCloudKitError.missingIdentifier }
+        let fields = try Self.recordFields(from: activity)
+        let scope = Self.databaseScope(for: club, memberID: fields.memberID)
+        let database = database(for: scope)
 
         let zoneName = CloudKitSchema.Zone.gardenClub
         let zoneID = CKRecordZone.ID(zoneName: zoneName, ownerName: CKCurrentUserDefaultName)
-        let recordID = CKRecord.ID(recordName: activityID.uuidString, zoneID: zoneID)
+        let recordID = if scope == .ownerPrivate {
+            CKRecord.ID(recordName: fields.recordName, zoneID: zoneID)
+        } else {
+            CKRecord.ID(recordName: fields.recordName)
+        }
 
         let record = CKRecord(recordType: CloudKitSchema.RecordType.clubActivity, recordID: recordID)
-        record["clubID"] = clubID.uuidString
-        record["memberName"] = activity.memberName ?? ""
-        record["memberID"] = activity.memberID ?? ""
-        record["activityType"] = activity.activityType ?? ""
-        record["activityDescription"] = activity.activityDescription ?? ""
-        record["gardenName"] = activity.gardenName ?? ""
-        record["timestamp"] = activity.timestamp ?? Date()
-        if let photoURL = activity.photoURL {
+        record["clubID"] = fields.clubID
+        record["memberName"] = fields.memberName
+        record["memberID"] = fields.memberID
+        record["activityType"] = fields.activityType
+        record["activityDescription"] = fields.activityDescription
+        record["gardenName"] = fields.gardenName
+        record["timestamp"] = fields.timestamp
+        if let photoURL = fields.photoURL {
             record["photoURL"] = photoURL
             if let assetURL = Self.localFileURL(from: photoURL),
                FileManager.default.fileExists(atPath: assetURL.path)
@@ -346,11 +397,21 @@ public final class ClubCloudKitService {
         }
 
         do {
-            _ = try await privateDatabase.save(record)
-            logger.info("Published activity \(activityID.uuidString) to shared zone")
+            _ = try await database.save(record)
+            logger.info("Published activity \(fields.recordName) to CloudKit")
         } catch {
             logger.error("Failed to publish activity: \(error.localizedDescription)")
             throw ClubCloudKitError.saveFailed(error.localizedDescription)
+        }
+    }
+
+    private func database(for scope: ClubCloudDatabaseScope) -> CKDatabase {
+        switch scope {
+        case .ownerPrivate:
+            privateDatabase
+
+        case .sharedParticipant:
+            sharedDatabase
         }
     }
 
@@ -369,6 +430,23 @@ public struct ClubSyncResult: Sendable {
     public let activities: [CKRecord]
     public let messages: [CKRecord]
     public let events: [CKRecord]
+}
+
+public struct ClubActivityCloudRecordFields: Equatable, Sendable {
+    public let recordName: String
+    public let clubID: String
+    public let memberName: String
+    public let memberID: String
+    public let activityType: String
+    public let activityDescription: String
+    public let gardenName: String
+    public let photoURL: String?
+    public let timestamp: Date
+}
+
+public enum ClubCloudDatabaseScope: Equatable, Sendable {
+    case ownerPrivate
+    case sharedParticipant
 }
 
 // MARK: - Errors

--- a/GrowWisePackage/Sources/GrowWiseServices/DataService+GardenClub.swift
+++ b/GrowWisePackage/Sources/GrowWiseServices/DataService+GardenClub.swift
@@ -54,12 +54,14 @@ public extension DataService {
     ///   - caption: The post body text (required, non-empty).
     ///   - activityType: One of "shared", "watered", "harvested", "planted", etc.
     ///   - plantName: Optional plant name prepended to the description.
+    ///   - gardenName: Optional garden context displayed as the post's location tag.
     /// - Throws: `CreateClubPostError.noClub` if the user is not in any club.
     @discardableResult
     func createClubPost(
         caption: String,
         activityType: String,
         plantName: String? = nil,
+        gardenName: String? = nil,
         club: GardenClub? = nil,
         photoURL: String? = nil
     ) throws -> ClubActivity {
@@ -81,6 +83,7 @@ public extension DataService {
             activityType: activityType,
             description: description
         )
+        activity.gardenName = gardenName
         activity.photoURL = photoURL
         let repo = ClubActivityRepository(context: mainContext)
         try repo.save(activity)

--- a/GrowWisePackage/Sources/GrowWiseServices/DataService.swift
+++ b/GrowWisePackage/Sources/GrowWiseServices/DataService.swift
@@ -453,6 +453,7 @@ public final class DataService {
         plant.isUserPlant = false
         plant.notes = notes
         try plants.add(plant)
+        invalidatePlantDatabaseCache()
     }
 
     public func fetchPlants(for garden: Garden? = nil, offset: Int = 0, limit: Int = 20) -> [Plant] {
@@ -506,6 +507,10 @@ public final class DataService {
 
         cache.set(cacheKey, value: allPlants, policy: .long)
         return allPlants
+    }
+
+    func invalidatePlantDatabaseCache() {
+        cache.invalidateAll(withPrefix: "plant_database:")
     }
 
     private func fetchPlantDatabasePage(offset: Int, limit: Int) -> [Plant] {

--- a/GrowWisePackage/Sources/GrowWiseServices/DataService.swift
+++ b/GrowWisePackage/Sources/GrowWiseServices/DataService.swift
@@ -243,6 +243,27 @@ public final class DataService {
         return garden
     }
 
+    @discardableResult
+    public func createGardenBed(
+        name: String,
+        bedType: BedType,
+        in garden: Garden
+    ) throws -> GardenBed {
+        let bed = GardenBed(name: name, bedType: bedType, garden: garden)
+        var beds = garden.beds ?? []
+        beds.append(bed)
+        garden.beds = beds
+        garden.lastModified = Date()
+
+        mainContext.insert(bed)
+        try mainContext.save()
+
+        cache.invalidateAll(withPrefix: "gardens:")
+        cache.invalidateAll(withPrefix: "plants:")
+
+        return bed
+    }
+
     public func fetchGardens(offset: Int = 0, limit: Int = 20) -> [Garden] {
         let clampedOffset = max(0, offset)
         let clampedLimit = max(1, min(limit, 50))
@@ -295,6 +316,7 @@ public final class DataService {
     public func createUserPlant(
         from template: Plant,
         in garden: Garden?,
+        gardenBed: GardenBed? = nil,
         plantingDate: Date = Date()
     ) throws -> Plant {
         let plant = Plant(
@@ -311,7 +333,11 @@ public final class DataService {
         plant.photoURLs = template.photoURLs
         plant.companionPlants = template.companionPlants
         plant.garden = garden
+        plant.bed = gardenBed
         plant.plantingDate = plantingDate
+        if let gardenBed {
+            gardenBed.plants = (gardenBed.plants ?? []) + [plant]
+        }
 
         try plants.add(plant)
         cache.invalidateAll(withPrefix: "plants:")
@@ -323,6 +349,7 @@ public final class DataService {
     public func createUserPlant(
         from detail: PerenualSpeciesDetail,
         in garden: Garden?,
+        gardenBed: GardenBed? = nil,
         plantingDate: Date = Date()
     ) throws -> Plant {
         let plant = Plant(
@@ -340,7 +367,11 @@ public final class DataService {
             plant.photoURLs = [imageURL]
         }
         plant.garden = garden
+        plant.bed = gardenBed
         plant.plantingDate = plantingDate
+        if let gardenBed {
+            gardenBed.plants = (gardenBed.plants ?? []) + [plant]
+        }
 
         try plants.add(plant)
         cache.invalidateAll(withPrefix: "plants:")
@@ -351,9 +382,15 @@ public final class DataService {
     public func createStarterPlant(
         from template: Plant,
         in garden: Garden?,
+        gardenBed: GardenBed? = nil,
         plantingDate: Date = Date()
     ) throws -> StarterPlantCreationResult {
-        let plant = try createUserPlant(from: template, in: garden, plantingDate: plantingDate)
+        let plant = try createUserPlant(
+            from: template,
+            in: garden,
+            gardenBed: gardenBed,
+            plantingDate: plantingDate
+        )
         let frequency = Self.reminderFrequency(for: plant.wateringFrequency)
         let dueDate = Calendar.current.date(
             byAdding: .day,

--- a/GrowWisePackage/Sources/GrowWiseServices/PerenualAPIService.swift
+++ b/GrowWisePackage/Sources/GrowWiseServices/PerenualAPIService.swift
@@ -424,7 +424,7 @@ public enum PerenualError: LocalizedError {
 
     public var errorDescription: String? {
         switch self {
-        case .noAPIKey: "No Perenual API key configured"
+        case .noAPIKey: "Online plant database is not configured for this build."
         case .invalidURL: "Invalid request URL"
         case .invalidResponse: "Invalid server response"
         case .unauthorized: "Invalid API key — check your Perenual subscription"

--- a/GrowWisePackage/Sources/GrowWiseServices/PerenualEnrichmentService.swift
+++ b/GrowWisePackage/Sources/GrowWiseServices/PerenualEnrichmentService.swift
@@ -58,6 +58,32 @@ public final class PerenualEnrichmentService {
         return await fetchAndCache(scientificName: sciName, key: key)
     }
 
+    /// Returns cached enrichment when available, otherwise waits for a lookup.
+    public func loadEnrichment(for plant: Plant) async -> PerenualSpeciesDetail? {
+        guard let sciName = plant.scientificName, !sciName.isEmpty else { return nil }
+        let key = sciName.lowercased()
+
+        if let cached = cache[key] {
+            return cached
+        }
+
+        if inflight.contains(key) {
+            for _ in 0 ..< 30 {
+                try? await Task.sleep(for: .milliseconds(200))
+                if let cached = cache[key] {
+                    return cached
+                }
+                if !inflight.contains(key) {
+                    return nil
+                }
+            }
+            return nil
+        }
+
+        inflight.insert(key)
+        return await fetchAndCache(scientificName: sciName, key: key)
+    }
+
     // MARK: - Private
 
     @discardableResult

--- a/GrowWisePackage/Sources/GrowWiseServices/PlantDatabaseService.swift
+++ b/GrowWisePackage/Sources/GrowWiseServices/PlantDatabaseService.swift
@@ -67,6 +67,8 @@ public final class PlantDatabaseService {
                 case .houseplants: plantData.type == .houseplant
                 case .fruits: plantData.type == .fruit
                 case .succulents: plantData.type == .succulent
+                case .trees: plantData.type == .tree
+                case .shrubs: plantData.type == .shrub
                 }
             }
             do {
@@ -428,6 +430,8 @@ public enum SeedCategory: String, CaseIterable, Sendable {
     case houseplants
     case fruits
     case succulents
+    case trees
+    case shrubs
 
     public var displayName: String {
         rawValue.capitalized

--- a/GrowWisePackage/Sources/GrowWiseServices/PlantDatabaseService.swift
+++ b/GrowWisePackage/Sources/GrowWiseServices/PlantDatabaseService.swift
@@ -447,6 +447,64 @@ public struct PlantRecommendation: Identifiable {
     }
 }
 
+public enum PlantSearchResultSource: String {
+    case local
+    case perenual
+}
+
+public struct PlantSearchResult: Identifiable {
+    public let id: String
+    public let displayName: String
+    public let scientificName: String?
+    public let source: PlantSearchResultSource
+    public let localPlant: Plant?
+    public let perenualSpecies: PerenualSpeciesSummary?
+
+    public static func combine(
+        local plants: [Plant],
+        perenual species: [PerenualSpeciesSummary],
+        limit: Int = 8
+    ) -> [PlantSearchResult] {
+        var seenKeys: Set<String> = []
+        var results: [PlantSearchResult] = []
+
+        for plant in plants {
+            let name = plant.name ?? "Plant"
+            let key = dedupeKey(name: name, scientificName: plant.scientificName)
+            guard seenKeys.insert(key).inserted else { continue }
+            results.append(PlantSearchResult(
+                id: "local-\(plant.id?.uuidString ?? name)",
+                displayName: name,
+                scientificName: plant.scientificName,
+                source: .local,
+                localPlant: plant,
+                perenualSpecies: nil
+            ))
+        }
+
+        for item in species {
+            let key = dedupeKey(name: item.commonName, scientificName: item.scientificName.first)
+            guard seenKeys.insert(key).inserted else { continue }
+            results.append(PlantSearchResult(
+                id: "perenual-\(item.id)",
+                displayName: item.commonName,
+                scientificName: item.scientificName.first,
+                source: .perenual,
+                localPlant: nil,
+                perenualSpecies: item
+            ))
+        }
+
+        return Array(results.prefix(max(1, limit)))
+    }
+
+    private static func dedupeKey(name: String, scientificName: String?) -> String {
+        let scientific = scientificName?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() ?? ""
+        if !scientific.isEmpty { return scientific }
+        return name.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    }
+}
+
 public struct UserGardenProfile {
     public let skillLevel: GardeningSkillLevel
     public let availableSpace: SpaceRequirement

--- a/GrowWisePackage/Sources/GrowWiseServices/PlantDatabaseService.swift
+++ b/GrowWisePackage/Sources/GrowWiseServices/PlantDatabaseService.swift
@@ -81,6 +81,7 @@ public final class PlantDatabaseService {
 
         if !failures.isEmpty { throw PlantDatabaseSeedingError(failures: failures) }
 
+        dataService.invalidatePlantDatabaseCache()
         let totalTime = CFAbsoluteTimeGetCurrent() - startTime
         let totalPlants = dataService.fetchPlantDatabase().count
         logger.info("Seeded \(totalPlants) plants in \(String(format: "%.2f", totalTime), privacy: .public)s")
@@ -120,6 +121,11 @@ public final class PlantDatabaseService {
 
     public func getBeginnerFriendlyPlants() -> [Plant] {
         filterPlants(difficulty: .beginner)
+    }
+
+    public func getSeededBeginnerFriendlyPlants() async throws -> [Plant] {
+        try await seedPlantDatabase()
+        return getBeginnerFriendlyPlants()
     }
 
     public func getPlantsBySeason(_ season: PlantingSeason) -> [Plant] {

--- a/GrowWisePackage/Sources/GrowWiseServices/PlantDatabaseService.swift
+++ b/GrowWisePackage/Sources/GrowWiseServices/PlantDatabaseService.swift
@@ -4,7 +4,7 @@ import os
 import SwiftData
 
 // SwiftLint suppressions for #284 — pre-existing structural & style violations; refactor out of scope.
-// swiftlint:disable cyclomatic_complexity function_parameter_count
+// swiftlint:disable cyclomatic_complexity file_length function_parameter_count
 
 private let logger = Logger(subsystem: "com.growwise", category: "PlantDatabaseService")
 

--- a/GrowWisePackage/Sources/GrowWiseServices/PlantDiagnosticService.swift
+++ b/GrowWisePackage/Sources/GrowWiseServices/PlantDiagnosticService.swift
@@ -59,6 +59,7 @@ public struct PlantDiagnosis: Sendable, Equatable {
 public enum PlantDiagnosticError: Error, LocalizedError {
     case invalidImage
     case noClassification
+    case missingCurrentUser
     case diagnosisLimitReached(remaining: Int, tier: SubscriptionTier)
 
     public var errorDescription: String? {
@@ -68,6 +69,9 @@ public enum PlantDiagnosticError: Error, LocalizedError {
 
         case .noClassification:
             "No plant health guidance could be produced from this image."
+
+        case .missingCurrentUser:
+            "Finish setup before running a Plant Health check so monthly limits can be applied."
 
         case .diagnosisLimitReached(let remaining, let tier):
             "You have reached your monthly Plant Health check limit (\(tier.aiDiagnosesPerMonth) per month on the \(tier.displayName) plan). Upgrade for unlimited checks. Remaining: \(remaining)."
@@ -136,6 +140,19 @@ public final class PlantDiagnosticService {
     }
 
     // MARK: - Plant Health Check
+
+    /// Run a plant health check from UI flows that may not have a loaded current user yet.
+    public func diagnose(image: PlatformImage, currentUser user: User?) async {
+        lastDiagnosis = nil
+        lastError = nil
+
+        guard let user else {
+            lastError = PlantDiagnosticError.missingCurrentUser.localizedDescription
+            return
+        }
+
+        await diagnose(image: image, user: user)
+    }
 
     /// Run a plant health check, enforcing the user's subscription limits.
     /// Increments the user's monthly health-check usage counter on success.

--- a/GrowWisePackage/Sources/GrowWiseServices/Resources/plant_database.json
+++ b/GrowWisePackage/Sources/GrowWiseServices/Resources/plant_database.json
@@ -882,5 +882,481 @@
       "Prune after flowering on old wood varieties, or in spring for new wood types"
     ],
     "companionPlants": ["Hosta", "Fern", "Azalea"]
+  },
+  {
+    "name": "Arugula",
+    "scientificName": "Eruca vesicaria",
+    "type": "vegetable",
+    "difficulty": "beginner",
+    "sunlight": "partialSun",
+    "watering": "twiceWeekly",
+    "space": "small",
+    "description": "Fast-growing peppery green for salads and cool-season containers",
+    "careInstructions": [
+      "Sow shallowly in cool weather for best flavor",
+      "Keep soil evenly moist to prevent bitterness",
+      "Harvest outer leaves when young and tender",
+      "Provide afternoon shade as temperatures rise"
+    ],
+    "companionPlants": ["Lettuce", "Radish", "Dill"]
+  },
+  {
+    "name": "Beet",
+    "scientificName": "Beta vulgaris",
+    "type": "vegetable",
+    "difficulty": "beginner",
+    "sunlight": "fullSun",
+    "watering": "twiceWeekly",
+    "space": "small",
+    "description": "Dual-purpose root crop with edible greens and sweet earthy roots",
+    "careInstructions": [
+      "Thin seedlings so roots have space to size up",
+      "Keep soil consistently moist during root development",
+      "Harvest greens sparingly while roots mature",
+      "Loosen compacted soil before planting"
+    ],
+    "companionPlants": ["Lettuce", "Onion", "Cabbage"]
+  },
+  {
+    "name": "Swiss Chard",
+    "scientificName": "Beta vulgaris subsp. cicla",
+    "type": "vegetable",
+    "difficulty": "beginner",
+    "sunlight": "partialSun",
+    "watering": "twiceWeekly",
+    "space": "medium",
+    "description": "Colorful leafy green that tolerates heat better than spinach",
+    "careInstructions": [
+      "Harvest outer stalks first for continuous growth",
+      "Water deeply during hot spells",
+      "Mulch to keep roots cool",
+      "Remove damaged leaves to keep plants productive"
+    ],
+    "companionPlants": ["Beans", "Lettuce", "Radish"]
+  },
+  {
+    "name": "Eggplant",
+    "scientificName": "Solanum melongena",
+    "type": "vegetable",
+    "difficulty": "intermediate",
+    "sunlight": "fullSun",
+    "watering": "twiceWeekly",
+    "space": "medium",
+    "description": "Warm-season fruiting vegetable for sunny beds and large containers",
+    "careInstructions": [
+      "Start after nights stay warm",
+      "Stake heavy branches as fruit develops",
+      "Water consistently to avoid bitter fruit",
+      "Harvest when skins are glossy"
+    ],
+    "companionPlants": ["Basil", "Marigold", "Pepper"]
+  },
+  {
+    "name": "Pea",
+    "scientificName": "Pisum sativum",
+    "type": "vegetable",
+    "difficulty": "beginner",
+    "sunlight": "fullSun",
+    "watering": "twiceWeekly",
+    "space": "small",
+    "description": "Cool-season climbing crop with sweet pods and nitrogen-fixing roots",
+    "careInstructions": [
+      "Provide a trellis at planting time",
+      "Sow early while soil is cool",
+      "Pick pods often to keep vines producing",
+      "Avoid heavy nitrogen fertilizer"
+    ],
+    "companionPlants": ["Carrot", "Radish", "Lettuce"]
+  },
+  {
+    "name": "Bok Choy",
+    "scientificName": "Brassica rapa subsp. chinensis",
+    "type": "vegetable",
+    "difficulty": "beginner",
+    "sunlight": "partialSun",
+    "watering": "twiceWeekly",
+    "space": "small",
+    "description": "Compact Asian green with crisp stems for cool-season gardens",
+    "careInstructions": [
+      "Grow in spring or fall to avoid bolting",
+      "Keep soil evenly moist",
+      "Harvest baby heads early or full heads when firm",
+      "Use row cover to reduce flea beetle damage"
+    ],
+    "companionPlants": ["Dill", "Mint", "Calendula"]
+  },
+  {
+    "name": "Rosemary",
+    "scientificName": "Salvia rosmarinus",
+    "type": "herb",
+    "difficulty": "intermediate",
+    "sunlight": "fullSun",
+    "watering": "biweekly",
+    "space": "medium",
+    "description": "Aromatic woody herb for dry sunny containers and Mediterranean beds",
+    "careInstructions": [
+      "Use sharply draining soil",
+      "Let soil dry between waterings",
+      "Prune lightly after flowering to keep shape",
+      "Protect from soggy winter soil"
+    ],
+    "companionPlants": ["Sage", "Thyme", "Lavender"]
+  },
+  {
+    "name": "Tarragon",
+    "scientificName": "Artemisia dracunculus",
+    "type": "herb",
+    "difficulty": "intermediate",
+    "sunlight": "fullSun",
+    "watering": "weekly",
+    "space": "small",
+    "description": "Delicate culinary herb with anise flavor for sauces and vegetables",
+    "careInstructions": [
+      "Plant in well-drained soil with good airflow",
+      "Water when the top inch of soil dries",
+      "Cut stems regularly to encourage fresh growth",
+      "Divide established plants every few years"
+    ],
+    "companionPlants": ["Eggplant", "Pepper", "Tomato"]
+  },
+  {
+    "name": "Bay Laurel",
+    "scientificName": "Laurus nobilis",
+    "type": "herb",
+    "difficulty": "intermediate",
+    "sunlight": "partialSun",
+    "watering": "weekly",
+    "space": "large",
+    "description": "Evergreen culinary herb grown as a patio tree or clipped container plant",
+    "careInstructions": [
+      "Grow in a container where winters are cold",
+      "Water when soil is dry several inches down",
+      "Prune to maintain size and shape",
+      "Harvest mature leaves and dry before use"
+    ],
+    "companionPlants": ["Rosemary", "Thyme", "Lavender"]
+  },
+  {
+    "name": "Sorrel",
+    "scientificName": "Rumex acetosa",
+    "type": "herb",
+    "difficulty": "beginner",
+    "sunlight": "partialSun",
+    "watering": "twiceWeekly",
+    "space": "small",
+    "description": "Perennial lemony green used as an herb or tender salad leaf",
+    "careInstructions": [
+      "Harvest young leaves for the best texture",
+      "Cut flower stalks to keep leaves tender",
+      "Grow in part shade in hot climates",
+      "Divide clumps when growth slows"
+    ],
+    "companionPlants": ["Chives", "Parsley", "Lettuce"]
+  },
+  {
+    "name": "Nasturtium",
+    "scientificName": "Tropaeolum majus",
+    "type": "flower",
+    "difficulty": "beginner",
+    "sunlight": "fullSun",
+    "watering": "weekly",
+    "space": "medium",
+    "description": "Edible trailing flower with peppery leaves and bright blooms",
+    "careInstructions": [
+      "Sow directly after frost danger passes",
+      "Avoid rich fertilizer to encourage flowers",
+      "Let soil dry slightly between waterings",
+      "Use flowers and young leaves fresh"
+    ],
+    "companionPlants": ["Cucumber", "Radish", "Tomato"]
+  },
+  {
+    "name": "Calendula",
+    "scientificName": "Calendula officinalis",
+    "type": "flower",
+    "difficulty": "beginner",
+    "sunlight": "fullSun",
+    "watering": "weekly",
+    "space": "small",
+    "description": "Cool-season edible flower that attracts pollinators and beneficial insects",
+    "careInstructions": [
+      "Deadhead spent blooms for more flowers",
+      "Sow in spring or fall in mild climates",
+      "Water at soil level to reduce mildew",
+      "Allow some flowers to self-seed"
+    ],
+    "companionPlants": ["Lettuce", "Bok Choy", "Carrot"]
+  },
+  {
+    "name": "Snapdragon",
+    "scientificName": "Antirrhinum majus",
+    "type": "flower",
+    "difficulty": "beginner",
+    "sunlight": "fullSun",
+    "watering": "weekly",
+    "space": "small",
+    "description": "Upright flowering annual for cool-season color and pollinator visits",
+    "careInstructions": [
+      "Plant in cool weather for strongest blooms",
+      "Pinch young plants for bushier growth",
+      "Deadhead to extend flowering",
+      "Provide support for tall varieties"
+    ],
+    "companionPlants": ["Pansy", "Calendula", "Lettuce"]
+  },
+  {
+    "name": "Coneflower",
+    "scientificName": "Echinacea purpurea",
+    "type": "flower",
+    "difficulty": "beginner",
+    "sunlight": "fullSun",
+    "watering": "weekly",
+    "space": "medium",
+    "description": "Hardy perennial daisy with long-lasting blooms and seed heads for birds",
+    "careInstructions": [
+      "Plant in full sun and average soil",
+      "Water regularly the first season",
+      "Leave some seed heads for wildlife",
+      "Divide clumps every few years if crowded"
+    ],
+    "companionPlants": ["Lavender", "Rosemary", "Zinnia"]
+  },
+  {
+    "name": "Blueberry",
+    "scientificName": "Vaccinium corymbosum",
+    "type": "fruit",
+    "difficulty": "intermediate",
+    "sunlight": "fullSun",
+    "watering": "twiceWeekly",
+    "space": "large",
+    "description": "Acid-loving fruiting shrub with spring flowers, berries, and fall color",
+    "careInstructions": [
+      "Plant in acidic soil with pH near 4.5 to 5.5",
+      "Mulch with pine bark or needles",
+      "Water deeply during fruit swell",
+      "Plant more than one variety for better yields"
+    ],
+    "companionPlants": ["Strawberry", "Thyme", "Azalea"]
+  },
+  {
+    "name": "Raspberry",
+    "scientificName": "Rubus idaeus",
+    "type": "fruit",
+    "difficulty": "intermediate",
+    "sunlight": "fullSun",
+    "watering": "twiceWeekly",
+    "space": "large",
+    "description": "Cane fruit with summer or fall harvests for sunny edible gardens",
+    "careInstructions": [
+      "Provide a trellis or wire support",
+      "Mulch to keep roots cool and moist",
+      "Prune spent canes after harvest",
+      "Harvest berries when they release easily"
+    ],
+    "companionPlants": ["Chives", "Garlic", "Marigold"]
+  },
+  {
+    "name": "Fig",
+    "scientificName": "Ficus carica",
+    "type": "fruit",
+    "difficulty": "intermediate",
+    "sunlight": "fullSun",
+    "watering": "weekly",
+    "space": "large",
+    "description": "Heat-loving fruit tree that can be grown in ground or large containers",
+    "careInstructions": [
+      "Plant in the warmest sunny spot available",
+      "Water deeply while fruit develops",
+      "Prune lightly during dormancy",
+      "Protect container plants from hard freezes"
+    ],
+    "companionPlants": ["Lavender", "Rosemary", "Thyme"]
+  },
+  {
+    "name": "Grape",
+    "scientificName": "Vitis vinifera",
+    "type": "fruit",
+    "difficulty": "intermediate",
+    "sunlight": "fullSun",
+    "watering": "weekly",
+    "space": "extraLarge",
+    "description": "Vining fruit crop for arbors, fences, and sunny trellises",
+    "careInstructions": [
+      "Train vines on a strong support",
+      "Prune hard in dormancy to manage fruiting wood",
+      "Water deeply but infrequently once established",
+      "Provide excellent airflow around foliage"
+    ],
+    "companionPlants": ["Rosemary", "Marigold", "Chives"]
+  },
+  {
+    "name": "Rubber Plant",
+    "scientificName": "Ficus elastica",
+    "type": "houseplant",
+    "difficulty": "beginner",
+    "sunlight": "partialSun",
+    "watering": "weekly",
+    "space": "medium",
+    "description": "Glossy-leaved houseplant that tolerates average indoor conditions",
+    "careInstructions": [
+      "Provide bright indirect light",
+      "Water when the top inch of soil is dry",
+      "Wipe leaves to remove dust",
+      "Rotate periodically for even growth"
+    ],
+    "companionPlants": ["Pothos", "Snake Plant", "ZZ Plant"]
+  },
+  {
+    "name": "Chinese Evergreen",
+    "scientificName": "Aglaonema commutatum",
+    "type": "houseplant",
+    "difficulty": "beginner",
+    "sunlight": "partialShade",
+    "watering": "weekly",
+    "space": "medium",
+    "description": "Low-light tolerant foliage plant with patterned leaves",
+    "careInstructions": [
+      "Keep in low to medium indirect light",
+      "Let the top inch of soil dry between waterings",
+      "Avoid cold drafts",
+      "Remove yellow leaves at the base"
+    ],
+    "companionPlants": ["Peace Lily", "Pothos", "Parlor Palm"]
+  },
+  {
+    "name": "Parlor Palm",
+    "scientificName": "Chamaedorea elegans",
+    "type": "houseplant",
+    "difficulty": "beginner",
+    "sunlight": "partialShade",
+    "watering": "weekly",
+    "space": "medium",
+    "description": "Classic compact indoor palm for low to medium light rooms",
+    "careInstructions": [
+      "Grow in indirect light away from harsh sun",
+      "Keep soil lightly moist but never soggy",
+      "Mist or group plants to improve humidity",
+      "Trim brown fronds close to the stem"
+    ],
+    "companionPlants": ["Chinese Evergreen", "Peace Lily", "Spider Plant"]
+  },
+  {
+    "name": "Philodendron",
+    "scientificName": "Philodendron hederaceum",
+    "type": "houseplant",
+    "difficulty": "beginner",
+    "sunlight": "partialSun",
+    "watering": "weekly",
+    "space": "medium",
+    "description": "Trailing or climbing foliage plant with heart-shaped leaves",
+    "careInstructions": [
+      "Provide bright indirect light or medium indoor light",
+      "Water when the top inch of soil dries",
+      "Pinch vines to encourage fullness",
+      "Root stem cuttings easily in water"
+    ],
+    "companionPlants": ["Pothos", "Monstera", "Rubber Plant"]
+  },
+  {
+    "name": "Sedum",
+    "scientificName": "Sedum spp.",
+    "type": "succulent",
+    "difficulty": "beginner",
+    "sunlight": "fullSun",
+    "watering": "biweekly",
+    "space": "small",
+    "description": "Drought-tolerant succulent groundcover or container plant with starry flowers",
+    "careInstructions": [
+      "Plant in gritty well-drained soil",
+      "Water sparingly once established",
+      "Trim leggy growth to keep compact",
+      "Propagate from stem or leaf cuttings"
+    ],
+    "companionPlants": ["Hen and Chicks", "Echeveria", "Thyme"]
+  },
+  {
+    "name": "Haworthia",
+    "scientificName": "Haworthia attenuata",
+    "type": "succulent",
+    "difficulty": "beginner",
+    "sunlight": "partialSun",
+    "watering": "biweekly",
+    "space": "small",
+    "description": "Small indoor succulent with striped rosettes for bright windowsills",
+    "careInstructions": [
+      "Grow in bright indirect light",
+      "Use cactus mix and a pot with drainage",
+      "Water only after soil dries fully",
+      "Keep out of hot direct afternoon sun"
+    ],
+    "companionPlants": ["Aloe Vera", "Echeveria", "Jade Plant"]
+  },
+  {
+    "name": "Dwarf Lemon Tree",
+    "scientificName": "Citrus limon",
+    "type": "tree",
+    "difficulty": "intermediate",
+    "sunlight": "fullSun",
+    "watering": "weekly",
+    "space": "large",
+    "description": "Container-friendly citrus tree with fragrant flowers and tart fruit",
+    "careInstructions": [
+      "Place in the sunniest location available",
+      "Water deeply when the top soil dries",
+      "Feed with citrus fertilizer during active growth",
+      "Bring indoors before frost in cold climates"
+    ],
+    "companionPlants": ["Rosemary", "Lavender", "Marigold"]
+  },
+  {
+    "name": "Serviceberry",
+    "scientificName": "Amelanchier alnifolia",
+    "type": "tree",
+    "difficulty": "intermediate",
+    "sunlight": "fullSun",
+    "watering": "weekly",
+    "space": "large",
+    "description": "Small edible landscape tree with spring flowers and berry-like fruit",
+    "careInstructions": [
+      "Plant in full sun to part shade",
+      "Water regularly during establishment",
+      "Mulch around the root zone",
+      "Prune lightly after flowering if needed"
+    ],
+    "companionPlants": ["Blueberry", "Coneflower", "Hydrangea"]
+  },
+  {
+    "name": "Lavender",
+    "scientificName": "Lavandula angustifolia",
+    "type": "shrub",
+    "difficulty": "intermediate",
+    "sunlight": "fullSun",
+    "watering": "biweekly",
+    "space": "medium",
+    "description": "Aromatic flowering shrub for dry sunny borders and pollinator gardens",
+    "careInstructions": [
+      "Plant in sharply drained soil",
+      "Avoid overwatering and heavy mulch",
+      "Prune lightly after flowering",
+      "Harvest stems as flowers begin opening"
+    ],
+    "companionPlants": ["Rosemary", "Thyme", "Coneflower"]
+  },
+  {
+    "name": "Boxwood",
+    "scientificName": "Buxus sempervirens",
+    "type": "shrub",
+    "difficulty": "beginner",
+    "sunlight": "partialSun",
+    "watering": "weekly",
+    "space": "medium",
+    "description": "Evergreen shrub for containers, edging, and structured garden shapes",
+    "careInstructions": [
+      "Plant in well-drained soil with morning sun",
+      "Water deeply during establishment",
+      "Prune lightly to maintain shape",
+      "Avoid piling mulch against the stems"
+    ],
+    "companionPlants": ["Hydrangea", "Lavender", "Hosta"]
   }
 ]

--- a/GrowWisePackage/Tests/GrowWiseFeatureTests/GardenClubFeedRoutingTests.swift
+++ b/GrowWisePackage/Tests/GrowWiseFeatureTests/GardenClubFeedRoutingTests.swift
@@ -50,4 +50,20 @@ struct GardenClubFeedRoutingTests {
 
         #expect(viewData.photoURL == "file:///tmp/tomato.jpg")
     }
+
+    @Test("ClubActivity view data carries garden context")
+    func clubActivityViewDataCarriesGardenContext() {
+        let activity = ClubActivity(
+            clubID: UUID(),
+            memberName: "Avery",
+            memberID: "user-1",
+            activityType: "shared",
+            description: "First tomato flower"
+        )
+        activity.gardenName = "Backyard Garden"
+
+        let viewData = GardenClubFeedView.viewData(from: activity)
+
+        #expect(viewData.zoneTag == "Backyard Garden")
+    }
 }

--- a/GrowWisePackage/Tests/GrowWiseFeatureTests/OnboardingGardenSetupTests.swift
+++ b/GrowWisePackage/Tests/GrowWiseFeatureTests/OnboardingGardenSetupTests.swift
@@ -12,12 +12,38 @@ struct OnboardingGardenSetupTests {
         #expect(profile.firstGardenName == "My First Garden")
     }
 
+    @Test("user profile defaults to creating a starter container")
+    func userProfileDefaultsToCreatingStarterContainer() {
+        let profile = UserProfile()
+
+        #expect(profile.shouldCreateFirstContainer)
+        #expect(profile.firstContainerName == "Starter Container")
+        #expect(profile.firstContainerType == .pot)
+    }
+
     @Test("completion summary describes skipped first garden")
     func completionSummaryDescribesSkippedGarden() {
         var profile = UserProfile()
         profile.shouldCreateFirstGarden = false
 
         #expect(CompletionView.gardenSummary(for: profile) == "Skipped")
+    }
+
+    @Test("completion summary describes selected starter container")
+    func completionSummaryDescribesSelectedStarterContainer() {
+        var profile = UserProfile()
+        profile.firstContainerName = "Herb Pot"
+        profile.firstContainerType = .windowBox
+
+        #expect(CompletionView.containerSummary(for: profile) == "Herb Pot")
+    }
+
+    @Test("completion summary describes skipped starter container")
+    func completionSummaryDescribesSkippedStarterContainer() {
+        var profile = UserProfile()
+        profile.shouldCreateFirstContainer = false
+
+        #expect(CompletionView.containerSummary(for: profile) == "Skipped")
     }
 
     @Test("completion summary describes selected first plant")

--- a/GrowWisePackage/Tests/GrowWiseFeatureTests/PaywallPresentationTests.swift
+++ b/GrowWisePackage/Tests/GrowWiseFeatureTests/PaywallPresentationTests.swift
@@ -4,6 +4,7 @@ import Testing
 @Suite("Paywall presentation")
 struct PaywallPresentationTests {
     @Test("1.0 paywall comparison does not advertise Pro")
+    @MainActor
     func onePointZeroPaywallComparisonDoesNotAdvertisePro() {
         #expect(PaywallView.freePlanName == "Free")
         #expect(PaywallView.premiumPlanName == "Premium")
@@ -11,5 +12,14 @@ struct PaywallPresentationTests {
         #expect(!PaywallView.premiumPlanName.localizedCaseInsensitiveContains("pro"))
         #expect(!PaywallView.comparisonRows.contains { $0.feature == "Expert Consults" })
         #expect(PaywallView.comparisonRows.contains { $0.feature == "Garden Clubs" })
+    }
+
+    @Test("1.0 paywall prices match Premium launch pricing")
+    @MainActor
+    func onePointZeroPaywallPricesMatchLaunchPricing() {
+        #expect(PaywallView.premiumMonthlyPriceText == "$2.99")
+        #expect(PaywallView.premiumAnnualPriceText == "$34.99")
+        #expect(PaywallView.premiumMonthlyPurchaseLabel == "Subscribe to Premium — $2.99/mo")
+        #expect(PaywallView.premiumAnnualPurchaseLabel == "Subscribe to Premium — $34.99/yr")
     }
 }

--- a/GrowWisePackage/Tests/GrowWiseFeatureTests/PerenualExperienceIntegrationTests.swift
+++ b/GrowWisePackage/Tests/GrowWiseFeatureTests/PerenualExperienceIntegrationTests.swift
@@ -1,0 +1,43 @@
+import Foundation
+import Testing
+
+@Suite("Perenual experience integration")
+struct PerenualExperienceIntegrationTests {
+    @Test("Plant detail renders the reusable Perenual encyclopedia card")
+    func plantDetailIncludesPerenualEncyclopediaCard() throws {
+        let source = try readFeatureSource("Views/MyGardenPlantDetailView.swift")
+
+        #expect(
+            source.contains("PerenualEnrichmentCard(plant: plant)"),
+            "Plant detail should show the reusable Perenual encyclopedia card for saved plants."
+        )
+    }
+
+    @Test("Perenual thumbnail awaits async enrichment instead of only checking the cold cache")
+    func thumbnailAwaitsAsyncEnrichment() throws {
+        let source = try readFeatureSource("Components/PerenualEnrichmentCard.swift")
+
+        #expect(
+            source.contains(".task(id: plant.scientificName) {\n            await loadEnrichment()"),
+            "Thumbnail should await enrichment work when it appears."
+        )
+        #expect(
+            source.contains("private func loadEnrichment() async"),
+            "Thumbnail should use an async loader so cold-cache fetches can update the image."
+        )
+        #expect(
+            source.contains("await enrichment.loadEnrichment(for: plant)"),
+            "Thumbnail should use the service async load API instead of a one-shot cache read."
+        )
+    }
+
+    private func readFeatureSource(_ relativePath: String) throws -> String {
+        let packageRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+
+        let sourceURL = packageRoot.appendingPathComponent("Sources/GrowWiseFeature/\(relativePath)")
+        return try String(contentsOf: sourceURL, encoding: .utf8)
+    }
+}

--- a/GrowWisePackage/Tests/GrowWiseFeatureTests/PlantScannerPresentationTests.swift
+++ b/GrowWisePackage/Tests/GrowWiseFeatureTests/PlantScannerPresentationTests.swift
@@ -1,0 +1,45 @@
+import Foundation
+import Testing
+
+@Suite("Plant scanner presentation")
+struct PlantScannerPresentationTests {
+    @Test("scanner routes photos through tier-aware Plant Health checks")
+    func scannerUsesTierAwareDiagnosticPath() throws {
+        let source = try readFeatureSource("Views/PlantScannerView.swift")
+
+        #expect(
+            source.contains("@Environment(DataService.self)"),
+            "PlantScannerView should read the current user through the injected DataService."
+        )
+        #expect(
+            source.contains("dataService.getCurrentUser()"),
+            "PlantScannerView should use the persisted user context for health-check limits."
+        )
+        #expect(
+            source.contains("diagnose(image: image, currentUser:"),
+            "Photo checks should use the tier-aware diagnostic overload."
+        )
+        #expect(
+            !source.contains("await diagnosticService.diagnose(image: image)\n"),
+            "The release scanner should not call the legacy unmetered diagnostic path."
+        )
+    }
+
+    @Test("scanner does not expose sample guidance controls in release UI")
+    func scannerHidesSampleGuidanceControl() throws {
+        let source = try readFeatureSource("Views/PlantScannerView.swift")
+
+        #expect(!source.contains("Show Sample Guidance"))
+        #expect(!source.contains("scannerRunSampleButton"))
+    }
+
+    private func readFeatureSource(_ relativePath: String) throws -> String {
+        let packageRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+
+        let sourceURL = packageRoot.appendingPathComponent("Sources/GrowWiseFeature/\(relativePath)")
+        return try String(contentsOf: sourceURL, encoding: .utf8)
+    }
+}

--- a/GrowWisePackage/Tests/GrowWiseModelsTests/UserTests.swift
+++ b/GrowWisePackage/Tests/GrowWiseModelsTests/UserTests.swift
@@ -1,20 +1,19 @@
-import Testing
 import Foundation
 @testable import GrowWiseModels
+import Testing
 
 @Suite("User Model Tests")
 struct UserTests {
-    
     @Test("User initialization with valid data")
-    func testUserInitialization() async throws {
+    func userInitialization() {
         // Arrange
         let email = "test@example.com"
         let displayName = "Test User"
         let skillLevel = GardeningSkillLevel.beginner
-        
+
         // Act
         let user = User(email: email, displayName: displayName, skillLevel: skillLevel)
-        
+
         // Assert
         #expect(user.email == email)
         #expect(user.displayName == displayName)
@@ -28,60 +27,60 @@ struct UserTests {
         #expect(user.journalEntries?.isEmpty ?? true)
         #expect(user.completedTutorials.isEmpty)
     }
-    
+
     @Test("User skill level display names")
-    func testSkillLevelDisplayNames() async throws {
+    func skillLevelDisplayNames() {
         #expect(GardeningSkillLevel.beginner.displayName == "Beginner")
         #expect(GardeningSkillLevel.intermediate.displayName == "Intermediate")
         #expect(GardeningSkillLevel.advanced.displayName == "Advanced")
         #expect(GardeningSkillLevel.expert.displayName == "Expert")
     }
-    
+
     @Test("User skill level descriptions")
-    func testSkillLevelDescriptions() async throws {
+    func skillLevelDescriptions() {
         #expect(GardeningSkillLevel.beginner.description == "Just starting out")
         #expect(GardeningSkillLevel.intermediate.description == "Some gardening experience")
         #expect(GardeningSkillLevel.advanced.description == "Experienced gardener")
         #expect(GardeningSkillLevel.expert.description == "Master gardener")
     }
-    
+
     @Test("Gardening goals display names")
-    func testGardeningGoalsDisplayNames() async throws {
+    func gardeningGoalsDisplayNames() {
         #expect(GardeningGoal.growFood.displayName == "Grow My Own Food")
         #expect(GardeningGoal.beautifySpace.displayName == "Beautify My Space")
         #expect(GardeningGoal.learnSkills.displayName == "Learn New Skills")
         #expect(GardeningGoal.relaxation.displayName == "Relaxation & Therapy")
         #expect(GardeningGoal.sustainability.displayName == "Environmental Sustainability")
     }
-    
+
     @Test("Time commitment values")
-    func testTimeCommitmentValues() async throws {
+    func timeCommitmentValues() {
         #expect(TimeCommitment.minimal.minutesPerWeek == 15)
         #expect(TimeCommitment.light.minutesPerWeek == 45)
         #expect(TimeCommitment.moderate.minutesPerWeek == 120)
         #expect(TimeCommitment.heavy.minutesPerWeek == 270)
         #expect(TimeCommitment.intensive.minutesPerWeek == 420)
     }
-    
+
     @Test("Subscription tier pricing")
-    func testSubscriptionTierPricing() async throws {
+    func subscriptionTierPricing() {
         #expect(SubscriptionTier.free.monthlyPrice == 0.0)
-        #expect(SubscriptionTier.premium.monthlyPrice == 4.99)
+        #expect(SubscriptionTier.premium.monthlyPrice == 2.99)
         #expect(SubscriptionTier.pro.monthlyPrice == 9.99)
     }
-    
+
     @Test("AI diagnoses limits per subscription tier")
-    func testAIDiagnosesLimits() async throws {
+    func aIDiagnosesLimits() {
         #expect(SubscriptionTier.free.aiDiagnosesPerMonth == 3)
         #expect(SubscriptionTier.premium.aiDiagnosesPerMonth == -1) // Unlimited
         #expect(SubscriptionTier.pro.aiDiagnosesPerMonth == -1) // Unlimited
     }
-    
+
     @Test("Reminder settings default values")
-    func testReminderSettingsDefaults() async throws {
+    func reminderSettingsDefaults() {
         // Arrange & Act
         let settings = ReminderSettings()
-        
+
         // Assert
         #expect(settings.enableWateringReminders == true)
         #expect(settings.enableFertilizingReminders == true)
@@ -95,18 +94,18 @@ struct UserTests {
         #expect(settings.quietHoursStart == nil)
         #expect(settings.quietHoursEnd == nil)
     }
-    
+
     @Test("Measurement system display names")
-    func testMeasurementSystemDisplayNames() async throws {
+    func measurementSystemDisplayNames() {
         #expect(MeasurementSystem.imperial.displayName == "Imperial (inches, feet, °F)")
         #expect(MeasurementSystem.metric.displayName == "Metric (cm, meters, °C)")
     }
-    
+
     @Test("User initialization with all skill levels")
-    func testUserInitializationWithAllSkillLevels() async throws {
+    func userInitializationWithAllSkillLevels() {
         let email = "test@example.com"
         let displayName = "Test User"
-        
+
         for skillLevel in GardeningSkillLevel.allCases {
             let user = User(email: email, displayName: displayName, skillLevel: skillLevel)
             #expect(user.skillLevel == skillLevel)
@@ -114,15 +113,15 @@ struct UserTests {
             #expect(user.displayName == displayName)
         }
     }
-    
+
     @Test("User timestamps are set correctly")
-    func testUserTimestamps() async throws {
+    func userTimestamps() {
         // Arrange
         let beforeCreation = Date()
-        
+
         // Act
         let user = User(email: "test@example.com", displayName: "Test User")
-        
+
         // Assert
         let afterCreation = Date()
         #expect(user.createdDate >= beforeCreation)

--- a/GrowWisePackage/Tests/GrowWiseServicesTests/ClubCloudKitServiceTests.swift
+++ b/GrowWisePackage/Tests/GrowWiseServicesTests/ClubCloudKitServiceTests.swift
@@ -1,0 +1,43 @@
+import Foundation
+@testable import GrowWiseModels
+@testable import GrowWiseServices
+import Testing
+
+@Suite("ClubCloudKitService")
+@MainActor
+struct ClubCloudKitServiceTests {
+    @Test("activity cloud fields include garden context and photo URL")
+    func activityCloudFieldsIncludeGardenContext() throws {
+        let clubID = UUID()
+        let activity = ClubActivity(
+            clubID: clubID,
+            memberName: "Blake",
+            memberID: "member-1",
+            activityType: "shared",
+            description: "Basil: First harvest"
+        )
+        activity.id = UUID(uuidString: "11111111-1111-1111-1111-111111111111")
+        activity.gardenName = "Backyard Garden"
+        activity.photoURL = "file:///tmp/club-photo.jpg"
+
+        let fields = try ClubCloudKitService.recordFields(from: activity)
+
+        #expect(fields.recordName == "11111111-1111-1111-1111-111111111111")
+        #expect(fields.clubID == clubID.uuidString)
+        #expect(fields.memberName == "Blake")
+        #expect(fields.memberID == "member-1")
+        #expect(fields.activityType == "shared")
+        #expect(fields.activityDescription == "Basil: First harvest")
+        #expect(fields.gardenName == "Backyard Garden")
+        #expect(fields.photoURL == "file:///tmp/club-photo.jpg")
+    }
+
+    @Test("database scope routes owners to private and invited members to shared")
+    func databaseScopeForOwnerAndMember() {
+        let club = GardenClub(name: "Backyard Growers", ownerID: "owner-1", inviteCode: "ABC123")
+
+        #expect(ClubCloudKitService.databaseScope(for: club, memberID: "owner-1") == .ownerPrivate)
+        #expect(ClubCloudKitService.databaseScope(for: club, memberID: "member-2") == .sharedParticipant)
+        #expect(ClubCloudKitService.databaseScope(for: nil, memberID: "member-2") == .ownerPrivate)
+    }
+}

--- a/GrowWisePackage/Tests/GrowWiseServicesTests/DataServiceGardenClubTests.swift
+++ b/GrowWisePackage/Tests/GrowWiseServicesTests/DataServiceGardenClubTests.swift
@@ -39,6 +39,24 @@ struct DataServiceGardenClubTests {
         #expect(activity.activityDescription == "Basil: Looking healthy!")
     }
 
+    @Test("createClubPost persists selected garden context")
+    func createClubPostWithGardenName() async throws {
+        let service = try await DataService.makeForTesting()
+        let club = try service.createClub(name: "Backyard Growers", ownerID: "u1")
+
+        let activity = try service.createClubPost(
+            caption: "First basil harvest",
+            activityType: "shared",
+            plantName: "Basil",
+            gardenName: "Backyard Garden",
+            club: club
+        )
+
+        #expect(activity.activityDescription == "Basil: First basil harvest")
+        #expect(activity.gardenName == "Backyard Garden")
+        #expect(activity.clubID == club.id)
+    }
+
     @Test("createClubPost can target an explicit club and persist a photo URL")
     func createClubPostWithExplicitClubAndPhotoURL() async throws {
         let service = try await DataService.makeForTesting()

--- a/GrowWisePackage/Tests/GrowWiseServicesTests/DataServiceOnboardingGardenTests.swift
+++ b/GrowWisePackage/Tests/GrowWiseServicesTests/DataServiceOnboardingGardenTests.swift
@@ -27,4 +27,26 @@ struct DataServiceOnboardingGardenTests {
         #expect(garden.spaceAvailable == .tiny)
         #expect(garden.user?.id == user.id)
     }
+
+    @Test("createGardenBed persists a container in the selected garden")
+    func createGardenBedPersistsContainerInGarden() throws {
+        let dataService = try DataService.makeForTesting()
+        let garden = try dataService.createGarden(
+            name: "Patio Starter",
+            type: .container,
+            isIndoor: false
+        )
+
+        let bed = try dataService.createGardenBed(
+            name: "Herb Pot",
+            bedType: .pot,
+            in: garden
+        )
+
+        let gardenBeds = garden.beds ?? []
+        #expect(bed.name == "Herb Pot")
+        #expect(bed.bedType == .pot)
+        #expect(bed.garden?.id == garden.id)
+        #expect(gardenBeds.contains { $0.id == bed.id })
+    }
 }

--- a/GrowWisePackage/Tests/GrowWiseServicesTests/DataServicePlantTemplateTests.swift
+++ b/GrowWisePackage/Tests/GrowWiseServicesTests/DataServicePlantTemplateTests.swift
@@ -49,6 +49,26 @@ struct DataServicePlantTemplateTests {
         #expect(result.reminder.plant?.id == result.plant.id)
     }
 
+    @Test("createStarterPlant assigns the plant to the selected container")
+    func createStarterPlantAssignsSelectedContainer() throws {
+        let dataService = try DataService.makeForTesting()
+        let garden = try dataService.createGarden(name: "Kitchen Garden", type: .container, isIndoor: false)
+        let bed = try dataService.createGardenBed(name: "Herb Pot", bedType: .pot, in: garden)
+        let template = try createTemplate(dataService: dataService)
+
+        let result = try dataService.createStarterPlant(
+            from: template,
+            in: garden,
+            gardenBed: bed,
+            plantingDate: Date(timeIntervalSince1970: 1_800_000_000)
+        )
+
+        let bedPlants = bed.plants ?? []
+        #expect(result.plant.garden?.id == garden.id)
+        #expect(result.plant.bed?.id == bed.id)
+        #expect(bedPlants.contains { $0.id == result.plant.id })
+    }
+
     private func createTemplate(dataService: DataService) throws -> Plant {
         try dataService.insertDatabasePlant(
             name: "Basil",

--- a/GrowWisePackage/Tests/GrowWiseServicesTests/PerenualAPIServiceContractTests.swift
+++ b/GrowWisePackage/Tests/GrowWiseServicesTests/PerenualAPIServiceContractTests.swift
@@ -662,6 +662,33 @@ struct PerenualNetworkContractTests {
     }
 }
 
+@MainActor
+@Suite(.serialized)
+struct PerenualEnrichmentServiceTests {
+    @Test("loadEnrichment fetches by scientific name and makes the detail synchronously available")
+    func loadEnrichmentFetchesAndCachesDetail() async {
+        PerenualAPIService.testAPIKey = "test-key-12345"
+        defer { PerenualAPIService.testAPIKey = nil }
+
+        MockURLProtocol.requestHandler = { request in
+            if request.url?.path.contains("species/details/1") == true {
+                return (httpResponse(url: "https://perenual.com/api/v2/species/details/1"), Data(speciesDetailJSON.utf8))
+            }
+            return (httpResponse(), Data(speciesListJSON.utf8))
+        }
+
+        let api = PerenualAPIService(session: makeStubSession())
+        let enrichment = PerenualEnrichmentService(api: api)
+        let plant = Plant(name: "European Silver Fir", plantType: .tree)
+        plant.scientificName = "Abies alba"
+
+        let detail = await enrichment.loadEnrichment(for: plant)
+
+        #expect(detail?.commonName == "European Silver Fir")
+        #expect(enrichment.enrichment(for: plant)?.id == 1)
+    }
+}
+
 // MARK: - PerenualError Tests
 
 @MainActor

--- a/GrowWisePackage/Tests/GrowWiseServicesTests/PerenualAPIServiceContractTests.swift
+++ b/GrowWisePackage/Tests/GrowWiseServicesTests/PerenualAPIServiceContractTests.swift
@@ -658,7 +658,7 @@ struct PerenualNetworkContractTests {
         // Temporarily remove API key — this is tricky since it's in Keychain.
         // We test the error type exists and has a description instead.
         let error = PerenualError.noAPIKey
-        #expect(error.errorDescription?.contains("API key") == true)
+        #expect(error.errorDescription == "Online plant database is not configured for this build.")
     }
 }
 

--- a/GrowWisePackage/Tests/GrowWiseServicesTests/PhotoServiceTests.swift
+++ b/GrowWisePackage/Tests/GrowWiseServicesTests/PhotoServiceTests.swift
@@ -1063,7 +1063,8 @@ struct PhotoServiceCleanupTests {
         // Drop an orphaned file into the plant's photo directory (no metadata entry)
         let plantDir = (photo.filePath as NSString).deletingLastPathComponent
         let orphanedFile = URL(fileURLWithPath: plantDir).appendingPathComponent("orphan_\(UUID().uuidString).jpg")
-        try try #require("fake image data".data(using: .utf8)?.write(to: orphanedFile))
+        let fakeImageData = try #require("fake image data".data(using: .utf8))
+        try fakeImageData.write(to: orphanedFile)
         #expect(FileManager.default.fileExists(atPath: orphanedFile.path))
 
         // Run cleanup

--- a/GrowWisePackage/Tests/GrowWiseServicesTests/PlantDatabaseOnboardingPersonalizationTests.swift
+++ b/GrowWisePackage/Tests/GrowWiseServicesTests/PlantDatabaseOnboardingPersonalizationTests.swift
@@ -26,6 +26,21 @@ struct PlantDatabaseOnboardingPersonalizationTests {
         #expect(recommendations.first?.reasons.contains("Matches your Grow My Own Food goal") == true)
     }
 
+    @Test("seeded beginner plants include onboarding curated starters")
+    func seededBeginnerPlantsIncludeOnboardingCuratedStarters() async throws {
+        let dataService = try DataService.makeForTesting()
+        let plantDBService = PlantDatabaseService(dataService: dataService)
+
+        let plants = try await plantDBService.getSeededBeginnerFriendlyPlants()
+        let names = Set(plants.compactMap(\.name))
+
+        #expect(names.contains("Basil"))
+        #expect(names.contains("Mint"))
+        #expect(names.contains("Lettuce"))
+        #expect(names.contains("Snake Plant"))
+        #expect(names.contains("Pothos"))
+    }
+
     private func seedRecommendationFixtures(dataService: DataService) throws {
         try dataService.insertDatabasePlant(
             name: "Marigold",

--- a/GrowWisePackage/Tests/GrowWiseServicesTests/PlantDatabaseServiceTests.swift
+++ b/GrowWisePackage/Tests/GrowWiseServicesTests/PlantDatabaseServiceTests.swift
@@ -148,9 +148,20 @@ struct PlantDatabaseServiceTests {
         let plantDBService = PlantDatabaseService(dataService: dataService)
         try await plantDBService.seedPlantDatabase()
         // Use the cache-free count API to verify all plants were persisted
-        // Expanded database: 50+ plants across vegetables, herbs, flowers, houseplants, fruits, succulents, trees, shrubs
-        #expect(dataService.getPlantDatabaseCount() >= 50)
+        // 1.0 offline baseline: 80+ plants across vegetables, herbs, flowers, houseplants, fruits, succulents, trees, shrubs
+        #expect(dataService.getPlantDatabaseCount() >= 80)
         _ = plantDBService
+    }
+
+    @Test("Seeded database includes practical tree and shrub coverage")
+    func databaseIncludesPracticalTreeAndShrubCoverage() async throws {
+        let dataService = try DataService.makeForTesting()
+        let plantDBService = PlantDatabaseService(dataService: dataService)
+        try await seedAndFlush(dataService: dataService, plantDBService: plantDBService)
+        let counts = plantDBService.getPlantCountByType()
+
+        #expect((counts[.tree] ?? 0) >= 3)
+        #expect((counts[.shrub] ?? 0) >= 3)
     }
 
     // MARK: - Idempotency

--- a/GrowWisePackage/Tests/GrowWiseServicesTests/PlantDatabaseServiceTests.swift
+++ b/GrowWisePackage/Tests/GrowWiseServicesTests/PlantDatabaseServiceTests.swift
@@ -217,6 +217,36 @@ struct PlantDatabaseServiceTests {
         #expect(!uppercase.isEmpty)
     }
 
+    @Test("unified search results prefer local plants and deduplicate Perenual summaries")
+    func unifiedSearchResultsPreferLocalPlantsAndDeduplicateOnlineSummaries() {
+        let localBasil = Plant(name: "Basil", plantType: .herb, difficultyLevel: .beginner)
+        localBasil.scientificName = "Ocimum basilicum"
+        let duplicateBasil = PerenualSpeciesSummary(
+            id: 10,
+            commonName: "Basil",
+            scientificName: ["Ocimum basilicum"],
+            otherName: nil,
+            family: nil,
+            genus: "Ocimum",
+            defaultImage: nil
+        )
+        let onlineRose = PerenualSpeciesSummary(
+            id: 11,
+            commonName: "Rose",
+            scientificName: ["Rosa"],
+            otherName: nil,
+            family: nil,
+            genus: "Rosa",
+            defaultImage: nil
+        )
+
+        let results = PlantSearchResult.combine(local: [localBasil], perenual: [duplicateBasil, onlineRose])
+
+        #expect(results.map(\.displayName) == ["Basil", "Rose"])
+        #expect(results.first?.source == .local)
+        #expect(results.last?.source == .perenual)
+    }
+
     // MARK: - Filter
 
     @Test("filterPlants by type returns only plants of that type")

--- a/GrowWisePackage/Tests/GrowWiseServicesTests/PlantDiagnosticServiceTests.swift
+++ b/GrowWisePackage/Tests/GrowWiseServicesTests/PlantDiagnosticServiceTests.swift
@@ -1,6 +1,12 @@
 @testable import GrowWiseModels
 @testable import GrowWiseServices
 import Testing
+#if canImport(UIKit)
+import UIKit
+#endif
+#if canImport(AppKit)
+import AppKit
+#endif
 
 @MainActor
 struct PlantDiagnosticServiceTests {
@@ -239,6 +245,23 @@ struct PlantDiagnosticServiceTests {
         let service = PlantDiagnosticService()
         #expect(service.canDiagnose(user: user) == false)
         #expect(service.remainingDiagnoses(user: user) == 0)
+    }
+
+    @Test("Missing current user reports setup required before image analysis")
+    func diagnoseWithMissingCurrentUserRequiresSetup() async {
+        let service = PlantDiagnosticService()
+        #if canImport(UIKit)
+        let image = UIGraphicsImageRenderer(size: CGSize(width: 1, height: 1)).image { _ in }
+        #elseif canImport(AppKit)
+        let image = PlatformImage(size: CGSize(width: 1, height: 1))
+        #endif
+
+        await service.diagnose(image: image, currentUser: nil)
+
+        #expect(service.lastDiagnosis == nil)
+        #expect(service.isAnalyzing == false)
+        #expect(service.lastError?.localizedCaseInsensitiveContains("finish setup") == true)
+        #expect(service.lastError?.localizedCaseInsensitiveContains("plant health check") == true)
     }
 
     @Test("Free tier user exceeding limit is clamped to 0 remaining")

--- a/GrowWisePackage/Tests/GrowWiseServicesTests/SeedScannerServiceTests.swift
+++ b/GrowWisePackage/Tests/GrowWiseServicesTests/SeedScannerServiceTests.swift
@@ -5,10 +5,6 @@ import Foundation
 import Testing
 import UIKit
 
-extension Tag {
-    @Tag static var integration: Tag
-}
-
 @MainActor
 struct SeedScannerServiceTests {
     let scanner = SeedScannerService()

--- a/GrowWiseUITests/GardenClubUITests.swift
+++ b/GrowWiseUITests/GardenClubUITests.swift
@@ -31,6 +31,134 @@ final class GardenClubUITests: XCTestCase {
         )
     }
 
+    private func navigateToGardenTab(file: StaticString = #file, line: UInt = #line) {
+        let gardenTab = app.tabBars.buttons["Garden"]
+        XCTAssertTrue(gardenTab.waitForExistence(timeout: 5.0), "Garden tab not found", file: file, line: line)
+        gardenTab.tap()
+
+        let gardenLoadedMarker = app.descendants(matching: .any).matching(
+            NSPredicate(
+                format: """
+                identifier == 'garden_button_create_first' OR \
+                identifier == 'garden_button_add_plant' OR \
+                identifier == 'garden_button_add_bed'
+                """
+            )
+        ).firstMatch
+        XCTAssertTrue(
+            gardenLoadedMarker.waitForExistence(timeout: 5.0),
+            "Garden tab did not load",
+            file: file,
+            line: line
+        )
+    }
+
+    private func createGardenIfNeeded(file: StaticString = #file, line: UInt = #line) {
+        let createFirstButton = app.buttons.matching(identifier: "garden_button_create_first").firstMatch
+        guard createFirstButton.waitForExistence(timeout: 1.0) else { return }
+
+        createFirstButton.tap()
+
+        let nameField = app.textFields.matching(identifier: "creategarden_textfield_name").firstMatch
+        XCTAssertTrue(nameField.waitForExistence(timeout: 5.0), "Create garden name field not found", file: file, line: line)
+        nameField.tap()
+        nameField.typeText("UI Test Garden")
+
+        let saveButton = app.buttons.matching(identifier: "creategarden_button_save").firstMatch
+        XCTAssertTrue(saveButton.waitForExistence(timeout: 3.0), "Create garden save button not found", file: file, line: line)
+        saveButton.tap()
+
+        let doneButton = app.buttons.matching(identifier: "recommended_button_done").firstMatch
+        XCTAssertTrue(doneButton.waitForExistence(timeout: 8.0), "Suggested plants done button not found", file: file, line: line)
+        doneButton.tap()
+
+        XCTAssertTrue(
+            app.buttons.matching(identifier: "garden_button_add_plant").firstMatch.waitForExistence(timeout: 8.0),
+            "Add plant button did not appear after creating a garden",
+            file: file,
+            line: line
+        )
+    }
+
+    private func plantRow(named name: String) -> XCUIElement {
+        app.descendants(matching: .any).matching(
+            NSPredicate(
+                format: "identifier BEGINSWITH 'garden_row_plant_' AND label CONTAINS %@",
+                name
+            )
+        ).firstMatch
+    }
+
+    private func createClubFromTopLevelClubTab(file: StaticString = #file, line: UInt = #line) {
+        let createPromptButton = app.buttons["Create a club"]
+        XCTAssertTrue(createPromptButton.waitForExistence(timeout: 3.0), file: file, line: line)
+        createPromptButton.tap()
+
+        let nameField = app.textFields.matching(identifier: "create_club_name_field").firstMatch
+        XCTAssertTrue(nameField.waitForExistence(timeout: 3.0), file: file, line: line)
+        nameField.tap()
+        nameField.typeText("Test Garden Club")
+
+        let createButton = app.buttons.matching(identifier: "create_club_button").firstMatch
+        XCTAssertTrue(createButton.waitForExistence(timeout: 3.0), file: file, line: line)
+        createButton.tap()
+
+        XCTAssertTrue(app.staticTexts["Club Created!"].waitForExistence(timeout: 5.0), file: file, line: line)
+        let doneButton = app.buttons.matching(identifier: "create_club_done_button").firstMatch
+        XCTAssertTrue(doneButton.waitForExistence(timeout: 3.0), file: file, line: line)
+        doneButton.tap()
+
+        XCTAssertTrue(element("club_share_prompt").waitForExistence(timeout: 5.0), file: file, line: line)
+    }
+
+    private func addTestPlant(name: String, file: StaticString = #file, line: UInt = #line) {
+        createGardenIfNeeded(file: file, line: line)
+
+        let addButton = app.buttons.matching(identifier: "garden_button_add_plant").firstMatch
+        XCTAssertTrue(addButton.waitForExistence(timeout: 5.0), "Add-plant button not found", file: file, line: line)
+        addButton.tap()
+
+        let nameField = app.textFields.matching(identifier: "addplant_textfield_name").firstMatch
+        XCTAssertTrue(nameField.waitForExistence(timeout: 5.0), "Plant name text field not found", file: file, line: line)
+        nameField.tap()
+        nameField.typeText(name)
+
+        XCTAssertTrue(
+            app.descendants(matching: .any).matching(identifier: "addplant_picker_garden").firstMatch
+                .waitForExistence(timeout: 5.0),
+            "Garden picker did not load before saving the plant",
+            file: file,
+            line: line
+        )
+
+        let saveButton = app.buttons.matching(identifier: "addplant_button_save").firstMatch
+        XCTAssertTrue(saveButton.waitForExistence(timeout: 3.0), "Save button not found in AddPlantSheet", file: file, line: line)
+        saveButton.tap()
+
+        let skipWateringButton = app.buttons.matching(identifier: "watering_button_skip").firstMatch
+        XCTAssertTrue(
+            skipWateringButton.waitForExistence(timeout: 8.0),
+            "Watering schedule confirmation did not appear",
+            file: file,
+            line: line
+        )
+        skipWateringButton.tap()
+
+        XCTAssertTrue(
+            element("addPlantSheet").waitForNonExistence(timeout: 5.0),
+            "AddPlantSheet did not dismiss after skipping watering setup",
+            file: file,
+            line: line
+        )
+
+        XCTAssertTrue(
+            plantRow(named: name).waitForExistence(timeout: 10.0),
+            "Plant did not appear after save",
+            file: file,
+            line: line
+        )
+    }
+
     func testClubTabEmptyStateUsesTopLevelClubNavigation() {
         navigateToClubTab()
 
@@ -57,6 +185,53 @@ final class GardenClubUITests: XCTestCase {
 
         XCTAssertTrue(app.staticTexts["Club Created!"].waitForExistence(timeout: 5.0))
         XCTAssertTrue(element("create_club_invite_code").waitForExistence(timeout: 3.0))
+    }
+
+    func testShareComposerFromClubTabPublishesLocalPost() {
+        navigateToClubTab()
+        createClubFromTopLevelClubTab()
+
+        element("club_share_prompt").tap()
+        let captionField = element("share_composer_textfield_caption")
+        XCTAssertTrue(captionField.waitForExistence(timeout: 5.0))
+        captionField.tap()
+        captionField.typeText("First tomato flower from UI")
+
+        let postButton = app.buttons.matching(identifier: "share_composer_button_post").firstMatch
+        XCTAssertTrue(postButton.waitForExistence(timeout: 3.0))
+        XCTAssertTrue(postButton.isEnabled)
+        postButton.tap()
+
+        let offlineAlert = app.alerts["Saved locally"].firstMatch
+        if offlineAlert.waitForExistence(timeout: 5.0) {
+            app.buttons.matching(identifier: "share_composer_alert_offline").firstMatch.tap()
+        }
+
+        XCTAssertTrue(app.staticTexts["First tomato flower from UI"].waitForExistence(timeout: 8.0))
+    }
+
+    func testShareToClubFromPlantDetailShowsPlantContext() {
+        navigateToClubTab()
+        createClubFromTopLevelClubTab()
+
+        navigateToGardenTab()
+        addTestPlant(name: "Club Basil")
+
+        let plantRow = plantRow(named: "Club Basil")
+        XCTAssertTrue(plantRow.waitForExistence(timeout: 5.0))
+        plantRow.tap()
+
+        let detailsButton = app.buttons.matching(identifier: "quickcard_button_viewdetails").firstMatch
+        XCTAssertTrue(detailsButton.waitForExistence(timeout: 5.0))
+        detailsButton.tap()
+
+        let shareButton = app.buttons.matching(identifier: "plantdetail_button_share_to_club").firstMatch
+        XCTAssertTrue(shareButton.waitForExistence(timeout: 5.0))
+        shareButton.tap()
+
+        XCTAssertTrue(element("screen_share_composer").waitForExistence(timeout: 5.0))
+        XCTAssertTrue(element("share_composer_chip_plant").waitForExistence(timeout: 3.0))
+        XCTAssertTrue(app.staticTexts["Club Basil"].waitForExistence(timeout: 3.0))
     }
 
     func testJoinClubFlowFromTopLevelClubTab() {

--- a/GrowWiseUITests/OnboardingFlowUITests.swift
+++ b/GrowWiseUITests/OnboardingFlowUITests.swift
@@ -43,7 +43,7 @@ final class OnboardingFlowUITests: XCTestCase {
         nextButton.tap()
     }
 
-    private func advanceToCompletion(skipGarden: Bool = false) {
+    private func advanceToCompletion(skipGarden: Bool = false, selectFirstPlant: Bool = false) {
         XCTAssertTrue(app.staticTexts["Cultivation"].waitForExistence(timeout: 5.0))
         tapNext()
 
@@ -71,23 +71,34 @@ final class OnboardingFlowUITests: XCTestCase {
         tapNext()
 
         XCTAssertTrue(element("onboarding_firstplant_title").waitForExistence(timeout: 5.0))
-        let firstPlantSkip = app.buttons.matching(identifier: "onboarding_firstplant_skip").firstMatch
-        XCTAssertTrue(firstPlantSkip.waitForExistence(timeout: 3.0))
-        firstPlantSkip.tap()
+        if selectFirstPlant {
+            let basilCard = element("onboarding_firstplant_card_basil")
+            XCTAssertTrue(basilCard.waitForExistence(timeout: 5.0), "Basil starter plant card not found")
+            basilCard.tap()
+        } else {
+            let firstPlantSkip = app.buttons.matching(identifier: "onboarding_firstplant_skip").firstMatch
+            XCTAssertTrue(firstPlantSkip.waitForExistence(timeout: 3.0))
+            firstPlantSkip.tap()
+        }
         tapNext()
     }
 
     // MARK: - Complete Onboarding Flow Tests
 
     func testCompleteOnboardingFlow() {
-        advanceToCompletion()
+        advanceToCompletion(selectFirstPlant: true)
 
         XCTAssertTrue(app.staticTexts["Your garden awaits!"].waitForExistence(timeout: 5.0))
         XCTAssertTrue(app.staticTexts["First Plant"].waitForExistence(timeout: 3.0))
+        XCTAssertTrue(app.staticTexts["Basil"].waitForExistence(timeout: 3.0))
         tapNext()
 
         let tabBar = app.tabBars.firstMatch
         XCTAssertTrue(tabBar.waitForExistence(timeout: 5.0))
+
+        app.tabBars.buttons["Garden"].tap()
+        XCTAssertTrue(app.staticTexts["Basil"].waitForExistence(timeout: 8.0))
+        XCTAssertTrue(app.staticTexts["Starter Container"].waitForExistence(timeout: 8.0))
     }
 
     func testOnboardingSkipGardenFlow() {

--- a/config/Shared.xcconfig
+++ b/config/Shared.xcconfig
@@ -26,6 +26,8 @@ TARGETED_DEVICE_FAMILY = 1,2
 GENERATE_INFOPLIST_FILE = YES
 INFOPLIST_KEY_UISupportedInterfaceOrientations = portrait landscape-left landscape-right
 INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = portrait landscape-left landscape-right portrait-upside-down
+PERENUAL_API_KEY =
+INFOPLIST_KEY_PERENUAL_API_KEY = $(PERENUAL_API_KEY)
 
 // ==========================================
 // Entitlements

--- a/docs/app-store/1.0-readiness-checklist.md
+++ b/docs/app-store/1.0-readiness-checklist.md
@@ -1,0 +1,75 @@
+# Cultivation 1.0 App Store Readiness Checklist
+
+## Launch Positioning
+
+Cultivation 1.0 should launch as the outdoor garden companion for people who grow together.
+
+Lead with:
+- Set up an outdoor garden.
+- Organize plants by bed, container, or area.
+- Follow timely care guidance.
+- Share progress with a private garden club.
+
+Do not lead with:
+- Plant-doctor positioning.
+- Largest-database positioning.
+- Model-first health claims.
+- Public social-network positioning.
+
+## Store Copy
+
+Use `docs/app-store/app-store-copy.md` as the 1.0 source of truth.
+
+Required copy checks:
+- Premium is listed as `$2.99/month` and `$34.99/year`.
+- Pro is explicitly not sold in 1.0.
+- Basic club participation is included in the free tier.
+- Plant Health copy describes guidance and common issue reference material.
+- Club copy uses private club language, not broad public community language.
+- Privacy copy says club activity is stored locally and synced with CloudKit where available.
+
+## Screenshot Storyboard
+
+Use `docs/app-store/screenshots-plan.md` as the capture plan.
+
+Required first-pass screenshots:
+- Home care dashboard.
+- Garden tab with plants organized by bed or area.
+- Add Plant flow with garden/location context.
+- Plant detail with care state and Share to Club entry point.
+- Club feed with real local posts.
+- Create/join club with invite code.
+- Plant Health Guidance, framed as common issue guidance.
+
+Screenshot copy guardrails:
+- Show the actual app screens and real flows.
+- Do not show placeholders or "coming soon" surfaces.
+- Do not describe health guidance as automated diagnosis.
+- Do not imply Pro can be bought in 1.0.
+
+## Subscription Checklist
+
+Before App Store submission:
+- App Store Connect product IDs match `SubscriptionService.purchasableProductIDs`.
+- Premium monthly product price is `$2.99`.
+- Premium annual product price is `$34.99`.
+- Pro products are not submitted as purchasable 1.0 products.
+- Paywall copy matches the store listing.
+- Subscription review notes mention that private club participation is not gated behind Pro.
+
+## Privacy Checklist
+
+Before App Store submission:
+- Privacy policy URL is live at the URL in `docs/app-store/app-store-copy.md`.
+- Support URL is live.
+- CloudKit data disclosure matches the implemented local/private/shared-zone behavior.
+- Photo library usage copy is limited to user-selected photos.
+- Health guidance copy does not claim professional, medical, or guaranteed plant disease diagnosis.
+
+## 1.1 Fast-Follow Notes
+
+Deferred from the 1.0 blocking scope:
+- More ambitious onboarding personalization.
+- Screenshot automation and demo-data launch argument.
+- Real model-backed plant diagnosis, if the product later wants model-first health positioning.
+- Pro tier launch, pricing, feature gates, and App Store products.

--- a/docs/app-store/app-store-copy.md
+++ b/docs/app-store/app-store-copy.md
@@ -19,9 +19,9 @@ Food & Drink
 
 ## Description (4000 chars max)
 
-**Plan. Track. Grow.**
+**Plan. Track. Grow together.**
 
-Cultivation is your gardening companion — helping you plan, plant, and nurture your garden with confidence. Whether you're growing tomatoes on a balcony or managing a full backyard vegetable patch, Cultivation guides you every step of the way.
+Cultivation is the outdoor garden companion for people who grow together. Set up your garden, organize plants by bed or area, keep care tasks on schedule, and share progress with a private garden club.
 
 ### Plant Care Made Simple
 - **Personalized Reminders**: Water, fertilize, prune, and harvest reminders tailored to each plant's needs and your local weather
@@ -44,9 +44,9 @@ Cultivation is your gardening companion — helping you plan, plant, and nurture
 - **Seed Inventory**: Track your seed packets with details and planting schedules
 
 ### Grow Together
-- **Garden Clubs**: Create or join a club to share what's growing with nearby gardeners
-- **Community Feed**: Share your garden with the community and get inspiration from others
-- **Q&A Forum**: Ask questions and help fellow gardeners
+- **Private Garden Clubs**: Create or join a club for the people you grow with
+- **Club Feed**: Share updates, photos, and plant context with your club
+- **Invite Codes**: Keep clubs private and easy to join
 
 ### Your Data, Your Privacy
 - All data stored locally on your device — no account required
@@ -66,8 +66,7 @@ Features:
 - Garden management with beds, companion planting, and health scores
 - Photo journal for tracking plant growth
 - Seasonal planner based on your hardiness zone
-- Garden Clubs — share what's growing with nearby gardeners
-- Community Q&A forum
+- Private Garden Clubs - share what's growing with people you trust
 - Plant Health guidance with common issues and treatments
 - Compost tracker and shopping list
 - iCloud sync across your devices
@@ -94,12 +93,13 @@ https://cultivation.app
 
 Cultivation offers auto-renewing subscriptions:
 
-- **Premium**: $4.99/month or $34.99/year
-- **Pro**: $9.99/month or $79.99/year
+- **Premium**: $2.99/month or $34.99/year
+
+Pro features are not sold in Cultivation 1.0.
 
 Payment will be charged to your Apple ID account at confirmation of purchase. Subscription automatically renews unless it is canceled at least 24 hours before the end of the current period. Your account will be charged for renewal within 24 hours prior to the end of the current period. You can manage and cancel your subscriptions by going to your account settings on the App Store after purchase.
 
-Free tier includes: basic reminders, 50-plant database, community access, 3 Plant Health checks per month.
+Free tier includes: basic reminders, the starter plant database, basic club participation, and limited Plant Health checks.
 
 ---
 
@@ -110,6 +110,6 @@ Cultivation uses CloudKit to sync your garden data across your Apple devices. Th
 - Garden and plant records (names, locations, care dates)
 - Care reminders and journal entries
 - User preferences and settings
-- Club activity you post (stored in the public CloudKit database)
+- Club activity you post (stored locally and synced with CloudKit where available)
 
 No data is shared with third parties. All CloudKit data is encrypted in transit and at rest by Apple.

--- a/docs/app-store/screenshots-plan.md
+++ b/docs/app-store/screenshots-plan.md
@@ -1,7 +1,7 @@
 # Cultivation — App Store Screenshots Plan
 
 ## Overview
-Generate 10 screenshots per device size (iPhone, iPad) covering core flows and features.
+Generate screenshots around the 1.0 promise: set up an outdoor garden, organize plants by bed or area, follow timely care guidance, and share progress with a private garden club.
 
 ## Device Sizes Required
 | Device | Display | Size | Notes |
@@ -13,10 +13,10 @@ Generate 10 screenshots per device size (iPhone, iPad) covering core flows and f
 ---
 
 ## Current App Structure (4 Tabs)
-- **Home** — Care task dashboard, weather, seasonal tips, club card
-- **Garden** — Plant list grouped by bed, add plant/garden FAB
-- **Club** — Garden Club feed, create/join, chat, share
-- **Me** — Profile, stats, settings, subscription
+- **Home** - Care task dashboard, weather, seasonal tips, club card
+- **Garden** - Plant list grouped by bed/area, first garden setup, add plant
+- **Club** - Private Garden Club feed, create/join, share composer
+- **Me** - Profile, stats, settings, subscription
 
 ---
 
@@ -32,13 +32,12 @@ Generate 10 screenshots per device size (iPhone, iPad) covering core flows and f
 - Your Club card
 **Caption**: "Never miss a watering or fertilizing task"
 
-### 2. Garden Tab — Plant List
+### 2. Garden Tab - Plant List
 **Feature**: Plants grouped by bed/area with hero header
 **Frame**: Garden screen showing:
 - Hero header with garden selector and plant count
 - Plants grouped by bed/area
 - Plant rows with health status indicators
-- Floating add button (coral FAB)
 **Caption**: "All your plants, organized by garden bed"
 
 ### 3. Add Plant — Quick Entry
@@ -60,22 +59,22 @@ Generate 10 screenshots per device size (iPhone, iPad) covering core flows and f
 - Photo journal strip
 **Caption**: "Track every plant's journey from seed to harvest"
 
-### 5. Club Tab — Garden Club Feed
-**Feature**: Share what's growing with nearby gardeners
+### 5. Club Tab - Garden Club Feed
+**Feature**: Share what's growing with a private garden club
 **Frame**: Club feed showing:
 - Club name and member count
 - Activity posts with photos
 - Share button
-- Member avatars
+- Empty/loading/offline states when applicable
 **Caption**: "Share what's growing with your garden club"
 
-### 6. Club — Create or Join
+### 6. Club - Create or Join
 **Feature**: Club creation and invite code flow
 **Frame**: Create Club sheet or Join Club sheet showing:
 - Club name field
 - Invite code display/copy
 - Join via invite code
-**Caption**: "Start a garden club or join one nearby"
+**Caption**: "Start a private garden club or join with an invite code"
 
 ### 7. Plant Health Guidance
 **Feature**: Common plant issues and treatments
@@ -160,6 +159,6 @@ Create a `--demo-data` launch argument that populates:
 - 5 plants across beds (tomato, pepper, basil, lettuce, carrot)
 - 3 overdue reminders
 - 2 due-today reminders
-- 1 garden club with 2 posts
+- 1 private garden club with 2 posts
 - 2 journal entries with photos
 - Hardiness zone: 7a

--- a/docs/plans/2026-05-14-1-0-blockers-design.md
+++ b/docs/plans/2026-05-14-1-0-blockers-design.md
@@ -1,0 +1,47 @@
+# Cultivation 1.0 Blockers Design
+
+## Goal
+
+Make first-run setup and plant creation credible for a 1.0 release: onboarding should create a usable garden structure, core Add Plant flows should persist through the service layer, and the plant database story should be honest when online enrichment is unavailable.
+
+## Blocker Tickets
+
+- #300: Inline garden and container creation must save through the service layer.
+- #301: Add Plant and onboarding must use unified local plus Perenual plant search.
+- #302: Onboarding must persist a complete garden, container, and first plant flow.
+- #303: Configure Perenual for TestFlight and show online database availability.
+- #304: Expand the bundled on-device plant database beyond starter scale.
+
+## Recommended 1.0 Scope
+
+The 1.0 release should prefer a dependable, visible first-run result over ambitious personalization. The first onboarding pass should:
+
+1. Capture level and goals.
+2. Offer a skippable first garden.
+3. Offer a skippable first container when a garden is being created.
+4. Offer a skippable first plant.
+5. Persist garden, container, starter plant, and starter watering reminder through `DataService`.
+6. Show the result in Garden immediately after onboarding.
+
+This means the selected level/goals remain useful but lightweight: they influence beginner recommendations and persisted user preferences. Deeper custom plans, adaptive lessons, garden layouts, and multi-week coaching stay out of 1.0 and should be queued for a quick 1.1 iteration under #287.
+
+## Architecture
+
+- Keep persistence behind `DataService` and repositories. Views should not directly insert core `Garden`, `GardenBed`, or `Plant` models for user-facing creation flows.
+- Add `DataService.createGardenBed(...)` as the service-layer path for containers.
+- Extend user-plant creation with an optional `GardenBed` parameter so onboarding and Add Plant can place a plant in a container atomically.
+- Keep SwiftUI state local to onboarding views per ADR-002. Do not add a new ViewModel for this flow.
+- Seed the local plant database before first-plant onboarding recommendations load, because the UI-test fast path can show onboarding before background seeding completes.
+- Keep online plant database integration graceful. Perenual should enrich Add Plant/search when configured, while local results remain usable offline.
+
+## 1.1 Fast-Follow Scope Left Out of the Recommended 1.0 Cut
+
+- Multi-garden onboarding.
+- Layout planning and container geometry.
+- Deep goal-based coaching plans.
+- Seasonal grow plans generated from location and hardiness zone.
+- Full offline catalog parity with Perenual.
+- Rich recommendation ranking across goals, climate, companion planting, and available space.
+- Bulk import/backfill of a large curated plant taxonomy beyond the 1.0 offline baseline.
+
+Those are valuable, but they are not required to make the 1.0 first-run promise honest.

--- a/docs/plans/2026-05-14-1-0-blockers.md
+++ b/docs/plans/2026-05-14-1-0-blockers.md
@@ -1,0 +1,255 @@
+# Cultivation 1.0 Blockers Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Close the newly identified 1.0 blockers around onboarding persistence, service-layer creation, and plant database availability.
+
+**Architecture:** Work from `codex/1.0-blockers` in `.worktrees/1-0-blockers`. Keep model persistence behind `DataService`, keep onboarding as local SwiftUI state, and implement behavior with Swift Testing red/green slices before touching production code. Run Swift package tests on `mac-mini` by SSH per ADR-016.
+
+**Tech Stack:** Swift 6, SwiftUI, SwiftData, Swift Testing, XCUITest, GitHub Issues, Perenual API integration, SwiftLint, SwiftFormat.
+
+---
+
+## Task 1: Service-Layer Container Persistence (#300, #302)
+
+**Files:**
+- Modify: `GrowWisePackage/Sources/GrowWiseServices/DataService.swift`
+- Modify: `GrowWisePackage/Tests/GrowWiseServicesTests/DataServiceOnboardingGardenTests.swift`
+
+**Step 1: Write the failing test**
+
+Add a test that creates a garden through `DataService.createGarden(...)`, creates a container through the desired new API, and asserts the container is associated with the garden:
+
+```swift
+@Test("createGardenBed persists a container in the selected garden")
+func createGardenBedPersistsContainerInGarden() throws {
+    let dataService = try DataService.makeForTesting()
+    let garden = try dataService.createGarden(name: "Patio Starter", type: .container, isIndoor: false)
+
+    let bed = try dataService.createGardenBed(name: "Herb Pot", bedType: .pot, in: garden)
+
+    #expect(bed.name == "Herb Pot")
+    #expect(bed.bedType == .pot)
+    #expect(bed.garden?.id == garden.id)
+    #expect(garden.beds?.contains { $0.id == bed.id } == true)
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+ssh mac-mini "cd ~/Projects/GrowWise/GrowWisePackage && set -o pipefail && swift test --filter DataServiceOnboardingGardenTests/createGardenBedPersistsContainerInGarden"
+```
+
+Expected: FAIL because `DataService.createGardenBed(...)` does not exist.
+
+**Step 3: Implement minimal service API**
+
+Add `DataService.createGardenBed(name:bedType:in:)` that creates `GardenBed`, appends it to `garden.beds`, inserts/saves through the active SwiftData context, and invalidates garden/plant caches.
+
+**Step 4: Run test to verify it passes**
+
+Run the same focused test. Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add GrowWisePackage/Sources/GrowWiseServices/DataService.swift GrowWisePackage/Tests/GrowWiseServicesTests/DataServiceOnboardingGardenTests.swift
+git commit -m "feat: persist containers through DataService"
+```
+
+## Task 2: Starter Plant Container Assignment (#302)
+
+**Files:**
+- Modify: `GrowWisePackage/Sources/GrowWiseServices/DataService.swift`
+- Modify: `GrowWisePackage/Tests/GrowWiseServicesTests/DataServicePlantTemplateTests.swift`
+
+**Step 1: Write the failing test**
+
+Add a test that creates a garden, creates a container, creates a starter plant in that container, and asserts the plant belongs to the container.
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+ssh mac-mini "cd ~/Projects/GrowWise/GrowWisePackage && set -o pipefail && swift test --filter DataServicePlantTemplateTests/createStarterPlantAssignsSelectedContainer"
+```
+
+Expected: FAIL because starter plant creation has no container parameter.
+
+**Step 3: Implement minimal API**
+
+Add `gardenBed: GardenBed? = nil` to `createUserPlant(from:in:plantingDate:)`, `createUserPlant(from detail:in:plantingDate:)`, and `createStarterPlant(from:in:plantingDate:)`. Set `plant.bed = gardenBed` before saving and append to `gardenBed.plants` when needed.
+
+**Step 4: Run test to verify it passes**
+
+Run the focused test again. Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add GrowWisePackage/Sources/GrowWiseServices/DataService.swift GrowWisePackage/Tests/GrowWiseServicesTests/DataServicePlantTemplateTests.swift
+git commit -m "feat: assign starter plants to containers"
+```
+
+## Task 3: Complete Onboarding Garden -> Container -> Plant Flow (#302)
+
+**Files:**
+- Modify: `GrowWisePackage/Sources/GrowWiseFeature/OnboardingFlow/OnboardingView.swift`
+- Modify: `GrowWisePackage/Sources/GrowWiseFeature/OnboardingFlow/Views/GardenSetupView.swift`
+- Modify: `GrowWisePackage/Sources/GrowWiseFeature/OnboardingFlow/Views/CompletionView.swift`
+- Modify: `GrowWisePackage/Sources/GrowWiseFeature/OnboardingFlow/Views/OnboardingNavigationView.swift`
+- Modify: `GrowWisePackage/Tests/GrowWiseFeatureTests/OnboardingGardenSetupTests.swift`
+
+**Step 1: Write failing feature tests**
+
+Add tests for default container values and container summary text.
+
+**Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+ssh mac-mini "cd ~/Projects/GrowWise/GrowWisePackage && set -o pipefail && swift test --filter OnboardingGardenSetupTests"
+```
+
+Expected: FAIL for new container expectations.
+
+**Step 3: Implement onboarding state and persistence**
+
+Add `shouldCreateFirstContainer`, `firstContainerName`, and `firstContainerType` to `UserProfile`. Show a compact container section inside `GardenSetupView` when first garden creation is enabled. In `OnboardingNavigationView`, create the garden, then container, then starter plant assigned to the container.
+
+**Step 4: Run tests to verify they pass**
+
+Run the same feature test filter. Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add GrowWisePackage/Sources/GrowWiseFeature/OnboardingFlow GrowWisePackage/Tests/GrowWiseFeatureTests/OnboardingGardenSetupTests.swift
+git commit -m "feat: complete onboarding starter garden setup"
+```
+
+## Task 4: Seed First-Plant Recommendations Before Loading (#302)
+
+**Files:**
+- Modify: `GrowWisePackage/Sources/GrowWiseFeature/OnboardingFlow/Views/FirstPlantStepView.swift`
+- Modify: `GrowWisePackage/Tests/GrowWiseServicesTests/PlantDatabaseOnboardingPersonalizationTests.swift`
+
+**Step 1: Write failing test or strengthen existing seed coverage**
+
+Assert seeded beginner recommendations include the curated onboarding plants used by `FirstPlantStepView`.
+
+**Step 2: Run focused test**
+
+Run:
+
+```bash
+ssh mac-mini "cd ~/Projects/GrowWise/GrowWisePackage && set -o pipefail && swift test --filter PlantDatabaseOnboardingPersonalizationTests"
+```
+
+Expected: FAIL if the strengthened assumption is not currently guaranteed.
+
+**Step 3: Implement async seed before loading recommendations**
+
+Change `FirstPlantStepView` to call `await plantDatabaseService.seedPlantDatabase()` before reading beginner plants.
+
+**Step 4: Run focused test**
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add GrowWisePackage/Sources/GrowWiseFeature/OnboardingFlow/Views/FirstPlantStepView.swift GrowWisePackage/Tests/GrowWiseServicesTests/PlantDatabaseOnboardingPersonalizationTests.swift
+git commit -m "fix: seed onboarding plant recommendations before display"
+```
+
+## Task 5: Replace Inline SwiftData Inserts in Creation Views (#300)
+
+**Files:**
+- Modify: `GrowWisePackage/Sources/GrowWiseFeature/Views/AddPlantSheet.swift`
+- Modify: `GrowWisePackage/Sources/GrowWiseFeature/Views/Garden/CreateBedSheet.swift`
+
+**Step 1: Add service tests already covering the persistence contract**
+
+Use the Task 1 service test as the red/green guard for container persistence. Add Plant garden creation reuses existing `DataService.createGarden(...)`.
+
+**Step 2: Implement view changes**
+
+Update Add Plant inline garden creation to call `dataService.createGarden(...)`. Update `CreateBedSheet` to call `dataService.createGardenBed(...)` and surface an alert if save fails.
+
+**Step 3: Run focused service tests and lint touched views**
+
+Run:
+
+```bash
+ssh mac-mini "cd ~/Projects/GrowWise/GrowWisePackage && set -o pipefail && swift test --filter DataServiceOnboardingGardenTests"
+swiftlint lint --strict --config .swiftlint.yml --path GrowWisePackage/Sources/GrowWiseFeature/Views/AddPlantSheet.swift --path GrowWisePackage/Sources/GrowWiseFeature/Views/Garden/CreateBedSheet.swift
+```
+
+Expected: tests and lint pass.
+
+**Step 4: Commit**
+
+```bash
+git add GrowWisePackage/Sources/GrowWiseFeature/Views/AddPlantSheet.swift GrowWisePackage/Sources/GrowWiseFeature/Views/Garden/CreateBedSheet.swift
+git commit -m "fix: save inline garden structure through services"
+```
+
+## Task 6: Perenual Release Availability (#303)
+
+**Files:**
+- Modify: `config/Shared.xcconfig`
+- Modify: `GrowWisePackage/Sources/GrowWiseFeature/Views/PlantDatabase/PerenualBrowseView.swift`
+- Modify or add: `GrowWisePackage/Tests/GrowWiseServicesTests/PerenualAPIServiceContractTests.swift`
+
+**Steps:**
+1. Add a failing test for no-key availability messaging or API-key status if practical.
+2. Add a non-secret build setting path for `PERENUAL_API_KEY`.
+3. Keep missing-key UI explicit and non-crashy.
+4. Run focused tests/lint.
+5. Commit with `fix: surface Perenual availability in release builds`.
+
+## Task 7: Unified Add Plant Search (#301)
+
+**Files:**
+- Modify: `GrowWisePackage/Sources/GrowWiseFeature/Views/AddPlantSheet.swift`
+- Modify: `GrowWisePackage/Sources/GrowWiseServices/PlantDatabaseService.swift`
+- Modify or add tests under `GrowWisePackage/Tests/GrowWiseServicesTests/`
+
+**Steps:**
+1. Write tests for a unified result model that preserves local fallback and maps online summaries.
+2. Implement shared search result data.
+3. Integrate Add Plant autocomplete with local plus Perenual results.
+4. Keep onboarding curated recommendations local for 1.0 unless online search is already configured.
+5. Run focused tests and lint.
+6. Commit with `feat: unify plant search in Add Plant`.
+
+## Task 8: Offline Catalog Baseline (#304)
+
+**Files:**
+- Modify: `GrowWisePackage/Sources/GrowWiseServices/Resources/plant_database.json`
+- Modify: `GrowWisePackage/Tests/GrowWiseServicesTests/PlantDatabaseServiceTests.swift`
+
+**Steps:**
+1. Write tests for minimum catalog size and category coverage.
+2. Expand curated offline entries to meet the 1.0 baseline.
+3. Run plant database tests.
+4. Commit with `feat: expand offline plant catalog`.
+
+## Task 9: Final Verification
+
+Run:
+
+```bash
+swiftformat --lint --config .swiftformat GrowWisePackage/Sources GrowWise
+swiftlint lint --strict --config .swiftlint.yml
+ssh mac-mini "cd ~/Projects/GrowWise/GrowWisePackage && set -o pipefail && swift test"
+ssh mac-mini "cd ~/Projects/GrowWise && xcodebuild -workspace GrowWise.xcworkspace -scheme GrowWise -sdk iphonesimulator build CODE_SIGN_IDENTITY='' CODE_SIGNING_REQUIRED=NO"
+```
+
+Expected: all verification passes before release readiness is claimed.

--- a/docs/superpowers/plans/2026-05-15-1-0-blocker-burn-down.md
+++ b/docs/superpowers/plans/2026-05-15-1-0-blocker-burn-down.md
@@ -1,0 +1,75 @@
+# 1.0 Blocker Burn-Down Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:executing-plans` or `superpowers:subagent-driven-development` to execute this plan task-by-task. Track progress with the checkbox list below.
+
+**Goal:** Resolve or verify every open `[1.0 blocker]` GitHub issue (#300-#310) so Cultivation can reach a credible 1.0 release candidate.
+
+**Architecture:** Treat already-implemented blockers as verification work and close them only with evidence. For remaining code blockers, use narrow service/view changes backed by Swift Testing or XCUITest coverage, preserving SwiftUI + SwiftData + service injection patterns. Release-copy readiness is documented in repo because App Store Connect assets cannot be fully verified from source.
+
+**Tech Stack:** Swift 6, SwiftUI, SwiftData, StoreKit 2, CloudKit, Swift Testing, XCUITest, SwiftLint, mac-mini SSH build/test verification, GitHub Issues.
+
+## Task 1: Verify Existing 1.0 Blocker Fixes (#300-#304)
+
+**Files to inspect:** `AddPlantSheet.swift`, `CreateBedSheet.swift`, onboarding flow views, `PerenualBrowseView.swift`, `PlantDatabaseService.swift`, `plant_database.json`.
+
+- [x] Verify Add Plant and Create Container route through `DataService` rather than direct view-level SwiftData inserts.
+- [x] Verify onboarding persists a first garden, first container, and selected first plant.
+- [x] Verify Add Plant combines local and Perenual results and handles missing Perenual API configuration gracefully.
+- [x] Verify offline plant catalog meets the 1.0 breadth target.
+- [x] Run focused onboarding, Perenual, and database tests on mac-mini.
+- [ ] Close #300-#304 with command evidence after final branch verification.
+
+## Task 2: Fix Lint And Pricing Drift (#306, #310)
+
+**Files:** `PaywallView.swift`, `User.swift`, `UserTests.swift`, `PaywallPresentationTests.swift`.
+
+- [ ] Write failing tests for launch Premium pricing: `$2.99/mo` and `$34.99/yr`.
+- [ ] Update `SubscriptionTier.premium.monthlyPrice` and Paywall display constants.
+- [ ] Fix the Paywall SwiftLint trailing-comma violation.
+- [ ] Run focused pricing tests and strict SwiftLint.
+
+## Task 3: Enforce Plant Health Scanner Limits (#307)
+
+**Files:** `PlantScannerView.swift`, `PlantDiagnosticService.swift`, Plant Diagnostic and scanner presentation tests.
+
+- [ ] Write a failing feature test proving the scanner no longer exposes sample/debug guidance in release UI and no longer calls the legacy unmetered `diagnose(image:)` path.
+- [ ] Add or verify service tests for allowed usage and limit-reached behavior.
+- [ ] Inject `DataService` into `PlantScannerView` and route photo analysis through the tier-aware diagnostic call.
+- [ ] Run focused scanner and diagnostic tests.
+
+## Task 4: Preserve Club Share Garden Context And CloudKit Mapping (#308)
+
+**Files:** `DataService+GardenClub.swift`, `ClubShareComposerSheet.swift`, `ClubCloudKitService.swift`, Garden Club service tests.
+
+- [ ] Write a failing service test for `createClubPost(... gardenName:)`.
+- [ ] Write pure CloudKit mapping/scope tests that require `gardenName` to be mapped and owner/member scope to be deterministic.
+- [ ] Propagate garden context from Plant Detail share composer into the persisted club post.
+- [ ] Use the tested CloudKit mapping/scope helpers from publish/fetch paths.
+- [ ] Run focused Garden Club and ClubCloudKit tests.
+
+## Task 5: Add Missing Critical UI Coverage (#309)
+
+**Files:** `OnboardingFlowUITests.swift`, `GardenClubUITests.swift`, possibly `FirstPlantStepView.swift`.
+
+- [ ] Add stable accessibility identifiers for starter plant cards if missing.
+- [ ] Extend onboarding UI coverage to create garden, container, and first plant.
+- [ ] Add Club composer coverage from the Club tab.
+- [ ] Add Plant Detail share-to-club composer coverage if the existing UI hooks make it reliable.
+- [ ] Run focused UI tests on mac-mini or document any simulator blocker.
+
+## Task 6: Document App Store Readiness (#305)
+
+**Files:** `docs/release/1.0-app-store-readiness.md`.
+
+- [ ] Add release copy focused on outdoor gardens, beds/areas, timely care, and private clubs.
+- [ ] Document subscription copy: Premium annual around `$34.99/year`, monthly available, Pro future-facing only.
+- [ ] Document screenshot storyboard and privacy/subscription checklist.
+- [ ] Add repository-side copy guardrails for Plant Health Guidance language.
+
+## Task 7: Final Verification And Issue Updates
+
+- [ ] Run `swiftlint lint --strict --config .swiftlint.yml`.
+- [ ] Run `ssh mac-mini "cd ~/Projects/GrowWise/.worktrees/1-0-blockers/GrowWisePackage && swift test"`.
+- [ ] Run `ssh mac-mini "cd ~/Projects/GrowWise/.worktrees/1-0-blockers && xcodebuild -workspace GrowWise.xcworkspace -scheme GrowWise -sdk iphonesimulator build CODE_SIGN_IDENTITY='' CODE_SIGNING_REQUIRED=NO"`.
+- [ ] Update or close #300-#310 with evidence and any residual risk.
+- [ ] Commit and push `codex/1.0-blockers`.


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Link to the beads issue: `bd show GW-XXX` -->

Closes: <!-- GW-XXX -->

## Changes

<!-- List the key changes made -->

- 

## Testing Done

<!-- How was this tested? Check all that apply -->

- [ ] `cd GrowWisePackage && swift test` passes
- [ ] Manually tested on iOS Simulator (specify version/device)
- [ ] SwiftLint passes: `swiftlint lint --config .swiftlint.yml`
- [ ] SwiftFormat passes: `swiftformat --lint --config .swiftformat GrowWisePackage/Sources GrowWise`

## Architecture Impact

<!-- Does this change the data model, service interfaces, or concurrency model? -->

- [ ] No architectural changes
- [ ] SwiftData model changes (CloudKit-compatible?)
- [ ] New service or service interface change
- [ ] Concurrency model change (`@MainActor`, Actor, async/await)
- [ ] Security-sensitive change (Keychain, encryption, auth)

## Checklist

- [ ] Code follows MV architecture (no ViewModels)
- [ ] No `as!` force casts or force unwraps (`!`)
- [ ] No `try?` silencing errors in views
- [ ] All `@Model` properties are optional or have defaults (CloudKit compatibility)
- [ ] New UI elements have `.accessibilityIdentifier()`
- [ ] No print statements (use Logger/OSLog)
- [ ] TODO/FIXME comments include beads issue reference (e.g., `TODO(GW-123): ...`)

## Screenshots / Recording

<!-- For UI changes, include before/after screenshots or a screen recording -->
