### PR TITLE
Expand tutorials and planting education

### DIFF
--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/HomeView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/HomeView.swift
@@ -17,11 +17,14 @@ public struct HomeView: View {
     private var router
     @Environment(NotificationService.self)
     private var notificationService
+    @Environment(TutorialService.self)
+    private var tutorialService
 
     @State private var viewModel = HomeViewModel()
     @State private var showCareShareSheet = false
     @State private var careShareCaption = ""
     @State private var showSeasonalPlanner = false
+    @State private var showTutorials = false
 
     public init() {}
 
@@ -66,6 +69,15 @@ public struct HomeView: View {
                         SeedStartCard(seeds: viewModel.readyToPlantSeeds, zone: viewModel.hardinessZone)
                             .padding(.horizontal, CultivationTheme.Spacing.screenPadding)
                     }
+
+                    Button {
+                        showTutorials = true
+                    } label: {
+                        learningCard
+                    }
+                    .buttonStyle(.plain)
+                    .padding(.horizontal, CultivationTheme.Spacing.screenPadding)
+                    .accessibilityIdentifier("home_button_learning_hub")
 
                     Button {
                         showSeasonalPlanner = true
@@ -121,6 +133,9 @@ public struct HomeView: View {
                 SeasonalPlannerView()
                     .environment(dataService)
                     .environment(locationService)
+            }
+            .sheet(isPresented: $showTutorials) {
+                TutorialsView()
             }
             .accessibilityIdentifier("home_screen")
         }
@@ -183,8 +198,66 @@ public struct HomeView: View {
             router.selectedTab = .garden
 
         case .startTutorial:
-            router.selectedTab = .profile
+            showTutorials = true
         }
+    }
+
+    private var learningCard: some View {
+        let guide = Array(tutorialService.getPlantingGuide().prefix(3))
+
+        return VStack(alignment: .leading, spacing: 12) {
+            HStack(spacing: 10) {
+                IconBubble(
+                    systemName: "book.pages.fill",
+                    color: CultivationTheme.Colors.brandLeaf,
+                    size: 40,
+                    iconSize: 17
+                )
+
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(TutorialView.homeLearningCardTitle)
+                        .font(CultivationTheme.Fonts.display(16, weight: .semibold))
+                        .foregroundStyle(CultivationTheme.Colors.textPrimary)
+
+                    Text(learningCardSubtitle(for: guide))
+                        .font(CultivationTheme.Fonts.body(12))
+                        .foregroundStyle(CultivationTheme.Colors.textSecondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                Spacer()
+
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(CultivationTheme.Colors.textTertiary)
+            }
+
+            if !guide.isEmpty {
+                HStack(spacing: 6) {
+                    ForEach(guide, id: \.id) { item in
+                        Text(item.plantName)
+                            .font(CultivationTheme.Fonts.body(11, weight: .semibold))
+                            .foregroundStyle(CultivationTheme.Colors.brandForest)
+                            .padding(.horizontal, 9)
+                            .padding(.vertical, 5)
+                            .background(
+                                Capsule()
+                                    .fill(CultivationTheme.Colors.brandLeaf.opacity(0.12))
+                            )
+                    }
+                }
+            }
+        }
+        .padding(CultivationTheme.Spacing.cardPadding)
+        .paperCard()
+        .accessibilityIdentifier("home_card_learning_hub")
+    }
+
+    private func learningCardSubtitle(for guide: [PlantingGuideItem]) -> String {
+        guard !guide.isEmpty else {
+            return "Open the beginner path for seasonal lessons and garden basics."
+        }
+        return "Start with \(guide[0].action.displayName.lowercased()) guidance and beginner lessons."
     }
 
     private func careTaskRow(_ reminder: PlantReminder) -> some View {
@@ -611,6 +684,9 @@ private struct HomeClubPlaceholderCard: View {
     let dataService = try! DataService()
     HomeView()
         .environment(dataService)
+        .environment(LocationService())
+        .environment(NotificationService())
+        .environment(TutorialService(dataService: dataService))
         .environment(AppRouter())
 }
 

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/ProfileView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/ProfileView.swift
@@ -212,7 +212,7 @@ public struct ProfileView: View {
             menuRow(
                 icon: "book.fill",
                 color: .blue,
-                title: "Tutorials",
+                title: "Guides & Tutorials",
                 id: "profile_row_tutorials"
             ) {
                 showTutorials = true

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/Tutorials/TutorialDetailView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/Tutorials/TutorialDetailView.swift
@@ -1,0 +1,227 @@
+import GrowWiseServices
+import SwiftUI
+
+public struct TutorialDetailView: View {
+    let tutorial: TutorialTopic
+    let tutorialService: TutorialService
+
+    @State private var progress: TutorialProgress
+
+    public init(tutorial: TutorialTopic, tutorialService: TutorialService) {
+        self.tutorial = tutorial
+        self.tutorialService = tutorialService
+        _progress = State(initialValue: tutorialService.getTutorialProgress(tutorialId: tutorial.id))
+    }
+
+    public var body: some View {
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: CultivationTheme.Spacing.sectionGap) {
+                header
+                stepList
+            }
+            .padding(.horizontal, CultivationTheme.Spacing.screenPadding)
+            .padding(.vertical, CultivationTheme.Spacing.sectionGap)
+        }
+        .background(CultivationTheme.Colors.background)
+        .navigationTitle(tutorial.title)
+        .gwNavigationBarTitleDisplayMode(.inline)
+        .accessibilityIdentifier("tutorialdetail_screen_\(tutorial.id)")
+        .onAppear {
+            refreshProgress()
+        }
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            HStack(alignment: .top, spacing: 12) {
+                IconBubble(
+                    systemName: tutorial.category.iconName,
+                    color: CultivationTheme.Colors.brandLeaf,
+                    size: 46,
+                    iconSize: 20
+                )
+
+                VStack(alignment: .leading, spacing: 5) {
+                    Text(tutorial.title)
+                        .font(CultivationTheme.Fonts.display(25, weight: .semibold))
+                        .foregroundStyle(CultivationTheme.Colors.textPrimary)
+                        .fixedSize(horizontal: false, vertical: true)
+
+                    Text(tutorial.subtitle)
+                        .font(CultivationTheme.Fonts.body(14))
+                        .foregroundStyle(CultivationTheme.Colors.textSecondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+
+            Text(tutorial.description)
+                .font(CultivationTheme.Fonts.body(14))
+                .foregroundStyle(CultivationTheme.Colors.textSecondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            VStack(alignment: .leading, spacing: 8) {
+                HStack {
+                    TutorialMetadata(
+                        difficulty: tutorial.difficultyLevel,
+                        duration: tutorial.estimatedDuration,
+                        progress: progress
+                    )
+
+                    Spacer()
+
+                    Text("\(progress.completedSteps)/\(progress.totalSteps)")
+                        .font(CultivationTheme.Fonts.body(12, weight: .semibold))
+                        .foregroundStyle(CultivationTheme.Colors.textTertiary)
+                }
+
+                ProgressView(value: Double(progress.completedSteps), total: Double(max(progress.totalSteps, 1)))
+                    .tint(CultivationTheme.Colors.brandLeaf)
+            }
+        }
+        .padding(CultivationTheme.Spacing.cardPadding)
+        .paperCard()
+        .accessibilityIdentifier("tutorialdetail_card_header")
+    }
+
+    private var stepList: some View {
+        VStack(alignment: .leading, spacing: CultivationTheme.Spacing.rowGap) {
+            Text("STEPS")
+                .sectionLabelStyle()
+                .foregroundStyle(CultivationTheme.Colors.sectionLabel)
+
+            ForEach(Array(tutorial.steps.enumerated()), id: \.offset) { index, step in
+                TutorialStepCard(
+                    tutorialId: tutorial.id,
+                    index: index,
+                    step: step,
+                    isCompleted: tutorialService.isStepCompleted(tutorialId: tutorial.id, stepIndex: index)
+                ) {
+                    tutorialService.markStepComplete(tutorialId: tutorial.id, stepIndex: index)
+                    refreshProgress()
+                }
+            }
+        }
+    }
+
+    private func refreshProgress() {
+        progress = tutorialService.getTutorialProgress(tutorialId: tutorial.id)
+    }
+}
+
+private struct TutorialStepCard: View {
+    let tutorialId: String
+    let index: Int
+    let step: TutorialStep
+    let isCompleted: Bool
+    let completeAction: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(alignment: .top, spacing: 10) {
+                Text("\(index + 1)")
+                    .font(CultivationTheme.Fonts.display(15, weight: .semibold))
+                    .foregroundStyle(Color.white)
+                    .frame(width: 30, height: 30)
+                    .background(Circle().fill(stepNumberColor))
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(step.title)
+                        .font(CultivationTheme.Fonts.display(18, weight: .semibold))
+                        .foregroundStyle(CultivationTheme.Colors.textPrimary)
+                        .fixedSize(horizontal: false, vertical: true)
+
+                    Text("\(step.duration) min")
+                        .font(CultivationTheme.Fonts.body(11, weight: .medium))
+                        .foregroundStyle(CultivationTheme.Colors.textTertiary)
+                }
+
+                Spacer()
+
+                if isCompleted {
+                    Image(systemName: "checkmark.circle.fill")
+                        .font(.system(size: 20, weight: .semibold))
+                        .foregroundStyle(CultivationTheme.Colors.statusHealthy)
+                }
+            }
+
+            Text(step.content)
+                .font(CultivationTheme.Fonts.body(14))
+                .foregroundStyle(CultivationTheme.Colors.textSecondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            if !step.tips.isEmpty {
+                guidanceList(title: "Tips", icon: "leaf.fill", items: step.tips)
+            }
+
+            if !step.commonMistakes.isEmpty {
+                guidanceList(title: "Avoid", icon: "exclamationmark.triangle.fill", items: step.commonMistakes)
+            }
+
+            Button {
+                completeAction()
+            } label: {
+                Label(isCompleted ? "Completed" : "Mark Complete", systemImage: isCompleted ? "checkmark" : "circle")
+                    .font(CultivationTheme.Fonts.body(14, weight: .semibold))
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 11)
+                    .foregroundStyle(isCompleted ? CultivationTheme.Colors.brandLeaf : Color.white)
+                    .background {
+                        RoundedRectangle(cornerRadius: CultivationTheme.Radius.button)
+                            .fill(isCompleted ? CultivationTheme.Colors.backgroundSecondary : CultivationTheme.Colors.brandForest)
+                    }
+            }
+            .buttonStyle(.plain)
+            .disabled(isCompleted)
+            .accessibilityIdentifier("tutorialdetail_button_step_\(index)")
+        }
+        .padding(CultivationTheme.Spacing.cardPadding)
+        .paperCard()
+        .accessibilityIdentifier("tutorialdetail_card_step_\(index)")
+    }
+
+    private func guidanceList(title: String, icon: String, items: [String]) -> some View {
+        VStack(alignment: .leading, spacing: 7) {
+            HStack(spacing: 6) {
+                Image(systemName: icon)
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(CultivationTheme.Colors.accentCoral)
+                Text(title.uppercased())
+                    .font(CultivationTheme.Fonts.body(11, weight: .semibold))
+                    .foregroundStyle(CultivationTheme.Colors.textTertiary)
+            }
+
+            ForEach(items, id: \.self) { item in
+                HStack(alignment: .top, spacing: 7) {
+                    Circle()
+                        .fill(CultivationTheme.Colors.brandLeaf)
+                        .frame(width: 4, height: 4)
+                        .padding(.top, 7)
+
+                    Text(item)
+                        .font(CultivationTheme.Fonts.body(12))
+                        .foregroundStyle(CultivationTheme.Colors.textSecondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+        }
+        .padding(10)
+        .background(
+            RoundedRectangle(cornerRadius: CultivationTheme.Radius.icon)
+                .fill(CultivationTheme.Colors.backgroundSecondary)
+        )
+    }
+
+    private var stepNumberColor: Color {
+        isCompleted ? CultivationTheme.Colors.statusHealthy : CultivationTheme.Colors.brandForest
+    }
+}
+
+#Preview {
+    let dataService = DataService.createFallback()
+    let tutorialService = TutorialService(dataService: dataService)
+    let tutorial = TutorialContent.allTutorials[0]
+
+    NavigationStack {
+        TutorialDetailView(tutorial: tutorial, tutorialService: tutorialService)
+    }
+}

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/Tutorials/TutorialView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/Tutorials/TutorialView.swift
@@ -3,6 +3,9 @@ import GrowWiseServices
 import SwiftUI
 
 public struct TutorialView: View {
+    public nonisolated static let learningHubTitle = "Learn & Grow"
+    public nonisolated static let homeLearningCardTitle = "Learn what to plant now"
+
     @Environment(TutorialService.self)
     private var tutorialService
     @State private var selectedCategory: TutorialCategory = .planning
@@ -13,28 +16,19 @@ public struct TutorialView: View {
 
     public var body: some View {
         NavigationStack {
-            VStack(spacing: 0) {
-                // Category Selector
-                categorySelector
-
-                // Tutorials Content
-                ScrollView {
-                    LazyVStack(spacing: 20) {
-                        // Featured Tutorial Section
-                        if selectedCategory == .planning {
-                            featuredTutorialSection
-                        }
-
-                        // Quick Progress Summary
-                        progressSummaryCard
-
-                        // Tutorial List
-                        tutorialListSection
-                    }
-                    .padding()
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: CultivationTheme.Spacing.sectionGap) {
+                    heroSection
+                    plantingGuideSection
+                    beginnerPathSection
+                    categorySelector
+                    tutorialListSection
                 }
+                .padding(.horizontal, CultivationTheme.Spacing.screenPadding)
+                .padding(.vertical, CultivationTheme.Spacing.sectionGap)
             }
-            .navigationTitle("Learn & Grow")
+            .background(CultivationTheme.Colors.background)
+            .navigationTitle(Self.learningHubTitle)
             .toolbar {
                 ToolbarItem(placement: .primaryAction) {
                     Button {
@@ -42,97 +36,243 @@ public struct TutorialView: View {
                     } label: {
                         Image(systemName: "chart.bar.fill")
                     }
+                    .accessibilityLabel("Learning progress")
                     .accessibilityIdentifier("tutorials_button_progress")
                 }
+            }
+            .navigationDestination(for: TutorialTopic.self) { tutorial in
+                TutorialDetailView(tutorial: tutorial, tutorialService: tutorialService)
             }
             .sheet(isPresented: $showProgressView) {
                 TutorialProgressView(tutorialService: tutorialService)
             }
-        }
-        .searchable(text: $searchText, prompt: "Search tutorials...")
-    }
-
-    private var categorySelector: some View {
-        ScrollView(.horizontal, showsIndicators: false) {
-            LazyHStack(spacing: 12) {
-                ForEach(TutorialCategory.allCases, id: \.self) { category in
-                    CategoryChip(
-                        category: category,
-                        isSelected: selectedCategory == category
-                    ) {
-                        selectedCategory = category
-                    }
-                }
-            }
-            .padding(.horizontal)
-        }
-        .padding(.vertical, 8)
-        .background(Color(.systemGray6))
-    }
-
-    private var featuredTutorialSection: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            Text("Start Here")
-                .font(.headline)
-                .foregroundColor(.primary)
-
-            let featuredTutorial = tutorialService.getAllTutorials().first(where: { $0.id == "getting-started-indoor-plants" })
-
-            if let tutorial = featuredTutorial {
-                FeaturedTutorialCard(tutorial: tutorial, tutorialService: tutorialService)
-            }
+            .searchable(text: $searchText, prompt: "Search tutorials")
+            .accessibilityIdentifier("tutorials_screen")
         }
     }
 
-    private var progressSummaryCard: some View {
+    private var heroSection: some View {
         let analytics = tutorialService.getTutorialAnalytics()
 
-        return HStack {
-            VStack(alignment: .leading, spacing: 4) {
-                Text("Your Progress")
-                    .font(.headline)
-                    .foregroundColor(.primary)
+        return VStack(alignment: .leading, spacing: 14) {
+            HStack(alignment: .top, spacing: 12) {
+                IconBubble(
+                    systemName: "graduationcap.fill",
+                    color: CultivationTheme.Colors.brandLeaf,
+                    size: 46,
+                    iconSize: 20
+                )
 
-                Text("\(analytics.completedTutorials) of \(analytics.totalTutorials) tutorials completed")
-                    .font(.subheadline)
-                    .foregroundColor(.secondary)
+                VStack(alignment: .leading, spacing: 5) {
+                    Text(Self.learningHubTitle)
+                        .font(CultivationTheme.Fonts.display(26, weight: .semibold))
+                        .foregroundStyle(CultivationTheme.Colors.textPrimary)
+
+                    Text("Seasonal guidance, beginner lessons, and practical next steps for your garden.")
+                        .font(CultivationTheme.Fonts.body(14))
+                        .foregroundStyle(CultivationTheme.Colors.textSecondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
             }
 
-            Spacer()
-
-            CircularProgressView(
-                progress: analytics.totalTutorials > 0
-                    ? Double(analytics.completedTutorials) / Double(analytics.totalTutorials)
-                    : 0
-            )
-            .frame(width: 50, height: 50)
+            HStack(spacing: 10) {
+                learningStat(
+                    value: "\(analytics.completedTutorials)",
+                    label: "Done",
+                    icon: "checkmark.circle.fill"
+                )
+                learningStat(
+                    value: "\(analytics.totalTutorials - analytics.completedTutorials)",
+                    label: "To Learn",
+                    icon: "book.closed.fill"
+                )
+                learningStat(
+                    value: "\(Int(analytics.completionRate * 100))%",
+                    label: "Progress",
+                    icon: "chart.line.uptrend.xyaxis"
+                )
+            }
         }
-        .padding()
-        .background(Color(.systemGray6))
-        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .padding(CultivationTheme.Spacing.cardPadding)
+        .paperCard()
+        .accessibilityIdentifier("tutorials_card_hero")
     }
 
-    private var tutorialListSection: some View {
-        VStack(alignment: .leading, spacing: 16) {
+    private func learningStat(value: String, label: String, icon: String) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Image(systemName: icon)
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(CultivationTheme.Colors.accentCoral)
+            Text(value)
+                .font(CultivationTheme.Fonts.display(18, weight: .semibold))
+                .foregroundStyle(CultivationTheme.Colors.textPrimary)
+            Text(label)
+                .font(CultivationTheme.Fonts.body(11))
+                .foregroundStyle(CultivationTheme.Colors.textTertiary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(10)
+        .background(
+            RoundedRectangle(cornerRadius: CultivationTheme.Radius.icon)
+                .fill(CultivationTheme.Colors.backgroundSecondary)
+        )
+    }
+
+    private var plantingGuideSection: some View {
+        let guide = tutorialService.getPlantingGuide().prefix(6)
+
+        return VStack(alignment: .leading, spacing: CultivationTheme.Spacing.rowGap) {
             HStack {
-                Text(selectedCategory.displayName)
-                    .font(.headline)
-                    .foregroundColor(.primary)
+                Text("WHAT TO PLANT NOW")
+                    .sectionLabelStyle()
+                    .foregroundStyle(CultivationTheme.Colors.sectionLabel)
 
                 Spacer()
 
-                Text("\(filteredTutorials.count) tutorials")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
+                Text(currentMonthName)
+                    .font(CultivationTheme.Fonts.body(12, weight: .semibold))
+                    .foregroundStyle(CultivationTheme.Colors.textTertiary)
             }
 
-            LazyVStack(spacing: 12) {
+            if guide.isEmpty {
+                emptyPlantingGuideCard
+            } else {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(alignment: .top, spacing: 12) {
+                        ForEach(Array(guide), id: \.id) { item in
+                            plantingGuideCard(item)
+                        }
+                    }
+                    .scrollTargetLayout()
+                }
+                .scrollTargetBehavior(.viewAligned)
+            }
+        }
+    }
+
+    private var emptyPlantingGuideCard: some View {
+        HStack(spacing: 12) {
+            IconBubble(
+                systemName: "calendar.badge.clock",
+                color: CultivationTheme.Colors.textTertiary,
+                size: 40,
+                iconSize: 17
+            )
+
+            Text("No planting windows are highlighted for this month. Browse the beginner path for prep work.")
+                .font(CultivationTheme.Fonts.body(13))
+                .foregroundStyle(CultivationTheme.Colors.textSecondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(CultivationTheme.Spacing.cardPadding)
+        .paperCard()
+        .accessibilityIdentifier("tutorials_card_planting_empty")
+    }
+
+    private func plantingGuideCard(_ item: PlantingGuideItem) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 8) {
+                IconBubble(
+                    systemName: item.action.icon,
+                    color: item.beginnerFriendly
+                        ? CultivationTheme.Colors.brandLeaf
+                        : CultivationTheme.Colors.accentAmber,
+                    size: 34,
+                    iconSize: 15
+                )
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(item.plantName)
+                        .font(CultivationTheme.Fonts.display(17, weight: .semibold))
+                        .foregroundStyle(CultivationTheme.Colors.textPrimary)
+                        .lineLimit(1)
+
+                    Text(item.action.displayName)
+                        .font(CultivationTheme.Fonts.body(12, weight: .semibold))
+                        .foregroundStyle(CultivationTheme.Colors.accentCoral)
+                }
+            }
+
+            Text(item.whyNow)
+                .font(CultivationTheme.Fonts.body(12))
+                .foregroundStyle(CultivationTheme.Colors.textSecondary)
+                .lineLimit(3)
+                .fixedSize(horizontal: false, vertical: true)
+
+            Text(item.nextStep)
+                .font(CultivationTheme.Fonts.body(11))
+                .foregroundStyle(CultivationTheme.Colors.textTertiary)
+                .lineLimit(3)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .frame(width: 230, alignment: .leading)
+        .padding(CultivationTheme.Spacing.cardPadding)
+        .paperCard()
+        .accessibilityIdentifier("tutorials_card_planting_\(item.id)")
+    }
+
+    private var beginnerPathSection: some View {
+        VStack(alignment: .leading, spacing: CultivationTheme.Spacing.rowGap) {
+            Text("BEGINNER PATH")
+                .sectionLabelStyle()
+                .foregroundStyle(CultivationTheme.Colors.sectionLabel)
+
+            LazyVStack(spacing: 10) {
+                ForEach(Array(tutorialService.getBeginnerLearningPath().enumerated()), id: \.element.id) { index, tutorial in
+                    NavigationLink(value: tutorial) {
+                        BeginnerPathRow(index: index + 1, tutorial: tutorial, tutorialService: tutorialService)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityIdentifier("tutorials_row_beginner_\(tutorial.id)")
+                }
+            }
+        }
+    }
+
+    private var categorySelector: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("BROWSE BY TOPIC")
+                .sectionLabelStyle()
+                .foregroundStyle(CultivationTheme.Colors.sectionLabel)
+
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 8) {
+                    ForEach(TutorialCategory.allCases, id: \.self) { category in
+                        CategoryChip(
+                            category: category,
+                            isSelected: selectedCategory == category
+                        ) {
+                            withAnimation(CultivationTheme.Animation.selection) {
+                                selectedCategory = category
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private var tutorialListSection: some View {
+        VStack(alignment: .leading, spacing: CultivationTheme.Spacing.rowGap) {
+            HStack {
+                Text(selectedCategory.displayName.uppercased())
+                    .sectionLabelStyle()
+                    .foregroundStyle(CultivationTheme.Colors.sectionLabel)
+
+                Spacer()
+
+                Text("\(filteredTutorials.count)")
+                    .font(CultivationTheme.Fonts.body(12, weight: .semibold))
+                    .foregroundStyle(CultivationTheme.Colors.textTertiary)
+            }
+
+            LazyVStack(spacing: 10) {
                 ForEach(filteredTutorials, id: \.id) { tutorial in
                     NavigationLink(value: tutorial) {
                         TutorialRowView(tutorial: tutorial, tutorialService: tutorialService)
                     }
                     .buttonStyle(.plain)
-                    .accessibilityIdentifier("tutorials_link_row_\(tutorial.id)")
+                    .accessibilityIdentifier("tutorials_row_\(tutorial.id)")
                 }
             }
         }
@@ -140,10 +280,7 @@ public struct TutorialView: View {
 
     private var filteredTutorials: [TutorialTopic] {
         let categoryTutorials = tutorialService.getAllTutorials().filter { $0.category == selectedCategory }
-
-        if searchText.isEmpty {
-            return categoryTutorials
-        }
+        guard !searchText.isEmpty else { return categoryTutorials }
 
         let lowercasedSearch = searchText.lowercased()
         return categoryTutorials.filter { tutorial in
@@ -152,141 +289,60 @@ public struct TutorialView: View {
                 tutorial.subtitle.lowercased().contains(lowercasedSearch)
         }
     }
+
+    private var currentMonthName: String {
+        let month = Calendar.current.component(.month, from: Date())
+        return Calendar.current.monthSymbols[month - 1]
+    }
 }
 
-// MARK: - Supporting Views
-
-struct CategoryChip: View {
+private struct CategoryChip: View {
     let category: TutorialCategory
     let isSelected: Bool
     let action: () -> Void
 
     var body: some View {
         Button(action: action) {
-            HStack(spacing: 4) {
+            HStack(spacing: 5) {
                 Image(systemName: category.iconName)
-                    .font(.caption)
+                    .font(.system(size: 12, weight: .semibold))
                 Text(category.displayName)
-                    .font(.caption)
-                    .fontWeight(.medium)
+                    .font(CultivationTheme.Fonts.body(12, weight: .semibold))
             }
             .padding(.horizontal, 12)
             .padding(.vertical, 8)
-            .background(isSelected ? Color.blue : Color(.systemGray5))
-            .foregroundColor(isSelected ? .white : .primary)
-            .clipShape(RoundedRectangle(cornerRadius: 16))
+            .foregroundStyle(isSelected ? Color.white : CultivationTheme.Colors.textSecondary)
+            .background {
+                Capsule()
+                    .fill(isSelected ? CultivationTheme.Colors.brandForest : CultivationTheme.Colors.backgroundSecondary)
+            }
         }
+        .buttonStyle(.plain)
         .accessibilityIdentifier("tutorials_button_category_\(category.rawValue)")
     }
 }
 
-/// Add extension for TutorialCategory iconName
-extension TutorialCategory {
-    var iconName: String {
-        switch self {
-        case .planning: "map"
-        case .preparation: "wrench"
-        case .care: "heart.fill"
-        case .environment: "sun.max.fill"
-        case .problemSolving: "stethoscope"
-        }
-    }
-}
-
-struct FeaturedTutorialCard: View {
-    let tutorial: TutorialTopic
-    let tutorialService: TutorialService
-
-    var body: some View {
-        NavigationLink(value: tutorial) {
-            VStack(alignment: .leading, spacing: 12) {
-                HStack {
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text(tutorial.title)
-                            .font(.title3)
-                            .fontWeight(.semibold)
-                            .foregroundColor(.primary)
-
-                        Text(tutorial.subtitle)
-                            .font(.subheadline)
-                            .foregroundColor(.secondary)
-                            .lineLimit(2)
-                    }
-
-                    Spacer()
-
-                    Image(systemName: "arrow.right.circle.fill")
-                        .foregroundColor(.blue)
-                        .font(.title2)
-                }
-
-                HStack {
-                    TutorialMetadata(
-                        difficulty: tutorial.difficultyLevel,
-                        duration: tutorial.estimatedDuration,
-                        progress: tutorialService.getTutorialProgress(tutorialId: tutorial.id)
-                    )
-
-                    Spacer()
-
-                    Text("RECOMMENDED")
-                        .font(.caption)
-                        .fontWeight(.bold)
-                        .padding(.horizontal, 8)
-                        .padding(.vertical, 4)
-                        .background(Color.green.opacity(0.2))
-                        .foregroundColor(.green)
-                        .clipShape(RoundedRectangle(cornerRadius: 8))
-                }
-            }
-            .padding()
-            .background(
-                LinearGradient(
-                    colors: [Color.green.opacity(0.1), Color.mint.opacity(0.1)],
-                    startPoint: .topLeading,
-                    endPoint: .bottomTrailing
-                )
-            )
-            .clipShape(RoundedRectangle(cornerRadius: 12))
-            .overlay(
-                RoundedRectangle(cornerRadius: 12)
-                    .stroke(Color.green.opacity(0.3), lineWidth: 1)
-            )
-        }
-        .buttonStyle(.plain)
-        .accessibilityIdentifier("tutorials_link_featured_\(tutorial.id)")
-    }
-}
-
-struct TutorialRowView: View {
+private struct BeginnerPathRow: View {
+    let index: Int
     let tutorial: TutorialTopic
     let tutorialService: TutorialService
 
     var body: some View {
         HStack(alignment: .top, spacing: 12) {
-            // Difficulty indicator
-            RoundedRectangle(cornerRadius: 4)
-                .fill(difficultyColor)
-                .frame(width: 4, height: 60)
+            Text("\(index)")
+                .font(CultivationTheme.Fonts.display(16, weight: .semibold))
+                .foregroundStyle(Color.white)
+                .frame(width: 32, height: 32)
+                .background(Circle().fill(CultivationTheme.Colors.brandForest))
 
-            VStack(alignment: .leading, spacing: 8) {
-                HStack {
-                    Text(tutorial.title)
-                        .font(.headline)
-                        .foregroundColor(.primary)
+            VStack(alignment: .leading, spacing: 5) {
+                Text(tutorial.title)
+                    .font(CultivationTheme.Fonts.display(16, weight: .semibold))
+                    .foregroundStyle(CultivationTheme.Colors.textPrimary)
 
-                    Spacer()
-
-                    if tutorialService.getTutorialProgress(tutorialId: tutorial.id).isCompleted {
-                        Image(systemName: "checkmark.circle.fill")
-                            .foregroundColor(.green)
-                            .font(.title3)
-                    }
-                }
-
-                Text(tutorial.description)
-                    .font(.subheadline)
-                    .foregroundColor(.secondary)
+                Text(tutorial.subtitle)
+                    .font(CultivationTheme.Fonts.body(12))
+                    .foregroundStyle(CultivationTheme.Colors.textSecondary)
                     .lineLimit(2)
 
                 TutorialMetadata(
@@ -294,25 +350,69 @@ struct TutorialRowView: View {
                     duration: tutorial.estimatedDuration,
                     progress: tutorialService.getTutorialProgress(tutorialId: tutorial.id)
                 )
-
-                // Progress bar
-                let progress = tutorialService.getTutorialProgress(tutorialId: tutorial.id)
-                if progress.totalSteps > 0 {
-                    ProgressView(value: Double(progress.completedSteps), total: Double(progress.totalSteps))
-                        .tint(.blue)
-                }
             }
+
+            Spacer()
+
+            Image(systemName: "chevron.right")
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(CultivationTheme.Colors.textTertiary)
         }
-        .padding()
-        .background(Color(.systemGray6))
-        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .padding(CultivationTheme.Spacing.cardPadding)
+        .paperCard()
+    }
+}
+
+private struct TutorialRowView: View {
+    let tutorial: TutorialTopic
+    let tutorialService: TutorialService
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            IconBubble(
+                systemName: tutorial.category.iconName,
+                color: difficultyColor,
+                size: 38,
+                iconSize: 16
+            )
+
+            VStack(alignment: .leading, spacing: 6) {
+                HStack(spacing: 8) {
+                    Text(tutorial.title)
+                        .font(CultivationTheme.Fonts.display(16, weight: .semibold))
+                        .foregroundStyle(CultivationTheme.Colors.textPrimary)
+                        .lineLimit(2)
+
+                    if tutorialService.getTutorialProgress(tutorialId: tutorial.id).isCompleted {
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundStyle(CultivationTheme.Colors.statusHealthy)
+                            .font(.system(size: 16, weight: .semibold))
+                    }
+                }
+
+                Text(tutorial.description)
+                    .font(CultivationTheme.Fonts.body(12))
+                    .foregroundStyle(CultivationTheme.Colors.textSecondary)
+                    .lineLimit(2)
+
+                TutorialMetadata(
+                    difficulty: tutorial.difficultyLevel,
+                    duration: tutorial.estimatedDuration,
+                    progress: tutorialService.getTutorialProgress(tutorialId: tutorial.id)
+                )
+            }
+
+            Spacer()
+        }
+        .padding(CultivationTheme.Spacing.cardPadding)
+        .paperCard()
     }
 
     private var difficultyColor: Color {
         switch tutorial.difficultyLevel {
-        case .beginner: .green
-        case .intermediate: .orange
-        case .advanced: .red
+        case .beginner: CultivationTheme.Colors.brandLeaf
+        case .intermediate: CultivationTheme.Colors.accentAmber
+        case .advanced: CultivationTheme.Colors.accentCoral
         }
     }
 }
@@ -323,72 +423,49 @@ struct TutorialMetadata: View {
     let progress: TutorialProgress
 
     var body: some View {
-        HStack(spacing: 12) {
-            HStack(spacing: 4) {
-                Image(systemName: "graduationcap.fill")
-                    .font(.caption2)
-                Text(difficulty.displayName)
-                    .font(.caption2)
-            }
-            .foregroundColor(difficultyColor)
-
-            HStack(spacing: 4) {
-                Image(systemName: "clock.fill")
-                    .font(.caption2)
-                Text("\(duration) min")
-                    .font(.caption2)
-            }
-            .foregroundColor(.secondary)
+        HStack(spacing: 10) {
+            metadataPill(icon: "graduationcap.fill", text: difficulty.displayName, color: difficultyColor)
+            metadataPill(icon: "clock.fill", text: "\(duration) min", color: CultivationTheme.Colors.textTertiary)
 
             if progress.isCompleted {
-                HStack(spacing: 4) {
-                    Image(systemName: "checkmark.circle.fill")
-                        .font(.caption2)
-                    Text("Completed")
-                        .font(.caption2)
-                }
-                .foregroundColor(.green)
+                metadataPill(icon: "checkmark.circle.fill", text: "Complete", color: CultivationTheme.Colors.statusHealthy)
             } else if progress.completedSteps > 0 {
-                HStack(spacing: 4) {
-                    Image(systemName: "clock.arrow.circlepath")
-                        .font(.caption2)
-                    Text("\(progress.completedSteps)/\(progress.totalSteps)")
-                        .font(.caption2)
-                }
-                .foregroundColor(.blue)
+                metadataPill(
+                    icon: "clock.arrow.circlepath",
+                    text: "\(progress.completedSteps)/\(progress.totalSteps)",
+                    color: CultivationTheme.Colors.brandLeaf
+                )
             }
         }
+    }
+
+    private func metadataPill(icon: String, text: String, color: Color) -> some View {
+        HStack(spacing: 4) {
+            Image(systemName: icon)
+                .font(.system(size: 10, weight: .semibold))
+            Text(text)
+                .font(CultivationTheme.Fonts.body(11, weight: .medium))
+        }
+        .foregroundStyle(color)
     }
 
     private var difficultyColor: Color {
         switch difficulty {
-        case .beginner: .green
-        case .intermediate: .orange
-        case .advanced: .red
+        case .beginner: CultivationTheme.Colors.brandLeaf
+        case .intermediate: CultivationTheme.Colors.accentAmber
+        case .advanced: CultivationTheme.Colors.accentCoral
         }
     }
 }
 
-struct CircularProgressView: View {
-    let progress: Double
-
-    var body: some View {
-        ZStack {
-            Circle()
-                .stroke(lineWidth: 4)
-                .opacity(0.3)
-                .foregroundColor(.blue)
-
-            Circle()
-                .trim(from: 0.0, to: CGFloat(min(progress, 1.0)))
-                .stroke(style: StrokeStyle(lineWidth: 4, lineCap: .round, lineJoin: .round))
-                .foregroundColor(.blue)
-                .rotationEffect(Angle(degrees: 270.0))
-                .animation(.linear, value: progress)
-
-            Text(String(format: "%.0f%%", min(progress, 1.0) * 100.0))
-                .font(.caption2)
-                .fontWeight(.bold)
+extension TutorialCategory {
+    var iconName: String {
+        switch self {
+        case .planning: "map.fill"
+        case .preparation: "trowel.fill"
+        case .care: "heart.fill"
+        case .environment: "sun.max.fill"
+        case .problemSolving: "stethoscope"
         }
     }
 }

--- a/GrowWisePackage/Sources/GrowWiseServices/PlantingGuideCatalog.swift
+++ b/GrowWisePackage/Sources/GrowWiseServices/PlantingGuideCatalog.swift
@@ -1,0 +1,271 @@
+import Foundation
+import GrowWiseModels
+
+// MARK: - PlantingGuide
+
+public enum PlantingGuideAction: String, CaseIterable, Sendable, Hashable {
+    case startIndoors = "start_indoors"
+    case directSow = "direct_sow"
+    case transplant
+
+    public var displayName: String {
+        switch self {
+        case .startIndoors: "Start indoors"
+        case .directSow: "Direct sow"
+        case .transplant: "Transplant"
+        }
+    }
+
+    public var icon: String {
+        switch self {
+        case .startIndoors: "light.recessed.3.fill"
+        case .directSow: "sprout"
+        case .transplant: "arrow.up.right.and.arrow.down.left.rectangle.fill"
+        }
+    }
+
+    fileprivate var sortPriority: Int {
+        switch self {
+        case .startIndoors: 0
+        case .directSow: 1
+        case .transplant: 2
+        }
+    }
+}
+
+public struct PlantingGuideItem: Identifiable, Sendable, Hashable {
+    public let id: String
+    public let plantName: String
+    public let plantType: PlantType
+    public let action: PlantingGuideAction
+    public let month: Int
+    public let beginnerFriendly: Bool
+    public let timingSummary: String
+    public let whyNow: String
+    public let nextStep: String
+    public let tutorialID: String?
+
+    public init(
+        plantName: String,
+        plantType: PlantType,
+        action: PlantingGuideAction,
+        month: Int,
+        beginnerFriendly: Bool,
+        timingSummary: String,
+        whyNow: String,
+        nextStep: String,
+        tutorialID: String?
+    ) {
+        self.plantName = plantName
+        self.plantType = plantType
+        self.action = action
+        self.month = month
+        self.beginnerFriendly = beginnerFriendly
+        self.timingSummary = timingSummary
+        self.whyNow = whyNow
+        self.nextStep = nextStep
+        self.tutorialID = tutorialID
+        id = "\(action.rawValue)-\(plantName.lowercased().replacingOccurrences(of: " ", with: "-"))-\(month)"
+    }
+}
+
+enum PlantingGuideCatalog {
+    private struct Template {
+        let plantName: String
+        let plantType: PlantType
+        let beginnerFriendly: Bool
+        let startIndoorsMonths: [Int]
+        let directSowMonths: [Int]
+        let transplantMonths: [Int]
+        let timingSummary: String
+        let whyNow: String
+
+        func months(for action: PlantingGuideAction) -> [Int] {
+            switch action {
+            case .startIndoors: startIndoorsMonths
+            case .directSow: directSowMonths
+            case .transplant: transplantMonths
+            }
+        }
+
+        func nextStep(for action: PlantingGuideAction) -> String {
+            switch action {
+            case .startIndoors:
+                "Sow in a clean tray with bright light, gentle warmth, and labels for each variety."
+
+            case .directSow:
+                "Prepare a weed-free row, water first, sow at packet depth, and keep the bed evenly moist."
+
+            case .transplant:
+                "Harden seedlings off for 7 days, then transplant on a cloudy afternoon or calm evening."
+            }
+        }
+
+        func tutorialID(for action: PlantingGuideAction) -> String {
+            switch action {
+            case .startIndoors: "seed-starting-indoors"
+            case .directSow: "direct-sowing-basics"
+            case .transplant: "transplanting-hardening-off"
+            }
+        }
+    }
+
+    private static let templates: [Template] = [
+        Template(
+            plantName: "Tomato",
+            plantType: .vegetable,
+            beginnerFriendly: false,
+            startIndoorsMonths: [2, 3],
+            directSowMonths: [],
+            transplantMonths: [4, 5],
+            timingSummary: "Warm-season crop; start early indoors and transplant after frost risk passes.",
+            whyNow: "Tomatoes need a head start before warm nights arrive."
+        ),
+        Template(
+            plantName: "Pepper",
+            plantType: .vegetable,
+            beginnerFriendly: false,
+            startIndoorsMonths: [2, 3],
+            directSowMonths: [],
+            transplantMonths: [5],
+            timingSummary: "Warm-season crop; start indoors early and wait for warm soil before transplanting.",
+            whyNow: "Peppers grow slowly at first and reward an early indoor start."
+        ),
+        Template(
+            plantName: "Basil",
+            plantType: .herb,
+            beginnerFriendly: true,
+            startIndoorsMonths: [3, 4],
+            directSowMonths: [5, 6],
+            transplantMonths: [5],
+            timingSummary: "Tender herb; plant after nights are reliably warm.",
+            whyNow: "Basil is simple, fast, and useful for new gardeners."
+        ),
+        Template(
+            plantName: "Lettuce",
+            plantType: .vegetable,
+            beginnerFriendly: true,
+            startIndoorsMonths: [2, 3],
+            directSowMonths: [3, 4, 8, 9],
+            transplantMonths: [3, 4, 9],
+            timingSummary: "Cool-season crop; sow in spring and again for fall harvests.",
+            whyNow: "Lettuce germinates quickly and teaches harvest-as-you-grow confidence."
+        ),
+        Template(
+            plantName: "Carrot",
+            plantType: .vegetable,
+            beginnerFriendly: true,
+            startIndoorsMonths: [],
+            directSowMonths: [3, 4, 5, 8],
+            transplantMonths: [],
+            timingSummary: "Root crop; direct sow into loose soil instead of transplanting.",
+            whyNow: "Carrots are forgiving when soil stays moist through germination."
+        ),
+        Template(
+            plantName: "Radish",
+            plantType: .vegetable,
+            beginnerFriendly: true,
+            startIndoorsMonths: [],
+            directSowMonths: [3, 4, 5, 9],
+            transplantMonths: [],
+            timingSummary: "Fast cool-season crop; direct sow for a quick first harvest.",
+            whyNow: "Radishes show progress in weeks, which makes them ideal for beginners."
+        ),
+        Template(
+            plantName: "Kale",
+            plantType: .vegetable,
+            beginnerFriendly: true,
+            startIndoorsMonths: [2, 3, 7],
+            directSowMonths: [3, 4, 8, 9],
+            transplantMonths: [4, 8],
+            timingSummary: "Cool-season green; grows well in spring and again in fall.",
+            whyNow: "Kale tolerates cool weather and stays productive after light frosts."
+        ),
+        Template(
+            plantName: "Zucchini",
+            plantType: .vegetable,
+            beginnerFriendly: true,
+            startIndoorsMonths: [4],
+            directSowMonths: [5, 6],
+            transplantMonths: [5],
+            timingSummary: "Warm-season squash; plant after soil warms.",
+            whyNow: "Zucchini is vigorous and gives beginners visible daily growth."
+        ),
+        Template(
+            plantName: "Cucumber",
+            plantType: .vegetable,
+            beginnerFriendly: true,
+            startIndoorsMonths: [4],
+            directSowMonths: [5, 6],
+            transplantMonths: [5],
+            timingSummary: "Warm-season vine; sow or transplant after frost danger has passed.",
+            whyNow: "Cucumbers grow quickly once nights stay warm."
+        ),
+        Template(
+            plantName: "Marigold",
+            plantType: .flower,
+            beginnerFriendly: true,
+            startIndoorsMonths: [3, 4],
+            directSowMonths: [5],
+            transplantMonths: [5],
+            timingSummary: "Easy annual flower; start indoors or direct sow after frost.",
+            whyNow: "Marigolds add color and draw beneficial insects around vegetables."
+        ),
+    ]
+
+    static func items(for month: Int, zone: String?) -> [PlantingGuideItem] {
+        let normalizedMonth = normalizeMonth(month)
+        let zoneNum = extractZoneNumber(from: zone) ?? 7
+        let zoneOffset = max(-2, min(2, 7 - zoneNum))
+
+        return templates.flatMap { template in
+            PlantingGuideAction.allCases.compactMap { action in
+                let months = template.months(for: action)
+                guard !months.isEmpty else { return nil }
+                guard shifted(months, by: zoneOffset).contains(normalizedMonth) else { return nil }
+
+                return PlantingGuideItem(
+                    plantName: template.plantName,
+                    plantType: template.plantType,
+                    action: action,
+                    month: normalizedMonth,
+                    beginnerFriendly: template.beginnerFriendly,
+                    timingSummary: template.timingSummary,
+                    whyNow: template.whyNow,
+                    nextStep: template.nextStep(for: action),
+                    tutorialID: template.tutorialID(for: action)
+                )
+            }
+        }
+        .sorted { lhs, rhs in
+            if lhs.beginnerFriendly != rhs.beginnerFriendly {
+                return lhs.beginnerFriendly && !rhs.beginnerFriendly
+            }
+            if lhs.action.sortPriority != rhs.action.sortPriority {
+                return lhs.action.sortPriority < rhs.action.sortPriority
+            }
+            return lhs.plantName < rhs.plantName
+        }
+    }
+
+    private static func extractZoneNumber(from zone: String?) -> Int? {
+        guard let zone else { return nil }
+        let digits = zone.prefix(while: { $0.isNumber })
+        return Int(digits)
+    }
+
+    private static func shifted(_ months: [Int], by offset: Int) -> Set<Int> {
+        Set(months.map { month in
+            var shiftedMonth = month + offset
+            if shiftedMonth < 1 { shiftedMonth += 12 }
+            if shiftedMonth > 12 { shiftedMonth -= 12 }
+            return shiftedMonth
+        })
+    }
+
+    private static func normalizeMonth(_ month: Int) -> Int {
+        if month < 1 { return 1 }
+        if month > 12 { return 12 }
+        return month
+    }
+}

--- a/GrowWisePackage/Sources/GrowWiseServices/Resources/tutorials.json
+++ b/GrowWisePackage/Sources/GrowWiseServices/Resources/tutorials.json
@@ -363,5 +363,411 @@
         ]
       }
     ]
+  },
+  {
+    "id": "first-outdoor-garden",
+    "title": "Start Your First Outdoor Garden",
+    "subtitle": "Pick a small space, a few reliable crops, and a realistic first week",
+    "description": "Build a first outdoor garden that is easy to keep alive. Learn how to choose a site, start small, prepare soil, and avoid taking on too much at once.",
+    "difficultyLevel": "beginner",
+    "estimatedDuration": 24,
+    "category": "planning",
+    "relevantGardenTypes": ["all", "in_ground", "raised_bed", "container"],
+    "imageURL": "tutorial-first-outdoor-garden",
+    "steps": [
+      {
+        "title": "Choose One Manageable Spot",
+        "content": "Start with a bed, a few containers, or one sunny corner you can visit every day. A small garden that gets regular attention teaches more than a large garden that becomes hard to manage.",
+        "imageURL": "step-choose-garden-spot",
+        "duration": 7,
+        "tips": [
+          "Look for 6 or more hours of sun for vegetables and herbs",
+          "Keep the garden close to water",
+          "Leave walking space so you can reach every plant"
+        ],
+        "commonMistakes": [
+          "Starting with too much space",
+          "Choosing a spot that is hard to water"
+        ]
+      },
+      {
+        "title": "Pick Forgiving First Plants",
+        "content": "Choose fast, beginner-friendly plants that match the season. Lettuce, radishes, basil, kale, marigolds, cucumbers, and zucchini are strong first choices in the right window.",
+        "imageURL": "step-pick-first-plants",
+        "duration": 8,
+        "tips": [
+          "Grow two or three plant types your household will actually use",
+          "Mix one quick crop with one longer-season crop",
+          "Check the What to Plant This Month guide before buying seeds"
+        ],
+        "commonMistakes": [
+          "Buying every interesting seed packet",
+          "Starting with fussy crops before learning the basics"
+        ]
+      },
+      {
+        "title": "Prepare for the First Week",
+        "content": "Before planting, gather labels, compost, mulch, and a watering plan. The first week is about steady moisture, observation, and simple notes.",
+        "imageURL": "step-first-week-plan",
+        "duration": 9,
+        "tips": [
+          "Label everything on planting day",
+          "Water gently and deeply after sowing or transplanting",
+          "Take one photo so you can compare growth later"
+        ],
+        "commonMistakes": [
+          "Planting before supplies are ready",
+          "Forgetting what was planted where"
+        ]
+      }
+    ]
+  },
+  {
+    "id": "what-to-plant-this-month",
+    "title": "What to Plant This Month",
+    "subtitle": "Use your zone and season to choose a confident next crop",
+    "description": "Learn how Cultivation's monthly planting guidance works and how to choose between starting indoors, direct sowing, and transplanting.",
+    "difficultyLevel": "beginner",
+    "estimatedDuration": 18,
+    "category": "planning",
+    "relevantGardenTypes": ["all"],
+    "imageURL": "tutorial-what-to-plant",
+    "steps": [
+      {
+        "title": "Read the Action First",
+        "content": "Planting advice usually falls into three actions: start indoors, direct sow, or transplant. The action matters more than the plant name because each one changes the supplies and timing.",
+        "imageURL": "step-read-planting-action",
+        "duration": 5,
+        "tips": [
+          "Start indoors means trays, light, and labels",
+          "Direct sow means seeds go straight into prepared soil",
+          "Transplant means a seedling moves into its final growing spot"
+        ],
+        "commonMistakes": [
+          "Direct sowing crops that prefer an indoor head start",
+          "Transplanting before seedlings are hardened off"
+        ]
+      },
+      {
+        "title": "Match the Crop to Your Space",
+        "content": "A good monthly recommendation still needs to fit your garden. Lettuce can tuck into a small bed, while zucchini needs room to sprawl or a large container.",
+        "imageURL": "step-match-crop-space",
+        "duration": 6,
+        "tips": [
+          "Use compact crops for balconies and small beds",
+          "Give vines a trellis or plenty of room",
+          "Choose herbs when you want a low-risk first win"
+        ],
+        "commonMistakes": [
+          "Planting large crops too close together",
+          "Ignoring the plant's mature size"
+        ]
+      },
+      {
+        "title": "Plant One Step, Then Observe",
+        "content": "Beginners learn faster by planting one clear recommendation and watching it closely. After a week, note germination, moisture, and any pest pressure before adding more.",
+        "imageURL": "step-plant-observe",
+        "duration": 7,
+        "tips": [
+          "Check the bed daily until seeds sprout",
+          "Record the planting date",
+          "Add a reminder for watering or thinning"
+        ],
+        "commonMistakes": [
+          "Planting too many new crops in the same weekend",
+          "Skipping notes because the planting felt obvious"
+        ]
+      }
+    ]
+  },
+  {
+    "id": "seed-starting-indoors",
+    "title": "Seed Starting Indoors",
+    "subtitle": "Grow sturdy seedlings before outdoor conditions are ready",
+    "description": "Learn when to start seeds indoors, how to set up trays and light, and how to keep seedlings strong until transplant time.",
+    "difficultyLevel": "beginner",
+    "estimatedDuration": 28,
+    "category": "preparation",
+    "relevantGardenTypes": ["all"],
+    "imageURL": "tutorial-seed-starting",
+    "steps": [
+      {
+        "title": "Choose Seeds Worth Starting Early",
+        "content": "Tomatoes, peppers, basil, kale, and many flowers benefit from an indoor head start. Root crops like carrots usually do better when direct sown outside.",
+        "imageURL": "step-choose-indoor-seeds",
+        "duration": 7,
+        "tips": [
+          "Read seed packets for weeks before last frost",
+          "Start with one tray if this is your first season",
+          "Label varieties before watering"
+        ],
+        "commonMistakes": [
+          "Starting every seed indoors",
+          "Starting too early without enough light"
+        ]
+      },
+      {
+        "title": "Set Up Light and Moisture",
+        "content": "Seedlings need bright light close to the leaves and evenly moist mix. A sunny window can work for a few herbs, but a simple grow light is more reliable.",
+        "imageURL": "step-seed-light-moisture",
+        "duration": 11,
+        "tips": [
+          "Use seed-starting mix instead of heavy garden soil",
+          "Keep lights close enough to prevent leggy stems",
+          "Bottom-water trays when possible"
+        ],
+        "commonMistakes": [
+          "Letting seedlings stretch toward weak light",
+          "Keeping mix soggy instead of evenly moist"
+        ]
+      },
+      {
+        "title": "Thin and Feed Gently",
+        "content": "Once seedlings have true leaves, keep the strongest plant in each cell and begin gentle airflow. If growth slows, use a diluted seedling fertilizer.",
+        "imageURL": "step-thin-seedlings",
+        "duration": 10,
+        "tips": [
+          "Snip extra seedlings instead of pulling roots",
+          "Use a small fan for stronger stems",
+          "Wait for true leaves before light feeding"
+        ],
+        "commonMistakes": [
+          "Keeping crowded seedlings together too long",
+          "Feeding seedlings at full fertilizer strength"
+        ]
+      }
+    ]
+  },
+  {
+    "id": "direct-sowing-basics",
+    "title": "Direct Sowing Basics",
+    "subtitle": "Plant seeds straight into the garden with confidence",
+    "description": "Learn how to prepare soil, sow at the right depth, and keep outdoor seeds moist through germination.",
+    "difficultyLevel": "beginner",
+    "estimatedDuration": 22,
+    "category": "preparation",
+    "relevantGardenTypes": ["all", "in_ground", "raised_bed", "container"],
+    "imageURL": "tutorial-direct-sowing",
+    "steps": [
+      {
+        "title": "Prepare a Fine Seedbed",
+        "content": "Seeds sprout best when soil is loose, level, and free of large clumps. Water the bed before sowing so tiny seeds are not washed away afterward.",
+        "imageURL": "step-prepare-seedbed",
+        "duration": 7,
+        "tips": [
+          "Remove weeds before planting",
+          "Mix in compost if soil is compacted",
+          "Smooth the surface with your hand or rake"
+        ],
+        "commonMistakes": [
+          "Sowing into dry, crusted soil",
+          "Planting before removing weeds"
+        ]
+      },
+      {
+        "title": "Use the Right Depth",
+        "content": "A simple rule is to plant seeds about two times as deep as the seed is wide. Tiny lettuce seeds need shallow cover; larger beans and peas go deeper.",
+        "imageURL": "step-seed-depth",
+        "duration": 7,
+        "tips": [
+          "Check the packet depth when available",
+          "Press soil gently for good seed contact",
+          "Label the row before moving on"
+        ],
+        "commonMistakes": [
+          "Burying tiny seeds too deeply",
+          "Leaving seeds uncovered where birds can find them"
+        ]
+      },
+      {
+        "title": "Keep Moist Until Sprouting",
+        "content": "Outdoor seeds fail most often when the soil dries out during germination. Check daily and water gently until seedlings are established.",
+        "imageURL": "step-keep-seeds-moist",
+        "duration": 8,
+        "tips": [
+          "Use a gentle spray or watering rose",
+          "Mulch lightly after seedlings are visible",
+          "Thin crowded seedlings once true leaves appear"
+        ],
+        "commonMistakes": [
+          "Letting the top layer dry out",
+          "Blasting seeds out of place with a strong hose"
+        ]
+      }
+    ]
+  },
+  {
+    "id": "transplanting-hardening-off",
+    "title": "Transplanting and Hardening Off",
+    "subtitle": "Move seedlings outdoors without shocking them",
+    "description": "Learn how to harden seedlings off, choose a good transplant day, and help young plants recover quickly.",
+    "difficultyLevel": "beginner",
+    "estimatedDuration": 24,
+    "category": "care",
+    "relevantGardenTypes": ["all"],
+    "imageURL": "tutorial-transplanting",
+    "steps": [
+      {
+        "title": "Harden Off for One Week",
+        "content": "Seedlings raised indoors need gradual exposure to sun, wind, and cooler nights. Start with a sheltered hour or two outside and increase time each day.",
+        "imageURL": "step-harden-off",
+        "duration": 8,
+        "tips": [
+          "Begin in bright shade or morning light",
+          "Bring seedlings in during harsh wind or cold nights",
+          "Increase outdoor time gradually"
+        ],
+        "commonMistakes": [
+          "Moving seedlings from indoors to full sun in one day",
+          "Leaving tender seedlings out during a cold snap"
+        ]
+      },
+      {
+        "title": "Transplant at the Right Time",
+        "content": "A cloudy day, calm evening, or mild morning gives seedlings the least stress. Water seedlings before planting and handle roots gently.",
+        "imageURL": "step-transplant-time",
+        "duration": 8,
+        "tips": [
+          "Dig the hole before removing the seedling from its pot",
+          "Plant at the same depth unless the crop benefits from deeper planting",
+          "Firm soil gently around roots"
+        ],
+        "commonMistakes": [
+          "Transplanting in hot midday sun",
+          "Letting root balls dry out"
+        ]
+      },
+      {
+        "title": "Protect the First Few Days",
+        "content": "New transplants need steady moisture and protection while roots settle. Check daily for wilting, pests, and soil gaps around the stem.",
+        "imageURL": "step-transplant-aftercare",
+        "duration": 8,
+        "tips": [
+          "Water deeply right after planting",
+          "Use shade cloth or a cover during sudden heat",
+          "Mulch after the plant has settled"
+        ],
+        "commonMistakes": [
+          "Fertilizing heavily on transplant day",
+          "Ignoring wilting after the first watering"
+        ]
+      }
+    ]
+  },
+  {
+    "id": "succession-planting",
+    "title": "Succession Planting",
+    "subtitle": "Keep harvests coming by planting small rounds over time",
+    "description": "Learn how to avoid one giant harvest and keep easy crops producing across the season.",
+    "difficultyLevel": "beginner",
+    "estimatedDuration": 20,
+    "category": "planning",
+    "relevantGardenTypes": ["all"],
+    "imageURL": "tutorial-succession-planting",
+    "steps": [
+      {
+        "title": "Choose Crops That Repeat Well",
+        "content": "Lettuce, radishes, carrots, bush beans, cilantro, and baby greens are good succession crops. Plant a small amount, then repeat after a short interval.",
+        "imageURL": "step-repeat-crops",
+        "duration": 6,
+        "tips": [
+          "Start with one crop and one repeat date",
+          "Use quick crops for the easiest first attempt",
+          "Leave a little open space for the next sowing"
+        ],
+        "commonMistakes": [
+          "Filling every inch on the first planting day",
+          "Trying to succession plant slow crops first"
+        ]
+      },
+      {
+        "title": "Set a Simple Interval",
+        "content": "A 2-week interval works well for many fast crops. In hot weather, switch from cool-season greens to heat-tolerant crops or wait for a fall round.",
+        "imageURL": "step-simple-interval",
+        "duration": 7,
+        "tips": [
+          "Add a reminder for the next sowing",
+          "Write the sowing date on a label",
+          "Pause cool-season crops during intense heat"
+        ],
+        "commonMistakes": [
+          "Planting repeated rounds too close together",
+          "Ignoring seasonal heat limits"
+        ]
+      },
+      {
+        "title": "Clear and Replant Promptly",
+        "content": "When a short crop finishes, clear the row, add compost if needed, and replant. Succession planting works because space keeps moving.",
+        "imageURL": "step-clear-replant",
+        "duration": 7,
+        "tips": [
+          "Cut spent plants at soil level when roots are not diseased",
+          "Top-dress with compost between rounds",
+          "Rotate crop families when possible"
+        ],
+        "commonMistakes": [
+          "Leaving finished crops in place for weeks",
+          "Replanting into exhausted dry soil"
+        ]
+      }
+    ]
+  },
+  {
+    "id": "harvesting-basics",
+    "title": "Harvesting Basics",
+    "subtitle": "Pick at the right time and keep plants productive",
+    "description": "Learn when to harvest beginner crops, how to pick without damaging plants, and how harvesting can encourage more growth.",
+    "difficultyLevel": "beginner",
+    "estimatedDuration": 18,
+    "category": "care",
+    "relevantGardenTypes": ["all"],
+    "imageURL": "tutorial-harvesting",
+    "steps": [
+      {
+        "title": "Harvest Early and Often",
+        "content": "Many beginner crops taste best when harvested young. Regular picking can also encourage herbs, greens, beans, cucumbers, and zucchini to keep producing.",
+        "imageURL": "step-harvest-often",
+        "duration": 6,
+        "tips": [
+          "Pick leafy greens from the outside first",
+          "Harvest zucchini before they get oversized",
+          "Pinch basil above a leaf pair"
+        ],
+        "commonMistakes": [
+          "Waiting for every crop to become huge",
+          "Letting herbs flower before regular harvests"
+        ]
+      },
+      {
+        "title": "Use Clean Cuts",
+        "content": "Use clean scissors or pruners for herbs, flowers, and tender stems. Pulling can damage roots or break stems that would keep producing.",
+        "imageURL": "step-clean-cuts",
+        "duration": 6,
+        "tips": [
+          "Clean blades before harvesting diseased plants",
+          "Support the stem while cutting",
+          "Harvest in the morning when possible"
+        ],
+        "commonMistakes": [
+          "Ripping stems by hand",
+          "Using dirty tools on healthy plants"
+        ]
+      },
+      {
+        "title": "Log What You Pick",
+        "content": "A harvest note helps you learn what worked. Record the crop, date, amount, and one observation for next season.",
+        "imageURL": "step-log-harvest",
+        "duration": 6,
+        "tips": [
+          "Take a quick photo before storing produce",
+          "Note flavor, pest pressure, or timing",
+          "Share harvest wins with your garden club"
+        ],
+        "commonMistakes": [
+          "Trusting memory until next season",
+          "Only logging problems and not wins"
+        ]
+      }
+    ]
   }
 ]

--- a/GrowWisePackage/Sources/GrowWiseServices/SeasonalPlannerService.swift
+++ b/GrowWisePackage/Sources/GrowWiseServices/SeasonalPlannerService.swift
@@ -294,6 +294,12 @@ public final class SeasonalPlannerService {
         }
     }
 
+    // MARK: - Planting Guide
+
+    public func getPlantingGuide(for month: Int, zone: String?) -> [PlantingGuideItem] {
+        PlantingGuideCatalog.items(for: month, zone: zone)
+    }
+
     // MARK: - Private
 
     private func activitiesForPlant(

--- a/GrowWisePackage/Sources/GrowWiseServices/TutorialService.swift
+++ b/GrowWisePackage/Sources/GrowWiseServices/TutorialService.swift
@@ -7,6 +7,16 @@ import SwiftData
 public final class TutorialService {
     private let dataService: DataService
 
+    public static let beginnerLearningPathIDs = [
+        "first-outdoor-garden",
+        "what-to-plant-this-month",
+        "seed-starting-indoors",
+        "direct-sowing-basics",
+        "transplanting-hardening-off",
+        "succession-planting",
+        "harvesting-basics",
+    ]
+
     public init(dataService: DataService) {
         self.dataService = dataService
     }
@@ -19,6 +29,21 @@ public final class TutorialService {
 
     public func getTutorial(by id: String) -> TutorialTopic? {
         TutorialContent.allTutorials.first { $0.id == id }
+    }
+
+    public func getBeginnerLearningPath() -> [TutorialTopic] {
+        Self.beginnerLearningPathIDs.compactMap { getTutorial(by: $0) }
+    }
+
+    public func getPlantingGuide(for date: Date = Date(), zone: String? = nil) -> [PlantingGuideItem] {
+        let month = Calendar.current.component(.month, from: date)
+        return getPlantingGuide(for: month, zone: zone)
+    }
+
+    public func getPlantingGuide(for month: Int, zone: String? = nil) -> [PlantingGuideItem] {
+        let resolvedZone = zone ?? dataService.getCurrentUser()?.hardinessZone
+        let seasonalPlannerService = SeasonalPlannerService(dataService: dataService)
+        return seasonalPlannerService.getPlantingGuide(for: month, zone: resolvedZone)
     }
 
     public func getTutorialsForSkillLevel(_ skillLevel: GardeningSkillLevel) -> [TutorialTopic] {

--- a/GrowWisePackage/Tests/GrowWiseFeatureTests/TutorialLearningPresentationTests.swift
+++ b/GrowWisePackage/Tests/GrowWiseFeatureTests/TutorialLearningPresentationTests.swift
@@ -1,0 +1,15 @@
+@testable import GrowWiseFeature
+import Testing
+
+@Suite("Tutorial learning presentation")
+struct TutorialLearningPresentationTests {
+    @Test("Learning hub title is beginner focused")
+    func learningHubTitleIsBeginnerFocused() {
+        #expect(TutorialView.learningHubTitle == "Learn & Grow")
+    }
+
+    @Test("Home learning card title points to planting guidance")
+    func homeLearningCardTitlePointsToPlantingGuidance() {
+        #expect(TutorialView.homeLearningCardTitle == "Learn what to plant now")
+    }
+}

--- a/GrowWisePackage/Tests/GrowWiseServicesTests/SeasonalPlannerServiceTests.swift
+++ b/GrowWisePackage/Tests/GrowWiseServicesTests/SeasonalPlannerServiceTests.swift
@@ -134,6 +134,58 @@ struct SeasonalPlannerServiceTests {
         let zone7Types = Set(zone7.map(\.activityType))
         #expect(nilTypes == zone7Types)
     }
+
+    @Test("Planting guide returns beginner direct-sow crops for spring in zone 7")
+    func plantingGuideSpringDirectSowZone7() async throws {
+        let dataService = try await DataService.makeForTesting()
+        let service = SeasonalPlannerService(dataService: dataService)
+
+        let guide = service.getPlantingGuide(for: 4, zone: "7a")
+        let directSowNames = Set(
+            guide
+                .filter { $0.action == .directSow && $0.beginnerFriendly }
+                .map(\.plantName)
+        )
+
+        #expect(directSowNames.contains("Lettuce"))
+        #expect(directSowNames.contains("Carrot"))
+        #expect(guide.allSatisfy { !$0.timingSummary.isEmpty && !$0.nextStep.isEmpty })
+    }
+
+    @Test("Planting guide shifts spring direct-sow guidance earlier in warmer zones")
+    func plantingGuideShiftsEarlierForWarmZones() async throws {
+        let dataService = try await DataService.makeForTesting()
+        let service = SeasonalPlannerService(dataService: dataService)
+
+        let warmZoneGuide = service.getPlantingGuide(for: 2, zone: "9b")
+        let coldZoneGuide = service.getPlantingGuide(for: 2, zone: "4a")
+
+        #expect(warmZoneGuide.contains { $0.plantName == "Lettuce" && $0.action == .directSow })
+        #expect(!coldZoneGuide.contains { $0.plantName == "Lettuce" && $0.action == .directSow })
+    }
+
+    @Test("Planting guide indoor starts link to seed-starting tutorial")
+    func plantingGuideIndoorStartsLinkToSeedStartingTutorial() async throws {
+        let dataService = try await DataService.makeForTesting()
+        let service = SeasonalPlannerService(dataService: dataService)
+
+        let guide = service.getPlantingGuide(for: 3, zone: "7a")
+        let indoorStarts = guide.filter { $0.action == .startIndoors }
+
+        #expect(!indoorStarts.isEmpty)
+        #expect(indoorStarts.allSatisfy { $0.tutorialID == "seed-starting-indoors" })
+    }
+
+    @Test("Planting guide item IDs are unique")
+    func plantingGuideItemIDsAreUnique() async throws {
+        let dataService = try await DataService.makeForTesting()
+        let service = SeasonalPlannerService(dataService: dataService)
+
+        let guide = service.getPlantingGuide(for: 5, zone: "7a")
+        let ids = guide.map(\.id)
+
+        #expect(Set(ids).count == ids.count)
+    }
 }
 
 // MARK: - FrostDate Tests
@@ -223,7 +275,7 @@ struct FrostPrepTasksTests {
 
         // Zone 4 first frost ~ Oct 1; simulate late September
         let calendar = Calendar.current
-        let lateSeptember = calendar.date(from: DateComponents(year: 2026, month: 9, day: 25))!
+        let lateSeptember = try #require(calendar.date(from: DateComponents(year: 2026, month: 9, day: 25)))
 
         let tomato = Plant(name: "Tomato", plantType: .vegetable)
         let basil = Plant(name: "Basil", plantType: .herb)

--- a/GrowWisePackage/Tests/GrowWiseServicesTests/TutorialContentOutdoorCurriculumTests.swift
+++ b/GrowWisePackage/Tests/GrowWiseServicesTests/TutorialContentOutdoorCurriculumTests.swift
@@ -1,0 +1,32 @@
+@testable import GrowWiseServices
+import Testing
+
+@Suite("TutorialContent outdoor beginner curriculum")
+struct TutorialContentOutdoorCurriculumTests {
+    private let requiredIDs = [
+        "first-outdoor-garden",
+        "what-to-plant-this-month",
+        "seed-starting-indoors",
+        "direct-sowing-basics",
+        "transplanting-hardening-off",
+        "succession-planting",
+        "harvesting-basics",
+    ]
+
+    @Test("Tutorial corpus includes the outdoor beginner learning path")
+    func outdoorBeginnerLearningPathIDsExist() {
+        let ids = Set(TutorialContent.allTutorials.map(\.id))
+
+        for id in requiredIDs {
+            #expect(ids.contains(id), "Missing beginner learning path tutorial: \(id)")
+        }
+    }
+
+    @Test("Outdoor beginner learning path tutorials are beginner friendly")
+    func outdoorBeginnerLearningPathIsBeginnerDifficulty() throws {
+        for id in requiredIDs {
+            let tutorial = try #require(TutorialContent.allTutorials.first { $0.id == id })
+            #expect(tutorial.difficultyLevel == .beginner)
+        }
+    }
+}

--- a/GrowWisePackage/Tests/GrowWiseServicesTests/TutorialServicePersonalizationTests.swift
+++ b/GrowWisePackage/Tests/GrowWiseServicesTests/TutorialServicePersonalizationTests.swift
@@ -20,4 +20,22 @@ struct TutorialServicePersonalizationTests {
 
         #expect(tutorials.first?.category == .planning)
     }
+
+    @Test("beginner learning path returns outdoor curriculum in order")
+    func beginnerLearningPathReturnsOutdoorCurriculumInOrder() throws {
+        let dataService = try DataService.makeForTesting()
+        let tutorialService = TutorialService(dataService: dataService)
+
+        let path = tutorialService.getBeginnerLearningPath()
+
+        #expect(path.map(\.id) == [
+            "first-outdoor-garden",
+            "what-to-plant-this-month",
+            "seed-starting-indoors",
+            "direct-sowing-basics",
+            "transplanting-hardening-off",
+            "succession-planting",
+            "harvesting-basics",
+        ])
+    }
 }

--- a/docs/superpowers/plans/2026-05-27-tutorials-education.md
+++ b/docs/superpowers/plans/2026-05-27-tutorials-education.md
@@ -1,0 +1,148 @@
+# Tutorials and Education Expansion Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a practical education hub with beginner tutorials, timely planting guidance, real tutorial detail screens, and Home/Profile access.
+
+**Architecture:** Keep tutorial content and progress in `TutorialService`, add deterministic planting-guide recommendations to `SeasonalPlannerService`, and reuse those service contracts in SwiftUI. The UI remains sheet-based per ADR-012 and uses the existing Cultivation paper-card theme.
+
+**Tech Stack:** Swift 6, SwiftUI, SwiftData-backed services, Swift Testing, JSON resources.
+
+---
+
+### Task 1: Planting Guide Service Contract
+
+**Files:**
+- Modify: `GrowWisePackage/Tests/GrowWiseServicesTests/SeasonalPlannerServiceTests.swift`
+- Modify: `GrowWisePackage/Sources/GrowWiseServices/SeasonalPlannerService.swift`
+
+- [ ] **Step 1: Write failing tests**
+
+Add tests asserting that zone 7 spring guidance includes beginner direct-sow crops, zone 9 shifts that guidance earlier than zone 4, indoor-start items link to `seed-starting-indoors`, and item ids are unique.
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run: `ssh mac-mini "cd ~/Projects/GrowWise/GrowWisePackage && swift test --filter SeasonalPlannerServiceTests 2>&1 | tail -40"`
+
+Expected: compile failure or missing symbol for `getPlantingGuide`.
+
+- [ ] **Step 3: Implement service types and method**
+
+Add `PlantingGuideAction`, `PlantingGuideItem`, and `getPlantingGuide(for:zone:)` to `SeasonalPlannerService`. Use a small static crop table and the existing zone-offset convention.
+
+- [ ] **Step 4: Run the focused test and verify GREEN**
+
+Run: `ssh mac-mini "cd ~/Projects/GrowWise/GrowWisePackage && swift test --filter SeasonalPlannerServiceTests 2>&1 | tail -40"`
+
+Expected: planting-guide tests pass.
+
+### Task 2: Beginner Curriculum and Tutorial Corpus
+
+**Files:**
+- Modify: `GrowWisePackage/Tests/GrowWiseServicesTests/TutorialServiceTests.swift`
+- Modify: `GrowWisePackage/Tests/GrowWiseServicesTests/TutorialServicePersonalizationTests.swift`
+- Modify: `GrowWisePackage/Sources/GrowWiseServices/TutorialService.swift`
+- Modify: `GrowWisePackage/Sources/GrowWiseServices/Resources/tutorials.json`
+
+- [ ] **Step 1: Write failing tests**
+
+Add tests for required outdoor tutorial ids and ordered beginner learning path ids.
+
+- [ ] **Step 2: Run focused tests and verify RED**
+
+Run: `ssh mac-mini "cd ~/Projects/GrowWise/GrowWisePackage && swift test --filter Tutorial 2>&1 | tail -60"`
+
+Expected: missing ids and missing `getBeginnerLearningPath`.
+
+- [ ] **Step 3: Implement tutorial helpers and expand JSON**
+
+Add `getBeginnerLearningPath()` and `getPlantingGuide(for:zone:)` to `TutorialService`. Add the new outdoor tutorials to `tutorials.json` with beginner-focused steps.
+
+- [ ] **Step 4: Run focused tests and verify GREEN**
+
+Run: `ssh mac-mini "cd ~/Projects/GrowWise/GrowWisePackage && swift test --filter Tutorial 2>&1 | tail -60"`
+
+Expected: tutorial tests pass.
+
+### Task 3: Tutorial Detail Experience
+
+**Files:**
+- Create: `GrowWisePackage/Sources/GrowWiseFeature/Views/Tutorials/TutorialDetailView.swift`
+- Modify: `GrowWisePackage/Sources/GrowWiseFeature/Views/Tutorials/TutorialView.swift`
+
+- [ ] **Step 1: Add static feature-label tests**
+
+Add static constants on `TutorialView` for the learning hub title and Home learning-card title, then assert them from `GrowWiseFeatureTests`.
+
+- [ ] **Step 2: Implement detail view**
+
+Create `TutorialDetailView` with header, progress, step cards, tips, mistake callouts, and mark-complete buttons using `tutorialService.markStepComplete`.
+
+- [ ] **Step 3: Wire navigation destination**
+
+Add `.navigationDestination(for: TutorialTopic.self)` in `TutorialView` and route rows/featured cards into `TutorialDetailView`.
+
+- [ ] **Step 4: Build-check feature target through package tests**
+
+Run: `ssh mac-mini "cd ~/Projects/GrowWise/GrowWisePackage && swift test --filter GrowWiseFeatureTests 2>&1 | tail -40"`
+
+Expected: feature target compiles.
+
+### Task 4: Learning Hub Surface
+
+**Files:**
+- Modify: `GrowWisePackage/Sources/GrowWiseFeature/Views/Tutorials/TutorialView.swift`
+- Modify: `GrowWisePackage/Sources/GrowWiseFeature/Views/HomeView.swift`
+- Modify: `GrowWisePackage/Sources/GrowWiseFeature/Views/ProfileView.swift`
+
+- [ ] **Step 1: Redesign TutorialView around hub sections**
+
+Add the planting-guide rail and beginner path rail above the existing category browser. Keep search and progress.
+
+- [ ] **Step 2: Add Home entry point**
+
+Add a `showTutorials` state, `learningCard`, and a sheet for `TutorialsView`. Give the button `home_button_learning_hub`.
+
+- [ ] **Step 3: Update Profile row copy**
+
+Rename the row to `Guides & Tutorials` while preserving `profile_row_tutorials`.
+
+- [ ] **Step 4: Run lint on touched Swift files**
+
+Run: `swiftlint lint --strict --config .swiftlint.yml GrowWisePackage/Sources/GrowWiseFeature/Views/Tutorials/TutorialView.swift GrowWisePackage/Sources/GrowWiseFeature/Views/Tutorials/TutorialDetailView.swift GrowWisePackage/Sources/GrowWiseFeature/Views/HomeView.swift GrowWisePackage/Sources/GrowWiseFeature/Views/ProfileView.swift GrowWisePackage/Sources/GrowWiseServices/TutorialService.swift GrowWisePackage/Sources/GrowWiseServices/SeasonalPlannerService.swift`
+
+Expected: no strict lint violations in touched files.
+
+### Task 5: Final Verification and Handoff
+
+**Files:**
+- All modified files
+
+- [ ] **Step 1: Run service and feature tests**
+
+Run: `ssh mac-mini "cd ~/Projects/GrowWise/GrowWisePackage && swift test 2>&1 | tail -40"`
+
+Expected: package tests pass or any unrelated pre-existing failure is identified with evidence.
+
+- [ ] **Step 2: Run strict lint**
+
+Run: `swiftlint lint --strict --config .swiftlint.yml`
+
+Expected: lint exits 0.
+
+- [ ] **Step 3: Run app build**
+
+Run: `ssh mac-mini "cd ~/Projects/GrowWise && xcodebuild -workspace GrowWise.xcworkspace -scheme GrowWise -sdk iphonesimulator build CODE_SIGN_IDENTITY='' CODE_SIGNING_REQUIRED=NO 2>&1 | tail -5"`
+
+Expected: `BUILD SUCCEEDED`.
+
+- [ ] **Step 4: Commit and push**
+
+Run:
+
+```bash
+git status --short
+git add docs/superpowers/specs/2026-05-27-tutorials-education-design.md docs/superpowers/plans/2026-05-27-tutorials-education.md GrowWisePackage
+git commit -m "feat: expand tutorials and planting education"
+git push -u origin codex/tutorials-education
+```

--- a/docs/superpowers/specs/2026-05-27-tutorials-education-design.md
+++ b/docs/superpowers/specs/2026-05-27-tutorials-education-design.md
@@ -1,0 +1,109 @@
+# Tutorials and Education Expansion Design
+
+**Date:** 2026-05-27
+**Status:** Approved for implementation
+
+## Purpose
+
+Cultivation should feel dependable for a beginner who wants to know what to do next, not like a settings screen with a few articles. The education experience will become a practical learning hub that is easy to reach from Home and Me, teaches outdoor gardening fundamentals, and surfaces timely planting guidance based on the user's zone and season.
+
+## Scope
+
+- Keep education inside the existing `TutorialsView` sheet per ADR-012.
+- Add a Home entry point for “what to plant now” and beginner lessons.
+- Rename the Me row from “Tutorials” to “Guides & Tutorials” while preserving the existing route.
+- Expand the tutorial corpus from mostly houseplant basics into a beginner outdoor-gardening path.
+- Add a deterministic planting-guide service API for current-month recommendations.
+- Add a tutorial detail screen so tutorial rows actually open usable step-by-step content.
+
+Out of scope:
+
+- A new top-level Learn tab.
+- Personalized push notifications for lessons.
+- Perenual-backed live educational content.
+- A full frost-date calendar replacement.
+
+## References
+
+- University of Maryland Extension vegetable planting calendar: `https://extension.umd.edu/resource/vegetable-planting-calendar/`
+- University of Minnesota Extension seed-starting guidance: `https://extension.umn.edu/planting-and-growing-guides/starting-seeds-indoors`
+- Penn State Extension seed starting and vegetable-garden guidance: `https://extension.psu.edu/seed-starting-demystified`
+
+These references inform the app copy at a high level. App content remains original, short, and action-oriented.
+
+## Architecture
+
+`TutorialService` stays the public education facade. It continues loading tutorial content from `tutorials.json`, tracking progress through Keychain-backed step completion, and filtering by skill level. It gains small query helpers for the beginner learning path and current planting guidance.
+
+`SeasonalPlannerService` gains a value-type planting guide API:
+
+- `PlantingGuideAction`: start indoors, direct sow, transplant.
+- `PlantingGuideItem`: plant name, type, action, beginner flag, timing summary, why-now copy, next-step copy, and an optional tutorial id.
+- `getPlantingGuide(for month:zone:)`: deterministic monthly recommendations using the existing zone-offset convention.
+
+This keeps time/zone logic near the existing seasonal planner while letting Tutorials and Home reuse it without duplicating planting calendars.
+
+## UI Design
+
+`TutorialView` becomes a learning hub:
+
+- Header: “Learn & Grow” with compact progress.
+- What to plant now rail: current zone/month guide cards with action chips and next steps.
+- Beginner path rail: ordered curriculum for first-time gardeners.
+- Category selector: existing categories remain for browsing.
+- Tutorial list: existing search and progress metadata remain.
+
+`TutorialDetailView` shows the tutorial title, description, progress, and step cards. Each step has tips, mistakes to avoid, and a mark-complete button with accessibility identifiers.
+
+`HomeView` gets a paper-card button that opens the same Tutorials sheet. It should read like a practical next action, not a marketing panel.
+
+## Data
+
+`tutorials.json` will be expanded with outdoor beginner topics:
+
+- First Outdoor Garden
+- What to Plant This Month
+- Seed Starting Indoors
+- Direct Sowing Basics
+- Transplanting and Hardening Off
+- Succession Planting
+- Harvesting Basics
+
+Existing tutorials remain valid and searchable. New tutorials are beginner-level unless the concept requires intermediate framing.
+
+## Testing
+
+Service tests will cover:
+
+- Planting-guide recommendations for spring direct sowing in zone 7.
+- Warmer and colder zones shifting the same planting window.
+- Indoor-start recommendations linking to the seed-starting tutorial.
+- Unique planting-guide ids.
+- Beginner curriculum ids resolving to tutorials in order.
+- Tutorial corpus containing the new outdoor beginner path.
+
+Feature tests will cover static learning entry labels where useful. Full SwiftUI navigation behavior is covered by build verification because current feature tests do not use a UI introspection framework.
+
+## Error Handling
+
+Tutorial content remains bundle-backed and fails fast if malformed, matching the existing service behavior. Planting-guide recommendations do not perform I/O and should return an empty array only when a month has no matching recommendations. User-facing fetch errors are not introduced.
+
+## Accessibility
+
+New interactive controls must use the existing snake-case identifier style:
+
+- `home_button_learning_hub`
+- `tutorials_button_progress`
+- `tutorials_card_planting_<id>`
+- `tutorials_row_<tutorial-id>`
+- `tutorialdetail_button_step_<index>`
+
+## Verification
+
+Run:
+
+```bash
+ssh mac-mini "cd ~/Projects/GrowWise/GrowWisePackage && swift test 2>&1 | tail -20"
+swiftlint lint --strict --config .swiftlint.yml
+ssh mac-mini "cd ~/Projects/GrowWise && xcodebuild -workspace GrowWise.xcworkspace -scheme GrowWise -sdk iphonesimulator build CODE_SIGN_IDENTITY='' CODE_SIGNING_REQUIRED=NO 2>&1 | tail -5"
+```


### PR DESCRIPTION
## Summary
- Adds a practical Learn & Grow hub with what-to-plant-now guidance, beginner path, and searchable tutorial browsing.
- Adds tutorial detail screens with step completion, tips, and common-mistake callouts.
- Adds a deterministic planting guide catalog used by Tutorials and Home, plus an expanded outdoor beginner tutorial corpus.
- Adds Home access and renames the Me row to Guides & Tutorials.

## Verification
- ssh mac-mini "cd ~/Projects/GrowWise/GrowWisePackage && swift test 2>&1 | tail -80" — 1677 tests passed
- swiftlint lint --strict --config .swiftlint.yml — 0 violations
- ssh mac-mini "cd ~/Projects/GrowWise && xcodebuild -workspace GrowWise.xcworkspace -scheme GrowWise -sdk iphonesimulator build CODE_SIGN_IDENTITY='' CODE_SIGNING_REQUIRED=NO 2>&1 | tail -20" — BUILD SUCCEEDED
- swiftformat --lint --config .swiftformat GrowWisePackage/Sources GrowWise — 0 files require formatting
