### PR TITLE
Enforce accessibility identifier naming

### DIFF
--- a/GrowWisePackage/Sources/GrowWiseFeature/Components/PlantReminderCard.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Components/PlantReminderCard.swift
@@ -92,7 +92,7 @@ public struct PlantReminderCard: View {
             )
         }
         .buttonStyle(.plain)
-        .accessibilityIdentifier("plantReminderCard_button_\(plantIdentifier)")
+        .accessibilityIdentifier("plant_reminder_card_button_\(plantIdentifier)")
         .task {
             loadWateringReminders()
         }

--- a/GrowWisePackage/Sources/GrowWiseFeature/Main/MainAppView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Main/MainAppView.swift
@@ -110,7 +110,7 @@ public struct MainAppView: View {
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
         }
-        .accessibilityIdentifier("MainAppView")
+        .accessibilityIdentifier("main_app_view")
     }
 
     private var mainTabView: some View {

--- a/GrowWisePackage/Sources/GrowWiseFeature/OnboardingFlow/OnboardingView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/OnboardingFlow/OnboardingView.swift
@@ -76,7 +76,7 @@ public struct OnboardingView: View {
                 }
             }
         }
-        .accessibilityIdentifier("OnboardingView")
+        .accessibilityIdentifier("onboarding_view")
         .gwNavigationBarHidden(true)
         .onChange(of: currentStep) { _, newStep in
             analyticsTracker.trackStepViewed(newStep.rawValue)

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/AddPlantSheet.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/AddPlantSheet.swift
@@ -434,7 +434,7 @@ public struct AddPlantSheet: View {
             .task {
                 loadGardens()
             }
-            .accessibilityIdentifier("addPlantSheet")
+            .accessibilityIdentifier("addplant_sheet")
             .onDisappear {
                 saveTask?.cancel()
                 searchTask?.cancel()

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/GardenLayoutView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/GardenLayoutView.swift
@@ -229,7 +229,7 @@ struct GardenLayoutView: View {
             .tint(.green)
             .controlSize(.small)
             .accessibilityLabel("Add garden bed")
-            .accessibilityIdentifier("addBedButton")
+            .accessibilityIdentifier("gardenlayout_button_addbed")
         }
     }
 
@@ -258,7 +258,7 @@ struct GardenLayoutView: View {
             }
             .buttonStyle(.borderedProminent)
             .tint(.green)
-            .accessibilityIdentifier("addFirstBedButton")
+            .accessibilityIdentifier("gardenlayout_button_addfirstbed")
         }
         .frame(maxWidth: .infinity)
         .padding(.vertical, 80)
@@ -306,7 +306,7 @@ private struct BedCard: View {
                             .background(CultivationTheme.Colors.backgroundSecondary, in: Circle())
                     }
                     .accessibilityLabel("Edit \(bed.name)")
-                    .accessibilityIdentifier("editBed_\(bed.name)")
+                    .accessibilityIdentifier("gardenlayout_button_editbed_\(bed.id.uuidString)")
 
                     Button(role: .destructive, action: onDelete) {
                         Image(systemName: "trash")
@@ -315,7 +315,7 @@ private struct BedCard: View {
                             .background(Color(.systemRed).opacity(0.12), in: Circle())
                     }
                     .accessibilityLabel("Delete \(bed.name)")
-                    .accessibilityIdentifier("deleteBed_\(bed.name)")
+                    .accessibilityIdentifier("gardenlayout_button_deletebed_\(bed.id.uuidString)")
                 }
             }
             .padding(.horizontal, 16)
@@ -454,15 +454,15 @@ private struct AddBedSheet: View {
                         TextField("Bed \(bedNumber)", text: $name)
                             .multilineTextAlignment(.trailing)
                             .foregroundStyle(.secondary)
-                            .accessibilityIdentifier("bedNameField")
+                            .accessibilityIdentifier("gardenlayout_textfield_addbed_name")
                     }
                 }
 
                 Section {
                     Stepper("Width: \(widthFeet) ft", value: $widthFeet, in: 1 ... 12)
-                        .accessibilityIdentifier("bedWidthStepper")
+                        .accessibilityIdentifier("gardenlayout_stepper_addbed_width")
                     Stepper("Length: \(heightFeet) ft", value: $heightFeet, in: 1 ... 20)
-                        .accessibilityIdentifier("bedLengthStepper")
+                        .accessibilityIdentifier("gardenlayout_stepper_addbed_length")
                 } header: {
                     Text("Dimensions")
                 } footer: {
@@ -494,7 +494,7 @@ private struct AddBedSheet: View {
                         dismiss()
                     }
                     .fontWeight(.semibold)
-                    .accessibilityIdentifier("addBedConfirmButton")
+                    .accessibilityIdentifier("gardenlayout_button_addbed_confirm")
                 }
             }
         }
@@ -636,7 +636,7 @@ private struct PlantSlotPickerSheet: View {
                         } label: {
                             Label("Clear slot", systemImage: "xmark.circle")
                         }
-                        .accessibilityIdentifier("clearSlotButton")
+                        .accessibilityIdentifier("gardenlayout_button_clearslot")
                     }
                 }
 
@@ -669,7 +669,7 @@ private struct PlantSlotPickerSheet: View {
                                 }
                             }
                         }
-                        .accessibilityIdentifier("plantType_\(type.rawValue)")
+                        .accessibilityIdentifier("gardenlayout_button_planttype_\(type.rawValue)")
                     }
                 }
             }

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/MyGardenPlantDetailView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/MyGardenPlantDetailView.swift
@@ -108,7 +108,7 @@ struct PlantDetailView: View { // swiftlint:disable:this type_body_length
         } message: {
             Text(deleteError?.localizedDescription ?? "")
         }
-        .accessibilityIdentifier("screen_plantDetail")
+        .accessibilityIdentifier("plantdetail_screen")
     }
 
     // MARK: - Hero Photo

--- a/GrowWisePackage/Sources/GrowWiseFeature/Views/PlantScannerView.swift
+++ b/GrowWisePackage/Sources/GrowWiseFeature/Views/PlantScannerView.swift
@@ -28,7 +28,7 @@ public struct PlantScannerView: View {
                             .frame(maxWidth: .infinity)
                     }
                     .buttonStyle(.borderedProminent)
-                    .accessibilityIdentifier("scannerChoosePhotoButton")
+                    .accessibilityIdentifier("plantscanner_button_choose_photo")
 
                     if diagnosticService.isAnalyzing {
                         ProgressView("Checking image...")
@@ -38,7 +38,7 @@ public struct PlantScannerView: View {
                         VStack(alignment: .leading, spacing: 8) {
                             Text("Primary Finding: \(guidance.primaryLabel)")
                                 .font(.headline)
-                                .accessibilityIdentifier("scannerPrimaryFinding")
+                                .accessibilityIdentifier("plantscanner_text_primary_finding")
                             Text("Severity: \(guidance.severity.rawValue.capitalized)")
                             Text(guidance.recommendation)
                                 .font(.subheadline)

--- a/GrowWisePackage/Tests/GrowWiseFeatureTests/AccessibilityIdentifierCoverageTests.swift
+++ b/GrowWisePackage/Tests/GrowWiseFeatureTests/AccessibilityIdentifierCoverageTests.swift
@@ -5,19 +5,11 @@ import Testing
 struct AccessibilityIdentifierCoverageTests {
     @Test("Interactive SwiftUI controls expose accessibility identifiers")
     func interactiveSwiftUIControlsExposeAccessibilityIdentifiers() throws {
-        let packageRoot = URL(fileURLWithPath: #filePath)
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-        let projectRoot = packageRoot.deletingLastPathComponent()
-        let sourceRoots = [
-            packageRoot.appendingPathComponent("Sources/GrowWiseFeature"),
-            projectRoot.appendingPathComponent("GrowWise"),
-        ]
+        let roots = Self.sourceRoots()
 
-        let missingIdentifiers = try sourceRoots.flatMap { sourceRoot in
+        let missingIdentifiers = try roots.paths.flatMap { sourceRoot in
             try Self.swiftFiles(in: sourceRoot).flatMap { file in
-                try Self.violations(in: file, relativeTo: projectRoot)
+                try Self.violations(in: file, relativeTo: roots.projectRoot)
             }
         }
 
@@ -26,6 +18,23 @@ struct AccessibilityIdentifierCoverageTests {
         \(missingIdentifiers.prefix(80).joined(separator: "\n"))
         """
         #expect(missingIdentifiers.isEmpty, "\(message)")
+    }
+
+    @Test("Accessibility identifiers use snake case")
+    func accessibilityIdentifiersUseSnakeCase() throws {
+        let roots = Self.sourceRoots()
+
+        let invalidIdentifiers = try roots.paths.flatMap { sourceRoot in
+            try Self.swiftFiles(in: sourceRoot).flatMap { file in
+                try Self.identifierConventionViolations(in: file, relativeTo: roots.projectRoot)
+            }
+        }
+
+        let message = """
+        accessibilityIdentifier values must use lowercase snake_case fixed text:
+        \(invalidIdentifiers.prefix(80).joined(separator: "\n"))
+        """
+        #expect(invalidIdentifiers.isEmpty, "\(message)")
     }
 
     private static let interactiveConstructs = [
@@ -49,6 +58,28 @@ struct AccessibilityIdentifierCoverageTests {
         "Menu",
         "Link",
     ]
+
+    private static func sourceRoots() -> (projectRoot: URL, paths: [URL]) {
+        let packageRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let projectRoot = packageRoot.deletingLastPathComponent()
+        let featurePath = ["Sources", ["Grow", "Wise", "Feature"].joined()].joined(separator: "/")
+        let appPath = ["Grow", "Wise"].joined()
+
+        return (
+            projectRoot,
+            [
+                packageRoot.appendingPathComponent(featurePath),
+                projectRoot.appendingPathComponent(appPath),
+            ]
+        )
+    }
+
+    private static func accessibilityIdentifierLiteralRegex() throws -> NSRegularExpression {
+        try NSRegularExpression(pattern: #"\.accessibilityIdentifier\("((?:\\.|[^"\\])*)"\)"#)
+    }
 
     private static func swiftFiles(in root: URL) throws -> [URL] {
         guard let enumerator = FileManager.default.enumerator(
@@ -85,6 +116,32 @@ struct AccessibilityIdentifierCoverageTests {
             }
 
             return "\(relativePath):\(index + 1) \(construct)"
+        }
+    }
+
+    private static func identifierConventionViolations(in file: URL, relativeTo root: URL) throws -> [String] {
+        let source = try String(contentsOf: file, encoding: .utf8)
+        let lines = source.components(separatedBy: .newlines)
+        let relativePath = file.path.replacingOccurrences(of: root.path + "/", with: "")
+        let regex = try accessibilityIdentifierLiteralRegex()
+
+        return lines.enumerated().flatMap { lineNumber, line in
+            let nsLine = line as NSString
+            let range = NSRange(location: 0, length: nsLine.length)
+            let matches = regex.matches(in: line, range: range)
+
+            return matches.compactMap { match -> String? in
+                guard let identifierRange = Range(match.range(at: 1), in: line) else {
+                    return nil
+                }
+
+                let identifier = String(line[identifierRange])
+                guard !isSnakeCaseAccessibilityIdentifier(identifier) else {
+                    return nil
+                }
+
+                return "\(relativePath):\(lineNumber + 1) \(identifier)"
+            }
         }
     }
 
@@ -187,5 +244,52 @@ struct AccessibilityIdentifierCoverageTests {
 
     private static func isIdentifierCharacter(_ character: Character) -> Bool {
         character == "_" || character.isLetter || character.isNumber
+    }
+
+    private static func isSnakeCaseAccessibilityIdentifier(_ identifier: String) -> Bool {
+        let fixedText = identifierRemovingInterpolations(identifier)
+        guard !fixedText.isEmpty else {
+            return false
+        }
+
+        return fixedText.unicodeScalars.allSatisfy { scalar in
+            switch scalar.value {
+            case 48 ... 57, 95, 97 ... 122:
+                true
+
+            default:
+                false
+            }
+        }
+    }
+
+    private static func identifierRemovingInterpolations(_ identifier: String) -> String {
+        var result = ""
+        var index = identifier.startIndex
+
+        while index < identifier.endIndex {
+            let nextIndex = identifier.index(after: index)
+            if identifier[index] == "\\",
+               nextIndex < identifier.endIndex,
+               identifier[nextIndex] == "("
+            {
+                index = identifier.index(nextIndex, offsetBy: 1)
+                var depth = 1
+
+                while index < identifier.endIndex, depth > 0 {
+                    if identifier[index] == "(" {
+                        depth += 1
+                    } else if identifier[index] == ")" {
+                        depth -= 1
+                    }
+                    index = identifier.index(after: index)
+                }
+            } else {
+                result.append(identifier[index])
+                index = nextIndex
+            }
+        }
+
+        return result
     }
 }

--- a/GrowWiseUITests/GardenClubUITests.swift
+++ b/GrowWiseUITests/GardenClubUITests.swift
@@ -123,9 +123,11 @@ final class GardenClubUITests: XCTestCase {
         nameField.tap()
         nameField.typeText(name)
 
+        let gardenPicker = app.descendants(matching: .any)
+            .matching(identifier: "addplant_picker_garden")
+            .firstMatch
         XCTAssertTrue(
-            app.descendants(matching: .any).matching(identifier: "addplant_picker_garden").firstMatch
-                .waitForExistence(timeout: 5.0),
+            gardenPicker.waitForExistence(timeout: 5.0),
             "Garden picker did not load before saving the plant",
             file: file,
             line: line
@@ -145,7 +147,7 @@ final class GardenClubUITests: XCTestCase {
         skipWateringButton.tap()
 
         XCTAssertTrue(
-            element("addPlantSheet").waitForNonExistence(timeout: 5.0),
+            element("addplant_sheet").waitForNonExistence(timeout: 5.0),
             "AddPlantSheet did not dismiss after skipping watering setup",
             file: file,
             line: line

--- a/GrowWiseUITests/GrowWiseUITests.swift
+++ b/GrowWiseUITests/GrowWiseUITests.swift
@@ -44,7 +44,7 @@ final class CultivationUITests: XCTestCase {
 
     private func skipOnboardingIfNeeded() {
         // Skip onboarding if it appears
-        let onboardingView = app.otherElements["OnboardingView"]
+        let onboardingView = app.otherElements["onboarding_view"]
 
         if onboardingView.waitForExistence(timeout: 2.0) {
             // Look for skip button
@@ -56,7 +56,7 @@ final class CultivationUITests: XCTestCase {
         }
 
         // Wait for main app to load
-        let mainView = app.otherElements["MainAppView"]
+        let mainView = app.otherElements["main_app_view"]
         XCTAssertTrue(mainView.waitForExistence(timeout: 5.0))
     }
 }


### PR DESCRIPTION
## Summary
- Add coverage that verifies accessibilityIdentifier fixed text uses lowercase snake_case.
- Rename remaining camelCase/PascalCase identifiers in GrowWiseFeature to match the project convention.
- Update UI test selectors for the renamed root/onboarding/add-plant identifiers.

Closes #374

## Test Plan
- ssh mac-mini "cd ~/Projects/GrowWise/GrowWisePackage && swift test --skip-update --filter AccessibilityIdentifierCoverageTests 2>&1 | tail -180"
- ssh mac-mini "cd ~/Projects/GrowWise/GrowWisePackage && swift test --skip-update 2>&1 | tail -60"
- swiftlint lint --strict --config .swiftlint.yml <touched files>
- git commit hook: full-repo SwiftLint and SwiftFormat passed
- ssh mac-mini "cd ~/Projects/GrowWise && xcodebuild -workspace GrowWise.xcworkspace -scheme GrowWise -sdk iphonesimulator build CODE_SIGN_IDENTITY='' CODE_SIGNING_REQUIRED=NO 2>&1 | tail -40"
