### PR TITLE
feat(#358): add club member profiles

### DIFF
--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/GardenClub/ActivityRowView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/GardenClub/ActivityRowView.swift
@@ -1,0 +1,68 @@
+import Foundation
+import GrowWiseModels
+import SwiftUI
+
+struct ActivityRowView: View {
+    let activity: ClubActivity
+
+    private var icon: String {
+        switch activity.activityType {
+        case "watered": "drop.fill"
+        case "harvested": "scissors"
+        case "planted": "leaf.fill"
+        case "journaled": "book.fill"
+        case "diagnosed": "stethoscope"
+        default: "star.fill"
+        }
+    }
+
+    private var iconColor: Color {
+        switch activity.activityType {
+        case "watered": .blue
+        case "harvested": CultivationTheme.Colors.accentAmber
+        case "planted": CultivationTheme.Colors.brandLeaf
+        case "journaled": .purple
+        case "diagnosed": CultivationTheme.Colors.statusAlert
+        default: CultivationTheme.Colors.brandForest
+        }
+    }
+
+    private var timeAgo: String {
+        guard let date = activity.timestamp else { return "" }
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .abbreviated
+        return formatter.localizedString(for: date, relativeTo: Date())
+    }
+
+    var body: some View {
+        HStack(spacing: 12) {
+            ZStack {
+                RoundedRectangle(cornerRadius: CultivationTheme.Radius.icon)
+                    .fill(iconColor.opacity(0.15))
+                    .frame(width: 36, height: 36)
+                Image(systemName: icon)
+                    .font(.system(size: 15))
+                    .foregroundStyle(iconColor)
+            }
+
+            VStack(alignment: .leading, spacing: 3) {
+                Text(activity.memberName ?? "A member")
+                    .font(.system(.subheadline, design: .rounded, weight: .medium))
+                    .foregroundStyle(CultivationTheme.Colors.textPrimary)
+                    + Text(" \(activity.activityDescription ?? activity.activityType ?? "did something")")
+                    .font(.system(.subheadline, design: .rounded))
+                    .foregroundStyle(CultivationTheme.Colors.textSecondary)
+
+                if !timeAgo.isEmpty {
+                    Text(timeAgo)
+                        .font(.system(size: 11, design: .rounded))
+                        .foregroundStyle(CultivationTheme.Colors.textTertiary)
+                }
+            }
+
+            Spacer()
+        }
+        .padding(CultivationTheme.Spacing.cardPadding)
+        .glassCard()
+    }
+}

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/GardenClub/ClubDetailView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/GardenClub/ClubDetailView.swift
@@ -3,7 +3,7 @@ import GrowWiseServices
 import SwiftUI
 
 // SwiftLint suppressions for #284 — pre-existing structural & style violations; refactor out of scope.
-// swiftlint:disable attributes identifier_name type_body_length
+// swiftlint:disable attributes type_body_length
 
 public struct ClubDetailView: View {
     @Environment(DataService.self) private var dataService
@@ -12,11 +12,13 @@ public struct ClubDetailView: View {
     let club: GardenClub
 
     @State private var activities: [ClubActivity] = []
+    @State private var memberUsers: [User] = []
     @State private var isLoading = false
     @State private var errorMessage: String?
     @State private var showLeaveAlert = false
     @State private var showRemoveMemberAlert = false
     @State private var memberToRemove: String?
+    @State private var selectedMemberProfile: ClubMemberProfile?
     @State private var codeCopied = false
 
     private var currentUserID: String {
@@ -53,7 +55,7 @@ public struct ClubDetailView: View {
             .navigationBarTitleDisplayMode(.large)
         #endif
             .toolbar { toolbarContent }
-            .task { await loadActivities() }
+            .task { await loadClubData() }
             .alert("Leave Club", isPresented: $showLeaveAlert) {
                 Button("Leave", role: .destructive) { Task { await leaveClub() } }
                 Button("Cancel", role: .cancel) {}
@@ -76,6 +78,9 @@ public struct ClubDetailView: View {
             }
             .navigationDestination(isPresented: $navigateToEvents) {
                 ClubEventsView(club: club)
+            }
+            .sheet(item: $selectedMemberProfile) { profile in
+                ClubMemberProfileView(profile: profile)
             }
     }
 
@@ -194,31 +199,48 @@ public struct ClubDetailView: View {
     }
 
     private func memberRow(memberID: String) -> some View {
-        HStack(spacing: 12) {
-            ZStack {
-                Circle()
-                    .fill(CultivationTheme.Colors.brandMint)
-                    .frame(width: 36, height: 36)
-                Text(memberID.prefix(1).uppercased())
-                    .font(.system(.subheadline, design: .rounded, weight: .bold))
-                    .foregroundStyle(CultivationTheme.Colors.brandForest)
-            }
+        let profile = memberProfile(for: memberID)
 
-            VStack(alignment: .leading, spacing: 2) {
-                HStack(spacing: 6) {
-                    Text(memberID == club.ownerID ? "Owner" : "Member")
-                        .font(.system(.subheadline, design: .rounded, weight: .medium))
-                        .foregroundStyle(CultivationTheme.Colors.textPrimary)
-                    if memberID == club.ownerID {
-                        Image(systemName: "crown.fill")
-                            .font(.system(size: 11))
-                            .foregroundStyle(CultivationTheme.Colors.accentAmber)
+        return HStack(spacing: 12) {
+            Button {
+                selectedMemberProfile = profile
+            } label: {
+                HStack(spacing: 12) {
+                    ZStack {
+                        Circle()
+                            .fill(CultivationTheme.Colors.brandMint)
+                            .frame(width: 36, height: 36)
+                        Text(profile.avatarLetters)
+                            .font(.system(.subheadline, design: .rounded, weight: .bold))
+                            .foregroundStyle(CultivationTheme.Colors.brandForest)
                     }
+
+                    VStack(alignment: .leading, spacing: 2) {
+                        HStack(spacing: 6) {
+                            Text(profile.displayName)
+                                .font(.system(.subheadline, design: .rounded, weight: .medium))
+                                .foregroundStyle(CultivationTheme.Colors.textPrimary)
+                            if memberID == club.ownerID {
+                                Image(systemName: "crown.fill")
+                                    .font(.system(size: 11))
+                                    .foregroundStyle(CultivationTheme.Colors.accentAmber)
+                            }
+                        }
+                        Text(profile.isCurrentUser ? "You" : profile.roleTitle)
+                            .font(.system(size: 11, design: .rounded))
+                            .foregroundStyle(CultivationTheme.Colors.textTertiary)
+                    }
+
+                    Spacer()
+
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundStyle(CultivationTheme.Colors.textTertiary)
                 }
-                Text(memberID == currentUserID ? "You" : memberID.prefix(8) + "…")
-                    .font(.system(size: 11, design: .monospaced))
-                    .foregroundStyle(CultivationTheme.Colors.textTertiary)
+                .contentShape(Rectangle())
             }
+            .buttonStyle(.plain)
+            .accessibilityIdentifier("clubprofile_button_member_\(accessibilitySafeMemberID(memberID))")
 
             Spacer()
 
@@ -374,6 +396,21 @@ public struct ClubDetailView: View {
     // MARK: - Actions
 
     @MainActor
+    private func loadClubData() async {
+        loadMemberUsers()
+        await loadActivities()
+    }
+
+    @MainActor
+    private func loadMemberUsers() {
+        do {
+            memberUsers = try dataService.users.fetchAll()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    @MainActor
     private func loadActivities() async {
         isLoading = true
         defer { isLoading = false }
@@ -403,72 +440,30 @@ public struct ClubDetailView: View {
             errorMessage = error.localizedDescription
         }
     }
-}
 
-// MARK: - Activity Row
-
-private struct ActivityRowView: View {
-    let activity: ClubActivity
-
-    private var icon: String {
-        switch activity.activityType {
-        case "watered": "drop.fill"
-        case "harvested": "scissors"
-        case "planted": "leaf.fill"
-        case "journaled": "book.fill"
-        case "diagnosed": "stethoscope"
-        default: "star.fill"
-        }
+    private func memberProfile(for memberID: String) -> ClubMemberProfile {
+        ClubMemberProfile(
+            memberID: memberID,
+            club: club,
+            user: memberUser(for: memberID),
+            activities: activities,
+            currentUserID: currentUserID
+        )
     }
 
-    private var iconColor: Color {
-        switch activity.activityType {
-        case "watered": .blue
-        case "harvested": CultivationTheme.Colors.accentAmber
-        case "planted": CultivationTheme.Colors.brandLeaf
-        case "journaled": .purple
-        case "diagnosed": CultivationTheme.Colors.statusAlert
-        default: CultivationTheme.Colors.brandForest
+    private func memberUser(for memberID: String) -> User? {
+        if let currentUser = dataService.getCurrentUser(),
+           currentUser.id.uuidString == memberID
+        {
+            return currentUser
         }
+        return memberUsers.first { $0.id.uuidString == memberID }
     }
 
-    private var timeAgo: String {
-        guard let date = activity.timestamp else { return "" }
-        let f = RelativeDateTimeFormatter()
-        f.unitsStyle = .abbreviated
-        return f.localizedString(for: date, relativeTo: Date())
-    }
-
-    var body: some View {
-        HStack(spacing: 12) {
-            ZStack {
-                RoundedRectangle(cornerRadius: CultivationTheme.Radius.icon)
-                    .fill(iconColor.opacity(0.15))
-                    .frame(width: 36, height: 36)
-                Image(systemName: icon)
-                    .font(.system(size: 15))
-                    .foregroundStyle(iconColor)
-            }
-
-            VStack(alignment: .leading, spacing: 3) {
-                Text(activity.memberName ?? "A member")
-                    .font(.system(.subheadline, design: .rounded, weight: .medium))
-                    .foregroundStyle(CultivationTheme.Colors.textPrimary)
-                    + Text(" \(activity.activityDescription ?? activity.activityType ?? "did something")")
-                    .font(.system(.subheadline, design: .rounded))
-                    .foregroundStyle(CultivationTheme.Colors.textSecondary)
-
-                if !timeAgo.isEmpty {
-                    Text(timeAgo)
-                        .font(.system(size: 11, design: .rounded))
-                        .foregroundStyle(CultivationTheme.Colors.textTertiary)
-                }
-            }
-
-            Spacer()
-        }
-        .padding(CultivationTheme.Spacing.cardPadding)
-        .glassCard()
+    private func accessibilitySafeMemberID(_ memberID: String) -> String {
+        String(memberID.map { character in
+            character.isLetter || character.isNumber ? character : "_"
+        })
     }
 }
 
@@ -479,4 +474,4 @@ private struct ActivityRowView: View {
     }
 }
 
-// swiftlint:enable attributes identifier_name type_body_length
+// swiftlint:enable attributes type_body_length

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/GardenClub/ClubDetailView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/GardenClub/ClubDetailView.swift
@@ -403,8 +403,15 @@ public struct ClubDetailView: View {
 
     @MainActor
     private func loadMemberUsers() {
+        let memberIDs = Set(club.memberIDs)
+
+        guard !memberIDs.isEmpty else {
+            memberUsers = []
+            return
+        }
+
         do {
-            memberUsers = try dataService.users.fetchAll()
+            memberUsers = try dataService.users.fetchAll().filter { memberIDs.contains($0.id.uuidString) }
         } catch {
             errorMessage = error.localizedDescription
         }

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/GardenClub/ClubDetailView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/GardenClub/ClubDetailView.swift
@@ -5,6 +5,10 @@ import SwiftUI
 // SwiftLint suppressions for #284 — pre-existing structural & style violations; refactor out of scope.
 // swiftlint:disable attributes type_body_length
 
+private struct SelectedMember: Identifiable {
+    let id: String
+}
+
 public struct ClubDetailView: View {
     @Environment(DataService.self) private var dataService
     @Environment(\.dismiss) private var dismiss
@@ -18,7 +22,7 @@ public struct ClubDetailView: View {
     @State private var showLeaveAlert = false
     @State private var showRemoveMemberAlert = false
     @State private var memberToRemove: String?
-    @State private var selectedMemberProfile: ClubMemberProfile?
+    @State private var selectedMemberID: String?
     @State private var codeCopied = false
 
     private var currentUserID: String {
@@ -79,8 +83,11 @@ public struct ClubDetailView: View {
             .navigationDestination(isPresented: $navigateToEvents) {
                 ClubEventsView(club: club)
             }
-            .sheet(item: $selectedMemberProfile) { profile in
-                ClubMemberProfileView(profile: profile)
+            .sheet(item: Binding(
+                get: { selectedMemberID.map { SelectedMember(id: $0) } },
+                set: { selectedMemberID = $0?.id }
+            )) { selection in
+                ClubMemberProfileView(profile: memberProfile(for: selection.id))
             }
     }
 
@@ -203,7 +210,7 @@ public struct ClubDetailView: View {
 
         return HStack(spacing: 12) {
             Button {
-                selectedMemberProfile = profile
+                selectedMemberID = memberID
             } label: {
                 HStack(spacing: 12) {
                     ZStack {

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/GardenClub/ClubMemberProfile.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/GardenClub/ClubMemberProfile.swift
@@ -1,0 +1,104 @@
+import Foundation
+import GrowWiseModels
+
+struct ClubMemberProfile: Identifiable {
+    let memberID: String
+    let roleTitle: String
+    let isCurrentUser: Bool
+    let canShowPublicDetails: Bool
+    let displayName: String
+    let avatarLetters: String
+    let bio: String?
+    let hardinessZone: String?
+    let memberSinceDate: Date?
+    let plantCount: Int?
+    let publicGardenCount: Int?
+    let recentContributions: [ClubActivity]
+
+    var id: String {
+        memberID
+    }
+
+    init(
+        memberID: String,
+        club: GardenClub,
+        user: User?,
+        activities: [ClubActivity],
+        currentUserID: String
+    ) {
+        self.memberID = memberID
+        roleTitle = memberID == club.ownerID ? "Owner" : "Member"
+        isCurrentUser = memberID == currentUserID
+        canShowPublicDetails = isCurrentUser || user?.isProfilePublic == true
+
+        if canShowPublicDetails, let name = user?.displayName?.trimmedNonEmpty {
+            displayName = name
+        } else {
+            displayName = "Club member"
+        }
+
+        avatarLetters = Self.avatarLetters(
+            displayName: canShowPublicDetails ? user?.displayName : nil,
+            memberID: memberID
+        )
+        bio = canShowPublicDetails ? user?.bio?.trimmedNonEmpty : nil
+        hardinessZone = canShowPublicDetails ? user?.hardinessZone?.trimmedNonEmpty : nil
+        memberSinceDate = club.createdDate
+        plantCount = canShowPublicDetails ? Self.plantCount(for: user) : nil
+        publicGardenCount = canShowPublicDetails ? Self.publicGardenCount(for: user, club: club) : nil
+        recentContributions = canShowPublicDetails ? Self.recentActivities(
+            for: memberID,
+            activities: activities
+        ) : []
+    }
+
+    private static func plantCount(for user: User?) -> Int {
+        (user?.gardens ?? []).reduce(0) { total, garden in
+            total + (garden.plants ?? []).count
+        }
+    }
+
+    private static func publicGardenCount(for user: User?, club: GardenClub) -> Int {
+        let sharedGardenIDs = Set(club.sharedGardenIDs ?? [])
+        guard !sharedGardenIDs.isEmpty else { return 0 }
+        return (user?.gardens ?? []).count(where: { garden in
+            guard let id = garden.id?.uuidString else { return false }
+            return sharedGardenIDs.contains(id)
+        })
+    }
+
+    private static func recentActivities(
+        for memberID: String,
+        activities: [ClubActivity]
+    ) -> [ClubActivity] {
+        Array(
+            activities
+                .filter { $0.memberID == memberID }
+                .sorted { lhs, rhs in
+                    (lhs.timestamp ?? .distantPast) > (rhs.timestamp ?? .distantPast)
+                }
+                .prefix(3)
+        )
+    }
+
+    private static func avatarLetters(displayName: String?, memberID _: String) -> String {
+        if let displayName = displayName?.trimmedNonEmpty {
+            let initials = displayName
+                .split(separator: " ")
+                .prefix(2)
+                .compactMap(\.first)
+                .map { String($0).uppercased() }
+                .joined()
+            if !initials.isEmpty { return initials }
+        }
+
+        return "M"
+    }
+}
+
+private extension String {
+    var trimmedNonEmpty: String? {
+        let trimmed = trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/GardenClub/ClubMemberProfile.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/GardenClub/ClubMemberProfile.swift
@@ -43,7 +43,7 @@ struct ClubMemberProfile: Identifiable {
         )
         bio = canShowPublicDetails ? user?.bio?.trimmedNonEmpty : nil
         hardinessZone = canShowPublicDetails ? user?.hardinessZone?.trimmedNonEmpty : nil
-        memberSinceDate = club.createdDate
+        memberSinceDate = canShowPublicDetails ? club.createdDate : nil
         plantCount = canShowPublicDetails ? Self.plantCount(for: user) : nil
         publicGardenCount = canShowPublicDetails ? Self.publicGardenCount(for: user, club: club) : nil
         recentContributions = canShowPublicDetails ? Self.recentActivities(

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/GardenClub/ClubMemberProfile.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/GardenClub/ClubMemberProfile.swift
@@ -81,7 +81,7 @@ struct ClubMemberProfile: Identifiable {
         )
     }
 
-    private static func avatarLetters(displayName: String?, memberID _: String) -> String {
+    private static func avatarLetters(displayName: String?, memberID: String) -> String {
         if let displayName = displayName?.trimmedNonEmpty {
             let initials = displayName
                 .split(separator: " ")
@@ -90,6 +90,10 @@ struct ClubMemberProfile: Identifiable {
                 .map { String($0).uppercased() }
                 .joined()
             if !initials.isEmpty { return initials }
+        }
+
+        if let firstAlphanumeric = memberID.first(where: { $0.isLetter || $0.isNumber }) {
+            return String(firstAlphanumeric).uppercased()
         }
 
         return "M"

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/GardenClub/ClubMemberProfileView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/GardenClub/ClubMemberProfileView.swift
@@ -1,0 +1,204 @@
+import GrowWiseModels
+import SwiftUI
+
+struct ClubMemberProfileView: View {
+    @Environment(\.dismiss)
+    private var dismiss
+
+    let profile: ClubMemberProfile
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(spacing: CultivationTheme.Spacing.sectionGap) {
+                    header
+
+                    if profile.canShowPublicDetails {
+                        publicDetails
+                    } else {
+                        privateProfileMessage
+                    }
+                }
+                .padding(.horizontal, CultivationTheme.Spacing.screenPadding)
+                .padding(.vertical, CultivationTheme.Spacing.sectionGap)
+            }
+            .background(CultivationTheme.Colors.background.ignoresSafeArea())
+            .navigationTitle("Member Profile")
+            #if os(iOS)
+                .navigationBarTitleDisplayMode(.inline)
+            #endif
+                .toolbar {
+                    ToolbarItem(placement: .cancellationAction) {
+                        Button("Done") { dismiss() }
+                            .accessibilityIdentifier("clubprofile_button_done")
+                    }
+                }
+        }
+        .accessibilityIdentifier("clubprofile_screen")
+    }
+
+    private var header: some View {
+        VStack(spacing: 14) {
+            ZStack {
+                Circle()
+                    .fill(CultivationTheme.Gradients.ctaVertical)
+                    .frame(width: 84, height: 84)
+                Text(profile.avatarLetters)
+                    .font(.system(size: 30, weight: .bold, design: .rounded))
+                    .foregroundStyle(.white)
+            }
+            .accessibilityIdentifier("clubprofile_avatar")
+
+            VStack(spacing: 5) {
+                Text(profile.displayName)
+                    .font(CultivationTheme.Fonts.display(26, weight: .semibold))
+                    .foregroundStyle(CultivationTheme.Colors.textPrimary)
+                    .multilineTextAlignment(.center)
+                    .accessibilityIdentifier("clubprofile_label_name")
+
+                HStack(spacing: 8) {
+                    Label(profile.roleTitle, systemImage: profile.roleTitle == "Owner" ? "crown.fill" : "person.fill")
+                    if profile.isCurrentUser {
+                        Text("You")
+                    }
+                }
+                .font(CultivationTheme.Fonts.body(13, weight: .semibold))
+                .foregroundStyle(CultivationTheme.Colors.textSecondary)
+                .accessibilityIdentifier("clubprofile_label_role")
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .padding(CultivationTheme.Spacing.cardPadding)
+        .glassCard()
+    }
+
+    private var publicDetails: some View {
+        VStack(spacing: CultivationTheme.Spacing.rowGap) {
+            if let bio = profile.bio {
+                profileSection(title: "Bio") {
+                    Text(bio)
+                        .font(CultivationTheme.Fonts.body(15))
+                        .foregroundStyle(CultivationTheme.Colors.textSecondary)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+            }
+
+            profileSection(title: "Garden Snapshot") {
+                VStack(spacing: 12) {
+                    if let hardinessZone = profile.hardinessZone {
+                        factRow(icon: "thermometer.sun.fill", title: "Hardiness Zone", value: hardinessZone)
+                    }
+                    if let memberSinceDate = profile.memberSinceDate {
+                        factRow(
+                            icon: "calendar",
+                            title: "Member Since",
+                            value: memberSinceDate.formatted(date: .abbreviated, time: .omitted)
+                        )
+                    }
+                    factRow(icon: "leaf.fill", title: "Plants", value: "\(profile.plantCount ?? 0)")
+                    factRow(icon: "globe.americas.fill", title: "Public Gardens", value: "\(profile.publicGardenCount ?? 0)")
+                }
+            }
+
+            profileSection(title: "Recent Contributions") {
+                if profile.recentContributions.isEmpty {
+                    emptyContributionRow
+                } else {
+                    VStack(spacing: CultivationTheme.Spacing.rowGap) {
+                        ForEach(profile.recentContributions, id: \.id) { activity in
+                            contributionRow(activity)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private var privateProfileMessage: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "lock.fill")
+                .font(.system(size: 18, weight: .semibold))
+                .foregroundStyle(CultivationTheme.Colors.textTertiary)
+            Text("This member has not shared a public profile.")
+                .font(CultivationTheme.Fonts.body(15))
+                .foregroundStyle(CultivationTheme.Colors.textSecondary)
+            Spacer()
+        }
+        .padding(CultivationTheme.Spacing.cardPadding)
+        .glassCard()
+        .accessibilityIdentifier("clubprofile_private_message")
+    }
+
+    private var emptyContributionRow: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "clock")
+                .foregroundStyle(CultivationTheme.Colors.textTertiary)
+            Text("No recent contributions")
+                .font(CultivationTheme.Fonts.body(14))
+                .foregroundStyle(CultivationTheme.Colors.textSecondary)
+            Spacer()
+        }
+    }
+
+    private func profileSection(
+        title: String,
+        @ViewBuilder content: () -> some View
+    ) -> some View {
+        VStack(alignment: .leading, spacing: CultivationTheme.Spacing.rowGap) {
+            Text(title)
+                .sectionLabelStyle()
+                .padding(.leading, 4)
+            content()
+                .padding(CultivationTheme.Spacing.cardPadding)
+                .glassCard()
+        }
+    }
+
+    private func factRow(icon: String, title: String, value: String) -> some View {
+        HStack(spacing: 12) {
+            Image(systemName: icon)
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundStyle(CultivationTheme.Colors.brandLeaf)
+                .frame(width: 24)
+            Text(title)
+                .font(CultivationTheme.Fonts.body(14))
+                .foregroundStyle(CultivationTheme.Colors.textSecondary)
+            Spacer()
+            Text(value)
+                .font(CultivationTheme.Fonts.body(14, weight: .semibold))
+                .foregroundStyle(CultivationTheme.Colors.textPrimary)
+        }
+    }
+
+    private func contributionRow(_ activity: ClubActivity) -> some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: contributionIcon(for: activity.activityType))
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundStyle(CultivationTheme.Colors.brandLeaf)
+                .frame(width: 24)
+
+            VStack(alignment: .leading, spacing: 3) {
+                Text(activity.activityDescription ?? activity.activityType ?? "Shared an update")
+                    .font(CultivationTheme.Fonts.body(14, weight: .medium))
+                    .foregroundStyle(CultivationTheme.Colors.textPrimary)
+                if let timestamp = activity.timestamp {
+                    Text(timestamp.formatted(date: .abbreviated, time: .omitted))
+                        .font(CultivationTheme.Fonts.body(11))
+                        .foregroundStyle(CultivationTheme.Colors.textTertiary)
+                }
+            }
+            Spacer()
+        }
+    }
+
+    private func contributionIcon(for activityType: String?) -> String {
+        switch activityType {
+        case "watered": "drop.fill"
+        case "harvested": "scissors"
+        case "planted": "leaf.fill"
+        case "journaled": "book.fill"
+        case "diagnosed": "stethoscope"
+        default: "sparkles"
+        }
+    }
+}

--- a/GrowWisePackage/Sources/GrowWiseModels/User.swift
+++ b/GrowWisePackage/Sources/GrowWiseModels/User.swift
@@ -6,6 +6,8 @@ public final class User {
     public var id = UUID() // CloudKit: made optional or with default value
     public var email: String? // CloudKit: made optional or with default value
     public var displayName: String? // CloudKit: made optional or with default value
+    public var bio: String? // CloudKit: made optional or with default value
+    public var isProfilePublic: Bool = false // CloudKit: made optional or with default value
     public var skillLevel = GardeningSkillLevel.beginner // CloudKit: made optional or with default value
 
     // Onboarding preferences
@@ -61,6 +63,8 @@ public final class User {
         id = UUID()
         self.email = email
         self.displayName = displayName
+        bio = nil
+        isProfilePublic = false
         self.skillLevel = skillLevel
         preferredPlantTypes = []
         gardeningGoals = []

--- a/GrowWisePackage/Tests/GrowWiseFeatureTests/ClubMemberProfilePresentationTests.swift
+++ b/GrowWisePackage/Tests/GrowWiseFeatureTests/ClubMemberProfilePresentationTests.swift
@@ -60,9 +60,12 @@ struct ClubMemberProfilePresentationTests {
         user.bio = "Likes peppers."
         user.hardinessZone = "9a"
         user.gardens = [Garden(name: "Pepper Patch", gardenType: .raised)]
+        // Use a fixed memberID so the expected avatar letter is deterministic.
+        // First alphanumeric of "bce-member-99" is 'B'.
+        let fixedMemberID = "bce-member-99"
 
         let profile = ClubMemberProfile(
-            memberID: user.id.uuidString,
+            memberID: fixedMemberID,
             club: club,
             user: user,
             activities: [],
@@ -71,7 +74,7 @@ struct ClubMemberProfilePresentationTests {
 
         #expect(!profile.canShowPublicDetails)
         #expect(profile.displayName == "Club member")
-        #expect(profile.avatarLetters == "M")
+        #expect(profile.avatarLetters == "B")
         #expect(profile.bio == nil)
         #expect(profile.hardinessZone == nil)
         #expect(profile.plantCount == nil)

--- a/GrowWisePackage/Tests/GrowWiseFeatureTests/ClubMemberProfilePresentationTests.swift
+++ b/GrowWisePackage/Tests/GrowWiseFeatureTests/ClubMemberProfilePresentationTests.swift
@@ -1,0 +1,127 @@
+import Foundation
+@testable import GrowWiseFeature
+import GrowWiseModels
+import Testing
+
+@Suite("Club Member Profile Presentation")
+struct ClubMemberProfilePresentationTests {
+    @Test("Public member profile exposes opted-in profile details")
+    func publicMemberProfileExposesOptedInDetails() {
+        let club = GardenClub(name: "Backyard Growers", ownerID: "owner-1", inviteCode: "GROW42")
+        let joinedDate = Date(timeIntervalSince1970: 1_700_000_000)
+        club.createdDate = joinedDate
+
+        let user = User(email: "avery@example.com", displayName: "Avery Brooks")
+        user.isProfilePublic = true
+        user.bio = "Seed saver and patio tomato person."
+        user.hardinessZone = "7b"
+
+        let garden = Garden(name: "Patio Garden", gardenType: .container)
+        let plant = Plant(name: "Sungold Tomato", plantType: .vegetable)
+        garden.plants = [plant]
+        user.gardens = [garden]
+        club.memberIDs = ["owner-1", user.id.uuidString]
+        club.sharedGardenIDs = [garden.id?.uuidString ?? "missing"]
+
+        let activities = makeActivities(
+            clubID: club.id ?? UUID(),
+            memberID: user.id.uuidString,
+            memberName: "Avery Brooks"
+        )
+
+        let profile = ClubMemberProfile(
+            memberID: user.id.uuidString,
+            club: club,
+            user: user,
+            activities: activities,
+            currentUserID: "other-member"
+        )
+
+        #expect(profile.canShowPublicDetails)
+        #expect(profile.displayName == "Avery Brooks")
+        #expect(profile.avatarLetters == "AB")
+        #expect(profile.bio == "Seed saver and patio tomato person.")
+        #expect(profile.hardinessZone == "7b")
+        #expect(profile.memberSinceDate == joinedDate)
+        #expect(profile.plantCount == 1)
+        #expect(profile.publicGardenCount == 1)
+        #expect(profile.recentContributions.map { $0.activityDescription ?? "" } == [
+            "Newest update",
+            "Second update",
+            "Third update",
+        ])
+    }
+
+    @Test("Private member profile hides details from other members")
+    func privateMemberProfileHidesDetailsFromOtherMembers() {
+        let club = GardenClub(name: "Backyard Growers", ownerID: "owner-1", inviteCode: "GROW42")
+        let user = User(email: "mina@example.com", displayName: "Mina Patel")
+        user.isProfilePublic = false
+        user.bio = "Likes peppers."
+        user.hardinessZone = "9a"
+        user.gardens = [Garden(name: "Pepper Patch", gardenType: .raised)]
+
+        let profile = ClubMemberProfile(
+            memberID: user.id.uuidString,
+            club: club,
+            user: user,
+            activities: [],
+            currentUserID: "other-member"
+        )
+
+        #expect(!profile.canShowPublicDetails)
+        #expect(profile.displayName == "Club member")
+        #expect(profile.avatarLetters == "M")
+        #expect(profile.bio == nil)
+        #expect(profile.hardinessZone == nil)
+        #expect(profile.plantCount == nil)
+        #expect(profile.publicGardenCount == nil)
+        #expect(profile.recentContributions.isEmpty)
+    }
+
+    @Test("Current user can view their own private profile")
+    func currentUserCanViewOwnPrivateProfile() {
+        let club = GardenClub(name: "Backyard Growers", ownerID: "owner-1", inviteCode: "GROW42")
+        let user = User(email: "sam@example.com", displayName: "Sam Rivera")
+        user.isProfilePublic = false
+        user.hardinessZone = "6a"
+
+        let profile = ClubMemberProfile(
+            memberID: user.id.uuidString,
+            club: club,
+            user: user,
+            activities: [],
+            currentUserID: user.id.uuidString
+        )
+
+        #expect(profile.canShowPublicDetails)
+        #expect(profile.displayName == "Sam Rivera")
+        #expect(profile.hardinessZone == "6a")
+        #expect(profile.isCurrentUser)
+    }
+
+    private func makeActivities(
+        clubID: UUID,
+        memberID: String,
+        memberName: String
+    ) -> [ClubActivity] {
+        let descriptions = [
+            "Oldest update",
+            "Third update",
+            "Second update",
+            "Newest update",
+        ]
+
+        return descriptions.enumerated().map { offset, description in
+            let activity = ClubActivity(
+                clubID: clubID,
+                memberName: memberName,
+                memberID: memberID,
+                activityType: "shared",
+                description: description
+            )
+            activity.timestamp = Date(timeIntervalSince1970: TimeInterval(offset))
+            return activity
+        }
+    }
+}

--- a/GrowWisePackage/Tests/GrowWiseModelsTests/UserTests.swift
+++ b/GrowWisePackage/Tests/GrowWiseModelsTests/UserTests.swift
@@ -17,6 +17,8 @@ struct UserTests {
         // Assert
         #expect(user.email == email)
         #expect(user.displayName == displayName)
+        #expect(user.bio == nil)
+        #expect(user.isProfilePublic == false)
         #expect(user.skillLevel == skillLevel)
         #expect(user.id != UUID())
         #expect(user.subscriptionTier == .free)


### PR DESCRIPTION
## Summary\n- add privacy-gated club member profile presentation and sheet from ClubDetailView member rows\n- add additive User profile fields for bio and public-profile opt-in\n- show member stats and latest 3 club contributions when profile details are visible\n\nCloses #358.\n\n## Verification\n- swiftlint lint --strict --config .swiftlint.yml\n- swiftformat --lint --config .swiftformat GrowWisePackage/Sources/GrowWiseModels/User.swift GrowWisePackage/Sources/GrowWiseFeature/Views/GardenClub/ActivityRowView.swift GrowWisePackage/Sources/GrowWiseFeature/Views/GardenClub/ClubDetailView.swift GrowWisePackage/Sources/GrowWiseFeature/Views/GardenClub/ClubMemberProfile.swift GrowWisePackage/Sources/GrowWiseFeature/Views/GardenClub/ClubMemberProfileView.swift GrowWisePackage/Tests/GrowWiseFeatureTests/ClubMemberProfilePresentationTests.swift GrowWisePackage/Tests/GrowWiseModelsTests/UserTests.swift\n- ssh mac-mini "cd ~/Projects/GrowWise/GrowWisePackage && swift test --filter ClubMemberProfilePresentationTests"\n- ssh mac-mini "cd ~/Projects/GrowWise/GrowWisePackage && swift test --filter UserTests"\n- ssh mac-mini "cd ~/Projects/GrowWise/GrowWisePackage && swift build"\n- ssh mac-mini "cd ~/Projects/GrowWise && xcodebuild -workspace GrowWise.xcworkspace -scheme GrowWise -sdk iphonesimulator build CODE_SIGN_IDENTITY='' CODE_SIGNING_REQUIRED=NO"\n\n## Note\nFull swift test currently fails outside this change in OnboardingAnalyticsTracker UserDefaults/shared-state tests.